### PR TITLE
Refactor companies services and dal

### DIFF
--- a/app/dal/companies/fetch-address.dal.js
+++ b/app/dal/companies/fetch-address.dal.js
@@ -2,7 +2,7 @@
 
 /**
  * Fetches the address data needed for the view '/companies/{id}/address/{addressId}/{role}'
- * @module FetchAddressService
+ * @module FetchAddressDal
  */
 
 const AddressModel = require('../../models/address.model.js')

--- a/app/dal/companies/fetch-billing-accounts.dal.js
+++ b/app/dal/companies/fetch-billing-accounts.dal.js
@@ -2,7 +2,7 @@
 
 /**
  * Fetches the company billing accounts data needed for the view '/companies/{id}/billing-accounts'
- * @module FetchBillingAccountsService
+ * @module FetchBillingAccountsDal
  */
 
 const BillingAccountModel = require('../../models/billing-account.model.js')

--- a/app/dal/companies/fetch-company-crm-data.dal.js
+++ b/app/dal/companies/fetch-company-crm-data.dal.js
@@ -2,7 +2,7 @@
 
 /**
  * Fetches the contacts data needed for the view '/companies/{id}/contacts'
- * @module FetchCompanyCRMDataService
+ * @module FetchCompanyCRMDataDal
  */
 
 const { db } = require('../../../db/db.js')

--- a/app/dal/companies/fetch-company-details.dal.js
+++ b/app/dal/companies/fetch-company-details.dal.js
@@ -2,7 +2,7 @@
 
 /**
  * Fetches the company details for the view '/companies/{id}/{role}' page
- * @module FetchCompanyDetailsService
+ * @module FetchCompanyDetailsDal
  */
 
 const CompanyModel = require('../../models/company.model.js')

--- a/app/dal/companies/fetch-company.dal.js
+++ b/app/dal/companies/fetch-company.dal.js
@@ -2,7 +2,7 @@
 
 /**
  * Fetches the company data needed for the view '/companies/{id}/contacts'
- * @module FetchCompanyService
+ * @module FetchCompanyDal
  */
 
 const CompanyModel = require('../../models/company.model.js')

--- a/app/dal/companies/fetch-history.dal.js
+++ b/app/dal/companies/fetch-history.dal.js
@@ -2,7 +2,7 @@
 
 /**
  * Fetches the licences and their versions, related to a company, data needed for the view '/companies/{id}/history'
- * @module FetchHistoryService
+ * @module FetchHistoryDal
  */
 
 const LicenceModel = require('../../models/licence.model.js')

--- a/app/dal/companies/fetch-licences.dal.js
+++ b/app/dal/companies/fetch-licences.dal.js
@@ -2,7 +2,7 @@
 
 /**
  * Fetches the licences, related to a company, data needed for the view '/companies/{id}/licences'
- * @module FetchLicencesService
+ * @module FetchLicencesDal
  */
 
 const LicenceModel = require('../../models/licence.model.js')

--- a/app/services/companies/view-billing-accounts.service.js
+++ b/app/services/companies/view-billing-accounts.service.js
@@ -7,8 +7,8 @@
  */
 
 const BillingAccountsPresenter = require('../../presenters/companies/billing-accounts.presenter.js')
-const FetchBillingAccountsService = require('./fetch-billing-accounts.service.js')
-const FetchCompanyService = require('./fetch-company.service.js')
+const FetchBillingAccountsDal = require('../../dal/companies/fetch-billing-accounts.dal.js')
+const FetchCompanyDal = require('../../dal/companies/fetch-company.dal.js')
 const PaginatorPresenter = require('../../presenters/paginator.presenter.js')
 const { userRoles } = require('../../presenters/licences/base-licences.presenter.js')
 
@@ -22,9 +22,9 @@ const { userRoles } = require('../../presenters/licences/base-licences.presenter
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(companyId, auth, page) {
-  const company = await FetchCompanyService.go(companyId)
+  const company = await FetchCompanyDal.go(companyId)
 
-  const { billingAccounts, totalNumber } = await FetchBillingAccountsService.go(companyId, page)
+  const { billingAccounts, totalNumber } = await FetchBillingAccountsDal.go(companyId, page)
 
   const pageData = BillingAccountsPresenter.go(company, billingAccounts)
 

--- a/app/services/companies/view-company-with-address.service.js
+++ b/app/services/companies/view-company-with-address.service.js
@@ -7,8 +7,8 @@
  */
 
 const CompanyWithAddressPresenter = require('../../presenters/companies/company-with-address.presenter.js')
-const FetchAddressService = require('./fetch-address.service.js')
-const FetchCompanyService = require('./fetch-company.service.js')
+const FetchAddressDal = require('../../dal/companies/fetch-address.dal.js')
+const FetchCompanyDal = require('../../dal/companies/fetch-company.dal.js')
 
 /**
  * Orchestrates fetching and presenting the data for the '/companies/{id}/address/{addressId}/{role}' page
@@ -21,8 +21,8 @@ const FetchCompanyService = require('./fetch-company.service.js')
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(companyId, addressId, role, licenceId = null) {
-  const company = await FetchCompanyService.go(companyId)
-  const address = await FetchAddressService.go(addressId)
+  const company = await FetchCompanyDal.go(companyId)
+  const address = await FetchAddressDal.go(addressId)
 
   const pageData = CompanyWithAddressPresenter.go(company, address, role, licenceId)
 

--- a/app/services/companies/view-company.service.js
+++ b/app/services/companies/view-company.service.js
@@ -7,7 +7,7 @@
  */
 
 const CompanyPresenter = require('../../presenters/companies/company.presenter.js')
-const FetchCompanyDetailsService = require('./fetch-company-details.service.js')
+const FetchCompanyDetailsDal = require('../../dal/companies/fetch-company-details.dal.js')
 const { roles } = require('../../lib/static-lookups.lib.js')
 
 /**
@@ -19,7 +19,7 @@ const { roles } = require('../../lib/static-lookups.lib.js')
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(companyId, role) {
-  const companyDetails = await FetchCompanyDetailsService.go(companyId, roles[role].name)
+  const companyDetails = await FetchCompanyDetailsDal.go(companyId, roles[role].name)
 
   const pageData = CompanyPresenter.go(companyDetails, role)
 

--- a/app/services/companies/view-contacts.service.js
+++ b/app/services/companies/view-contacts.service.js
@@ -7,8 +7,8 @@
  */
 
 const ContactsPresenter = require('../../presenters/companies/contacts.presenter.js')
-const FetchCompanyCRMDataService = require('./fetch-company-crm-data.service.js')
-const FetchCompanyService = require('./fetch-company.service.js')
+const FetchCompanyCRMDataDal = require('../../dal/companies/fetch-company-crm-data.dal.js')
+const FetchCompanyDal = require('../../dal/companies/fetch-company.dal.js')
 const PaginatorPresenter = require('../../presenters/paginator.presenter.js')
 const { readFlashNotification } = require('../../lib/general.lib.js')
 const { userRoles } = require('../../presenters/licences/base-licences.presenter.js')
@@ -24,11 +24,11 @@ const { userRoles } = require('../../presenters/licences/base-licences.presenter
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(companyId, auth, page, yar) {
-  const company = await FetchCompanyService.go(companyId)
+  const company = await FetchCompanyDal.go(companyId)
 
   const roles = userRoles(auth)
 
-  const { contacts, totalNumber } = await FetchCompanyCRMDataService.go(companyId, roles, page)
+  const { contacts, totalNumber } = await FetchCompanyCRMDataDal.go(companyId, roles, page)
 
   const pageData = ContactsPresenter.go(company, contacts)
 

--- a/app/services/companies/view-history.service.js
+++ b/app/services/companies/view-history.service.js
@@ -6,8 +6,8 @@
  * @module ViewHistoryService
  */
 
-const FetchCompanyService = require('./fetch-company.service.js')
-const FetchHistoryService = require('./fetch-history.service.js')
+const FetchCompanyDal = require('../../dal/companies/fetch-company.dal.js')
+const FetchHistoryDal = require('../../dal/companies/fetch-history.dal.js')
 const HistoryPresenter = require('../../presenters/companies/history.presenter.js')
 const PaginatorPresenter = require('../../presenters/paginator.presenter.js')
 const { userRoles } = require('../../presenters/licences/base-licences.presenter.js')
@@ -22,9 +22,9 @@ const { userRoles } = require('../../presenters/licences/base-licences.presenter
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(companyId, auth, page) {
-  const company = await FetchCompanyService.go(companyId)
+  const company = await FetchCompanyDal.go(companyId)
 
-  const { licences, totalNumber } = await FetchHistoryService.go(companyId, page)
+  const { licences, totalNumber } = await FetchHistoryDal.go(companyId, page)
 
   const pageData = HistoryPresenter.go(company, licences)
 

--- a/app/services/companies/view-licences.service.js
+++ b/app/services/companies/view-licences.service.js
@@ -6,8 +6,8 @@
  * @module ViewLicencesService
  */
 
-const FetchCompanyService = require('./fetch-company.service.js')
-const FetchLicencesService = require('./fetch-licences.service.js')
+const FetchCompanyDal = require('../../dal/companies/fetch-company.dal.js')
+const FetchLicencesDal = require('../../dal/companies/fetch-licences.dal.js')
 const LicencesPresenter = require('../../presenters/companies/licences.presenter.js')
 const PaginatorPresenter = require('../../presenters/paginator.presenter.js')
 const { userRoles } = require('../../presenters/licences/base-licences.presenter.js')
@@ -22,9 +22,9 @@ const { userRoles } = require('../../presenters/licences/base-licences.presenter
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(companyId, auth, page) {
-  const company = await FetchCompanyService.go(companyId)
+  const company = await FetchCompanyDal.go(companyId)
 
-  const { licences, totalNumber } = await FetchLicencesService.go(companyId, page)
+  const { licences, totalNumber } = await FetchLicencesDal.go(companyId, page)
 
   const pageData = LicencesPresenter.go(company, licences)
 

--- a/app/services/company-contacts/setup/initiate-session.service.js
+++ b/app/services/company-contacts/setup/initiate-session.service.js
@@ -7,7 +7,7 @@
 
 const CreateSessionDal = require('../../../dal/create-session.dal.js')
 const FetchCompanyLicencesDal = require('../../../dal/company-contacts/fetch-company-licences.dal.js')
-const FetchCompanyService = require('../../companies/fetch-company.service.js')
+const FetchCompanyService = require('../../../dal/companies/fetch-company.dal.js')
 
 /**
  * Initiates the session record used for setting up a new company contact

--- a/app/services/company-contacts/view-communications.service.js
+++ b/app/services/company-contacts/view-communications.service.js
@@ -8,7 +8,7 @@
 
 const CommunicationsPresenter = require('../../presenters/company-contacts/communications.presenter.js')
 const FetchCompanyContactDal = require('../../dal/company-contacts/fetch-company-contact.dal.js')
-const FetchCompanyService = require('../companies/fetch-company.service.js')
+const FetchCompanyService = require('../../dal/companies/fetch-company.dal.js')
 const FetchNotificationsDal = require('../../dal/company-contacts/fetch-notifications.dal.js')
 const PaginatorPresenter = require('../../presenters/paginator.presenter.js')
 

--- a/app/services/company-contacts/view-contact-details.service.js
+++ b/app/services/company-contacts/view-contact-details.service.js
@@ -9,7 +9,7 @@
 const ContactDetailsPresenter = require('../../presenters/company-contacts/contact-details.presenter.js')
 const FetchAbstractionAlertLicencesDal = require('../../dal/company-contacts/fetch-abstraction-alert-licences.dal.js')
 const FetchCompanyContactDetailsService = require('./fetch-company-contact-details.service.js')
-const FetchCompanyService = require('../companies/fetch-company.service.js')
+const FetchCompanyService = require('../../dal/companies/fetch-company.dal.js')
 const { readFlashNotification } = require('../../lib/general.lib.js')
 const { userRoles } = require('../../presenters/licences/base-licences.presenter.js')
 

--- a/app/services/company-contacts/view-remove-company-contact.service.js
+++ b/app/services/company-contacts/view-remove-company-contact.service.js
@@ -8,7 +8,7 @@
 
 const FetchAbstractionAlertLicencesDal = require('../../dal/company-contacts/fetch-abstraction-alert-licences.dal.js')
 const FetchCompanyContactDal = require('../../dal/company-contacts/fetch-company-contact.dal.js')
-const FetchCompanyService = require('../companies/fetch-company.service.js')
+const FetchCompanyService = require('../../dal/companies/fetch-company.dal.js')
 const RemoveCompanyContactPresenter = require('../../presenters/company-contacts/remove-company-contact.presenter.js')
 
 /**

--- a/test/dal/companies/fetch-address.dal.test.js
+++ b/test/dal/companies/fetch-address.dal.test.js
@@ -11,9 +11,9 @@ const { expect } = Code
 const AddressHelper = require('../../support/helpers/address.helper.js')
 
 // Thing under test
-const FetchAddressService = require('../../../app/services/companies/fetch-address.service.js')
+const FetchAddressDal = require('../../../app/dal/companies/fetch-address.dal.js')
 
-describe('Companies - Fetch Address service', () => {
+describe('Companies - Fetch Address dal', () => {
   let address
 
   describe('when there is an address', () => {
@@ -22,7 +22,7 @@ describe('Companies - Fetch Address service', () => {
     })
 
     it('returns the matching address', async () => {
-      const result = await FetchAddressService.go(address.id)
+      const result = await FetchAddressDal.go(address.id)
 
       expect(result).to.equal({
         id: address.id,

--- a/test/dal/companies/fetch-billing-accounts.dal.test.js
+++ b/test/dal/companies/fetch-billing-accounts.dal.test.js
@@ -14,9 +14,9 @@ const BillingAccountHelper = require('../../support/helpers/billing-account.help
 const BillingAccountAddressHelper = require('../../support/helpers/billing-account-address.helper.js')
 
 // Thing under test
-const FetchBillingAccountsService = require('../../../app/services/companies/fetch-billing-accounts.service.js')
+const FetchCompanyDal = require('../../../app/dal/companies/fetch-billing-accounts.dal.js')
 
-describe('Companies - Fetch Billing Accounts service', () => {
+describe('Companies - Fetch Billing Accounts dal', () => {
   let address
   let company
   let billingAccount
@@ -40,7 +40,7 @@ describe('Companies - Fetch Billing Accounts service', () => {
   })
 
   it('returns the billing accounts for the company', async () => {
-    const result = await FetchBillingAccountsService.go(company.id)
+    const result = await FetchCompanyDal.go(company.id)
 
     expect(result).to.equal({
       billingAccounts: [

--- a/test/dal/companies/fetch-company-crm-data.dal.test.js
+++ b/test/dal/companies/fetch-company-crm-data.dal.test.js
@@ -15,9 +15,9 @@ const CRMSeeder = require('../../support/seeders/crm.seeder.js')
 const DatabaseConfig = require('../../../config/database.config.js')
 
 // Thing under test
-const FetchCompanyCRMDataService = require('../../../app/services/companies/fetch-company-crm-data.service.js')
+const FetchCompanyCRMDataDal = require('../../../app/dal/companies/fetch-company-crm-data.dal.js')
 
-describe('Companies - Fetch Company CRM Data service', () => {
+describe('Companies - Fetch Company CRM Data dal', () => {
   let company
   let crmData
   let page
@@ -43,7 +43,7 @@ describe('Companies - Fetch Company CRM Data service', () => {
 
   describe('when there are contacts', () => {
     it('returns the matching contacts', async () => {
-      const result = await FetchCompanyCRMDataService.go(company.record.id, roles, page)
+      const result = await FetchCompanyCRMDataDal.go(company.record.id, roles, page)
 
       expect(result).to.equal({
         contacts: [
@@ -108,7 +108,7 @@ describe('Companies - Fetch Company CRM Data service', () => {
         })
 
         it('returns the matching contacts for the page (defaulted to 1) with the total number', async () => {
-          const result = await FetchCompanyCRMDataService.go(company.record.id, roles, page)
+          const result = await FetchCompanyCRMDataDal.go(company.record.id, roles, page)
 
           expect(result).to.equal({
             contacts: [
@@ -129,7 +129,7 @@ describe('Companies - Fetch Company CRM Data service', () => {
         })
 
         it('returns the matching contacts for the page (defaulted to 1) with the total number', async () => {
-          const result = await FetchCompanyCRMDataService.go(company.record.id, roles, page)
+          const result = await FetchCompanyCRMDataDal.go(company.record.id, roles, page)
 
           expect(result).to.equal({
             contacts: [
@@ -150,7 +150,7 @@ describe('Companies - Fetch Company CRM Data service', () => {
         })
 
         it('returns the matching contacts for the page (the second page) with the total number', async () => {
-          const result = await FetchCompanyCRMDataService.go(company.record.id, roles, page)
+          const result = await FetchCompanyCRMDataDal.go(company.record.id, roles, page)
 
           expect(result).to.equal({
             contacts: [

--- a/test/dal/companies/fetch-company-details.dal.test.js
+++ b/test/dal/companies/fetch-company-details.dal.test.js
@@ -15,9 +15,9 @@ const LicenceRoleHelper = require('../../support/helpers/licence-role.helper.js'
 const { tomorrow, yesterday } = require('../../support/general.js')
 
 // Thing under test
-const FetchCompanyDetailsService = require('../../../app/services/companies/fetch-company-details.service.js')
+const FetchCompanyDetailsDal = require('../../../app/dal/companies/fetch-company-details.dal.js')
 
-describe('Companies - Fetch Company details service', () => {
+describe('Companies - Fetch Company details dal', () => {
   let addressDifferentRole
   let addressEndDateInPast
   let addressEndDateInFuture
@@ -86,7 +86,7 @@ describe('Companies - Fetch Company details service', () => {
 
   describe('when there is a company', () => {
     it("returns the matching company's details and _all_ addresses for the specified role", async () => {
-      const result = await FetchCompanyDetailsService.go(company.id, 'licenceHolder')
+      const result = await FetchCompanyDetailsDal.go(company.id, 'licenceHolder')
 
       expect(result).to.equal({
         id: company.id,
@@ -146,7 +146,7 @@ describe('Companies - Fetch Company details service', () => {
 
     describe('and the company does not have any addresses for the specified role', () => {
       it("returns the matching company's details and no addresses", async () => {
-        const result = await FetchCompanyDetailsService.go(company.id, 'billing')
+        const result = await FetchCompanyDetailsDal.go(company.id, 'billing')
 
         expect(result).to.equal({
           id: company.id,

--- a/test/dal/companies/fetch-company.dal.test.js
+++ b/test/dal/companies/fetch-company.dal.test.js
@@ -11,9 +11,9 @@ const { expect } = Code
 const CompanyHelper = require('../../support/helpers/company.helper.js')
 
 // Thing under test
-const FetchCompanyService = require('../../../app/services/companies/fetch-company.service.js')
+const FetchCompanyDal = require('../../../app/dal/companies/fetch-company.dal.js')
 
-describe('Companies - Fetch Company service', () => {
+describe('Companies - Fetch Company dal', () => {
   let company
 
   describe('when there is a company', () => {
@@ -22,7 +22,7 @@ describe('Companies - Fetch Company service', () => {
     })
 
     it('returns the matching company', async () => {
-      const result = await FetchCompanyService.go(company.id)
+      const result = await FetchCompanyDal.go(company.id)
 
       expect(result).to.equal({
         id: company.id,

--- a/test/dal/companies/fetch-history.dal.test.js
+++ b/test/dal/companies/fetch-history.dal.test.js
@@ -19,9 +19,9 @@ const { generateUUID } = require('../../../app/lib/general.lib.js')
 const DatabaseConfig = require('../../../config/database.config.js')
 
 // Thing under test
-const FetchHistoryService = require('../../../app/services/companies/fetch-history.service.js')
+const FetchHistoryDal = require('../../../app/dal/companies/fetch-history.dal.js')
 
-describe('Companies - Fetch History service', () => {
+describe('Companies - Fetch History dal', () => {
   let company
   let licence
   let licenceVersion
@@ -92,7 +92,7 @@ describe('Companies - Fetch History service', () => {
 
   describe('when called', () => {
     it('returns licences linked to the company where it is the licence holder', async () => {
-      const result = await FetchHistoryService.go(company.id, pageNumber)
+      const result = await FetchHistoryDal.go(company.id, pageNumber)
 
       expect(result).to.equal({
         licences: [

--- a/test/dal/companies/fetch-licences.dal.test.js
+++ b/test/dal/companies/fetch-licences.dal.test.js
@@ -18,9 +18,9 @@ const { generateRandomInteger, generateUUID } = require('../../../app/lib/genera
 const databaseConfig = require('../../../config/database.config.js')
 
 // Thing under test
-const FetchLicencesService = require('../../../app/services/companies/fetch-licences.service.js')
+const FetchLicencesDal = require('../../../app/dal/companies/fetch-licences.dal.js')
 
-describe('Companies - Fetch Licences service', () => {
+describe('Companies - Fetch Licences dal', () => {
   let anotherLicence
   let anotherLicenceVersion
   let anotherLicenceVersionHolder
@@ -132,7 +132,7 @@ describe('Companies - Fetch Licences service', () => {
 
   describe('when called', () => {
     it('returns licences linked to the company where it is the licence holder', async () => {
-      const result = await FetchLicencesService.go(companyId, pageNumber)
+      const result = await FetchLicencesDal.go(companyId, pageNumber)
 
       expect(result).to.equal({
         licences: [

--- a/test/services/companies/view-billing-accounts.service.test.js
+++ b/test/services/companies/view-billing-accounts.service.test.js
@@ -12,8 +12,8 @@ const { expect } = Code
 const CustomersFixtures = require('../../support/fixtures/customers.fixture.js')
 
 // Things we need to stub
-const FetchBillingAccountsService = require('../../../app/services/companies/fetch-billing-accounts.service.js')
-const FetchCompanyService = require('../../../app/services/companies/fetch-company.service.js')
+const FetchBillingAccountsDal = require('../../../app/dal/companies/fetch-billing-accounts.dal.js')
+const FetchCompanyDal = require('../../../app/dal/companies/fetch-company.dal.js')
 
 // Thing under test
 const ViewBillingAccountsService = require('../../../app/services/companies/view-billing-accounts.service.js')
@@ -34,9 +34,9 @@ describe('Companies - View Billing Accounts service', () => {
 
     billingAccount = billingAccounts[0]
 
-    Sinon.stub(FetchCompanyService, 'go').returns(company)
+    Sinon.stub(FetchCompanyDal, 'go').returns(company)
 
-    Sinon.stub(FetchBillingAccountsService, 'go').returns({
+    Sinon.stub(FetchBillingAccountsDal, 'go').returns({
       billingAccounts,
       totalNumber: 1
     })

--- a/test/services/companies/view-company-with-address.service.test.js
+++ b/test/services/companies/view-company-with-address.service.test.js
@@ -12,8 +12,8 @@ const { expect } = Code
 const CustomersFixtures = require('../../support/fixtures/customers.fixture.js')
 
 // Things we need to stub
-const FetchAddressService = require('../../../app/services/companies/fetch-address.service.js')
-const FetchCompanyService = require('../../../app/services/companies/fetch-company.service.js')
+const FetchAddressDal = require('../../../app/dal/companies/fetch-address.dal.js')
+const FetchCompanyDal = require('../../../app/dal/companies/fetch-company.dal.js')
 
 // Thing under test
 const ViewCompanyWithAddressService = require('../../../app/services/companies/view-company-with-address.service.js')
@@ -29,8 +29,8 @@ describe('Companies - View Company With Address Service', () => {
     company = CustomersFixtures.company()
     address = CustomersFixtures.companyAddress().address
 
-    Sinon.stub(FetchCompanyService, 'go').returns(company)
-    Sinon.stub(FetchAddressService, 'go').returns(address)
+    Sinon.stub(FetchCompanyDal, 'go').returns(company)
+    Sinon.stub(FetchAddressDal, 'go').returns(address)
   })
 
   afterEach(() => {

--- a/test/services/companies/view-company.service.test.js
+++ b/test/services/companies/view-company.service.test.js
@@ -12,7 +12,7 @@ const { expect } = Code
 const CustomersFixtures = require('../../support/fixtures/customers.fixture.js')
 
 // Things we need to stub
-const FetchCompanyDetailsService = require('../../../app/services/companies/fetch-company-details.service.js')
+const FetchCompanyDetailsDal = require('../../../app/dal/companies/fetch-company-details.dal.js')
 
 // Thing under test
 const ViewCompanyService = require('../../../app/services/companies/view-company.service.js')
@@ -33,7 +33,7 @@ describe('Companies - View Company Service', () => {
     companyAddress.address.country = null
     companyDetails.companyAddresses.push({ ...companyAddress })
 
-    Sinon.stub(FetchCompanyDetailsService, 'go').returns(companyDetails)
+    Sinon.stub(FetchCompanyDetailsDal, 'go').returns(companyDetails)
   })
 
   afterEach(() => {
@@ -77,7 +77,7 @@ describe('Companies - View Company Service', () => {
       it('calls the fetch service with role converted to camelCase', async () => {
         await ViewCompanyService.go(companyDetails.id, role)
 
-        expect(FetchCompanyDetailsService.go.calledWith(companyDetails.id, 'licenceHolder')).to.be.true()
+        expect(FetchCompanyDetailsDal.go.calledWith(companyDetails.id, 'licenceHolder')).to.be.true()
       })
     })
 
@@ -117,7 +117,7 @@ describe('Companies - View Company Service', () => {
       it('calls the fetch service with role converted to camelCase', async () => {
         await ViewCompanyService.go(companyDetails.id, role)
 
-        expect(FetchCompanyDetailsService.go.calledWith(companyDetails.id, 'returnsTo')).to.be.true()
+        expect(FetchCompanyDetailsDal.go.calledWith(companyDetails.id, 'returnsTo')).to.be.true()
       })
     })
   })

--- a/test/services/companies/view-contacts.service.test.js
+++ b/test/services/companies/view-contacts.service.test.js
@@ -16,8 +16,8 @@ const { generateUUID } = require('../../../app/lib/general.lib.js')
 const YarStub = require('../../support/stubs/yar.stub.js')
 
 // Things we need to stub
-const FetchCompanyContactsService = require('../../../app/services/companies/fetch-company-crm-data.service.js')
-const FetchCompanyService = require('../../../app/services/companies/fetch-company.service.js')
+const FetchCompanyContactsDal = require('../../../app/dal/companies/fetch-company-crm-data.dal.js')
+const FetchCompanyDal = require('../../../app/dal/companies/fetch-company.dal.js')
 
 // Thing under test
 const ViewContactsService = require('../../../app/services/companies/view-contacts.service.js')
@@ -42,9 +42,9 @@ describe('Companies - View Contacts service', () => {
       }
     ]
 
-    Sinon.stub(FetchCompanyService, 'go').returns(company)
+    Sinon.stub(FetchCompanyDal, 'go').returns(company)
 
-    Sinon.stub(FetchCompanyContactsService, 'go').returns({
+    Sinon.stub(FetchCompanyContactsDal, 'go').returns({
       contacts,
       totalNumber: contacts.length
     })

--- a/test/services/companies/view-history.service.test.js
+++ b/test/services/companies/view-history.service.test.js
@@ -12,8 +12,8 @@ const { expect } = Code
 const CustomersFixtures = require('../../support/fixtures/customers.fixture.js')
 
 // Things we need to stub
-const FetchCompanyService = require('../../../app/services/companies/fetch-company.service.js')
-const FetchHistoryService = require('../../../app/services/companies/fetch-history.service.js')
+const FetchCompanyDal = require('../../../app/dal/companies/fetch-company.dal.js')
+const FetchHistoryDal = require('../../../app/dal/companies/fetch-history.dal.js')
 
 // Thing under test
 const ViewHistoryService = require('../../../app/services/companies/view-history.service.js')
@@ -31,8 +31,8 @@ describe('Companies - View History service', () => {
 
     licences = CustomersFixtures.licences()
 
-    Sinon.stub(FetchCompanyService, 'go').returns(company)
-    Sinon.stub(FetchHistoryService, 'go').returns({
+    Sinon.stub(FetchCompanyDal, 'go').returns(company)
+    Sinon.stub(FetchHistoryDal, 'go').returns({
       licences,
       totalNumber: 1
     })

--- a/test/services/companies/view-licences.service.test.js
+++ b/test/services/companies/view-licences.service.test.js
@@ -13,8 +13,8 @@ const CustomersFixtures = require('../../support/fixtures/customers.fixture.js')
 const LicenceModel = require('../../../app/models/licence.model.js')
 
 // Things we need to stub
-const FetchCompanyService = require('../../../app/services/companies/fetch-company.service.js')
-const FetchLicencesService = require('../../../app/services/companies/fetch-licences.service.js')
+const FetchCompanyService = require('../../../app/dal/companies/fetch-company.dal.js')
+const FetchLicencesService = require('../../../app/dal/companies/fetch-licences.dal.js')
 const { generateUUID } = require('../../../app/lib/general.lib.js')
 const { generateLicenceRef } = require('../../support/helpers/licence.helper.js')
 

--- a/test/services/company-contacts/setup/initiate-session.service.test.js
+++ b/test/services/company-contacts/setup/initiate-session.service.test.js
@@ -16,7 +16,7 @@ const { generateLicenceRef } = require('../../../support/helpers/licence.helper.
 
 // Things we need to stub
 const FetchCompanyLicencesDal = require('../../../../app/dal/company-contacts/fetch-company-licences.dal.js')
-const FetchCompanyService = require('../../../../app/services/companies/fetch-company.service.js')
+const FetchCompanyService = require('../../../../app/dal/companies/fetch-company.dal.js')
 
 // Thing under test
 const InitiateSessionService = require('../../../../app/services/company-contacts/setup/initiate-session.service.js')

--- a/test/services/company-contacts/view-communications.service.test.js
+++ b/test/services/company-contacts/view-communications.service.test.js
@@ -14,7 +14,7 @@ const { generateUUID } = require('../../../app/lib/general.lib.js')
 
 // Things we need to stub
 const FetchCompanyContactDal = require('../../../app/dal/company-contacts/fetch-company-contact.dal.js')
-const FetchCompanyService = require('../../../app/services/companies/fetch-company.service.js')
+const FetchCompanyService = require('../../../app/dal/companies/fetch-company.dal.js')
 const FetchNotificationsDal = require('../../../app/dal/company-contacts/fetch-notifications.dal.js')
 
 // Thing under test

--- a/test/services/company-contacts/view-contact-details.service.test.js
+++ b/test/services/company-contacts/view-contact-details.service.test.js
@@ -15,7 +15,7 @@ const YarStub = require('../../support/stubs/yar.stub.js')
 // Things we need to stub
 const FetchAbstractionAlertLicencesDal = require('../../../app/dal/company-contacts/fetch-abstraction-alert-licences.dal.js')
 const FetchCompanyContactDetailsService = require('../../../app/services/company-contacts/fetch-company-contact-details.service.js')
-const FetchCompanyService = require('../../../app/services/companies/fetch-company.service.js')
+const FetchCompanyService = require('../../../app/dal/companies/fetch-company.dal.js')
 
 // Thing under test
 const ViewContactDetailsService = require('../../../app/services/company-contacts/view-contact-details.service.js')

--- a/test/services/company-contacts/view-remove-company-contact.service.test.js
+++ b/test/services/company-contacts/view-remove-company-contact.service.test.js
@@ -14,7 +14,7 @@ const CustomersFixtures = require('../../support/fixtures/customers.fixture.js')
 // Things we need to stub
 const FetchAbstractionAlertLicencesDal = require('../../../app/dal/company-contacts/fetch-abstraction-alert-licences.dal.js')
 const FetchCompanyContactDal = require('../../../app/dal/company-contacts/fetch-company-contact.dal.js')
-const FetchCompanyService = require('../../../app/services/companies/fetch-company.service.js')
+const FetchCompanyService = require('../../../app/dal/companies/fetch-company.dal.js')
 
 // Thing under test
 const ViewRemoveCompanyContactService = require('../../../app/services/company-contacts/view-remove-company-contact.service.js')


### PR DESCRIPTION
We are moving service which comminnucate directly with the database into the DAL folder. This creates a seperation between services and external dependencies (in this case a database).

This change refactors the database services in the companies services into the dal folder (and tests).