### PR TITLE
Order of communications changes on refresh - Users

### DIFF
--- a/app/dal/users/external/fetch-notifications.dal.js
+++ b/app/dal/users/external/fetch-notifications.dal.js
@@ -37,7 +37,12 @@ async function _fetch(username, page) {
   OR notifications.personalisation->>'reset_url' LIKE '${ServerConfig.domains.external}%'
 )`
     )
-    .orderBy('createdAt', 'DESC')
+    .orderBy([
+      { column: 'createdAt', order: 'desc' },
+      { column: 'messageType', order: 'asc' },
+      { column: 'status', order: 'asc' },
+      { column: 'id', order: 'asc' }
+    ])
     .page(Number(page) - 1, DatabaseConfig.defaultPageSize)
 }
 

--- a/app/dal/users/internal/fetch-notifications.dal.js
+++ b/app/dal/users/internal/fetch-notifications.dal.js
@@ -37,7 +37,12 @@ async function _fetch(username, page) {
   OR notifications.personalisation->>'reset_url' LIKE '${ServerConfig.domains.internal}%'
 )`
     )
-    .orderBy('createdAt', 'DESC')
+    .orderBy([
+      { column: 'createdAt', order: 'desc' },
+      { column: 'messageType', order: 'asc' },
+      { column: 'status', order: 'asc' },
+      { column: 'id', order: 'asc' }
+    ])
     .page(Number(page) - 1, DatabaseConfig.defaultPageSize)
 }
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5674

Our QA team have spotted that when viewing communications, their order can sometimes be different. For example, view the table, select a notification to view, then return to the table, and the order is different.

Users expect the order to be consistent every time they view the page.

We are going to start with some housekeeping. Where we have a `fetch-notifications.service.js` (or something similar), move it into the DAL. For example, app/services/return-logs/fetch-notifications.service.js.

Then update all fetch-notifications.dal.js modules to order by:
- created at desc
- message type asc
- status asc
- id asc (id will always be unique, so as a method of last resort, it will ensure the order is always consistent).

This PR will focus on the internal and external User Communications.