### PR TITLE
Order of communications changes on refresh - Licences

### DIFF
--- a/app/dal/licences/fetch-notifications.dal.js
+++ b/app/dal/licences/fetch-notifications.dal.js
@@ -29,7 +29,12 @@ async function _fetch(licenceRef, page) {
   return NotificationModel.query()
     .select(['createdAt', 'id', 'messageType', 'status'])
     .where('licences', '?', licenceRef)
-    .orderBy('createdAt', 'DESC')
+    .orderBy([
+      { column: 'createdAt', order: 'desc' },
+      { column: 'messageType', order: 'asc' },
+      { column: 'status', order: 'asc' },
+      { column: 'id', order: 'asc' }
+    ])
     .withGraphFetched('event')
     .modifyGraph('event', (builder) => {
       builder.select([

--- a/app/dal/licences/fetch-notifications.dal.js
+++ b/app/dal/licences/fetch-notifications.dal.js
@@ -2,7 +2,7 @@
 
 /**
  * Fetches data needed for the view '/licences/{id}/communications` page
- * @module FetchCommunicationsService
+ * @module FetchNotificationsDal
  */
 
 const { ref } = require('objection')

--- a/app/services/licences/view-communications.service.js
+++ b/app/services/licences/view-communications.service.js
@@ -6,8 +6,8 @@
  */
 
 const CommunicationsPresenter = require('../../presenters/licences/communications.presenter.js')
-const FetchCommunicationsService = require('./fetch-communications.service.js')
 const FetchLicenceService = require('./fetch-licence.service.js')
+const FetchNotificationsDal = require('../../dal/licences/fetch-notifications.dal.js')
 const PaginatorPresenter = require('../../presenters/paginator.presenter.js')
 const { userRoles } = require('../../presenters/licences/base-licences.presenter.js')
 
@@ -23,7 +23,7 @@ const { userRoles } = require('../../presenters/licences/base-licences.presenter
 async function go(licenceId, auth, page) {
   const licence = await FetchLicenceService.go(licenceId)
 
-  const { notifications, totalNumber } = await FetchCommunicationsService.go(licence.licenceRef, page)
+  const { notifications, totalNumber } = await FetchNotificationsDal.go(licence.licenceRef, page)
 
   const pageData = CommunicationsPresenter.go(notifications, licence)
 

--- a/test/dal/licences/fetch-notifications.dal.test.js
+++ b/test/dal/licences/fetch-notifications.dal.test.js
@@ -15,9 +15,9 @@ const NotificationHelper = require('../../support/helpers/notification.helper.js
 const NotificationsFixture = require('../../support/fixtures/notifications.fixture.js')
 
 // Thing under test
-const FetchCommunicationsService = require('../../../app/services/licences/fetch-communications.service.js')
+const FetchNotificationsDal = require('../../../app/dal/licences/fetch-notifications.dal.js')
 
-describe('Licences - Fetch Communications service', () => {
+describe('Licences - Fetch Notifications DAL', () => {
   let licence
   let notice
   let notification
@@ -41,7 +41,7 @@ describe('Licences - Fetch Communications service', () => {
 
   describe('when the licence has notifications', () => {
     it('returns the matching notifications', async () => {
-      const result = await FetchCommunicationsService.go(licence.licenceRef)
+      const result = await FetchNotificationsDal.go(licence.licenceRef)
 
       expect(result).to.equal({
         notifications: [
@@ -69,7 +69,7 @@ describe('Licences - Fetch Communications service', () => {
     })
 
     it('returns no notifications', async () => {
-      const result = await FetchCommunicationsService.go(licence.licenceRef)
+      const result = await FetchNotificationsDal.go(licence.licenceRef)
 
       expect(result).to.equal({
         notifications: [],

--- a/test/services/licences/view-communications.service.test.js
+++ b/test/services/licences/view-communications.service.test.js
@@ -15,8 +15,8 @@ const { generateLicenceRef } = require('../../support/helpers/licence.helper.js'
 const { generateUUID } = require('../../../app/lib/general.lib.js')
 
 // Things we need to stub
-const FetchCommunicationsService = require('../../../app/services/licences/fetch-communications.service.js')
 const FetchLicenceService = require('../../../app/services/licences/fetch-licence.service.js')
+const FetchNotificationsDal = require('../../../app/dal/licences/fetch-notifications.dal.js')
 
 // Thing under test
 const ViewCommunicationsService = require('../../../app/services/licences/view-communications.service.js')
@@ -64,7 +64,7 @@ describe('Licences - View Communications service', () => {
       licenceRef
     })
 
-    Sinon.stub(FetchCommunicationsService, 'go').resolves({
+    Sinon.stub(FetchNotificationsDal, 'go').resolves({
       notifications: [notification],
       totalNumber: 1
     })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5674

Our QA team have spotted that when viewing communications, their order can sometimes be different. For example, view the table, select a notification to view, then return to the table, and the order is different.

Users expect the order to be consistent every time they view the page.

We are going to start with some housekeeping. Where we have a `fetch-notifications.service.js` (or something similar), move it into the DAL. For example, app/services/return-logs/fetch-notifications.service.js.

Then update all fetch-notifications.dal.js modules to order by:
- created at desc
- message type asc
- status asc
- id asc (id will always be unique, so as a method of last resort, it will ensure the order is always consistent).

This PR will focus on the Licences Communications `app/services/licences/fetch-communications.service.js`.