### PR TITLE
Refactor licence versions to not use licence version holder

### DIFF
--- a/app/dal/licence-versions/fetch-licence-version.dal.js
+++ b/app/dal/licence-versions/fetch-licence-version.dal.js
@@ -5,8 +5,9 @@
  * @module FetchLicenceVersionDal
  */
 
-const LicenceVersionModel = require('../../models/licence-version.model.js')
 const { raw } = require('objection')
+
+const LicenceVersionModel = require('../../models/licence-version.model.js')
 
 /**
  * Fetches data needed for the view `/licence-versions/{id}` page

--- a/app/dal/licence-versions/fetch-licence-version.dal.js
+++ b/app/dal/licence-versions/fetch-licence-version.dal.js
@@ -2,7 +2,7 @@
 
 /**
  * Fetches data needed for the view `/licence-versions/{id}` page
- * @module FetchLicenceVersionService
+ * @module FetchLicenceVersionDal
  */
 
 const LicenceVersionModel = require('../../models/licence-version.model.js')
@@ -49,20 +49,23 @@ async function _fetch(licenceVersionId) {
     .modifyGraph('licence', (licenceBuilder) => {
       licenceBuilder.select(['id', 'licenceRef'])
     })
-    .withGraphFetched('licenceVersionHolder')
-    .modifyGraph('licenceVersionHolder', (licenceVersionHolderBuilder) => {
-      licenceVersionHolderBuilder.select([
-        'id',
-        'addressLine1',
-        'addressLine2',
-        'addressLine3',
-        'addressLine4',
+    .withGraphFetched('address')
+    .modifyGraph('address', (addressBuilder) => {
+      addressBuilder.select([
+        'address1',
+        'address2',
+        'address3',
+        'address4',
+        'address5',
+        'address6',
         'country',
-        'county',
-        'derivedName',
-        'postcode',
-        'town'
+        'id',
+        'postcode'
       ])
+    })
+    .withGraphFetched('company')
+    .modifyGraph('company', (companyBuilder) => {
+      companyBuilder.select(['id', 'name'])
     })
     .modify('history')
     .withGraphFetched('licenceVersionPurposes')

--- a/app/presenters/licence-versions/view.presenter.js
+++ b/app/presenters/licence-versions/view.presenter.js
@@ -48,11 +48,8 @@ function go(licenceVersionData, auth, conditions) {
 }
 
 /**
- * The 'NotifyAddressPresenter' is designed for 'recipients'.
- *
- * We need to add the name to the expected contact.
- *
- * We use a macro to render address, and it expects an array of address lines.
+ * The name is always set to address line 1 when using the notify address presenter. We need to remove this, specfically
+ * for this page as the name is show directyl above and would look like a duplciate.
  *
  * @private
  */
@@ -61,6 +58,8 @@ function _address(licenceVersion) {
     name: licenceVersion.company.name,
     ...licenceVersion.address
   })
+
+  delete address.address_line_1
 
   return Object.values(address)
 }

--- a/app/presenters/licence-versions/view.presenter.js
+++ b/app/presenters/licence-versions/view.presenter.js
@@ -5,11 +5,12 @@
  * @module ViewPresenter
  */
 
+const NotifyAddressPresenter = require('../notices/setup/notify-address.presenter.js')
 const NotifyConfig = require('../../../config/notify.config.js')
 const PreviousAndNextPresenter = require('../previous-and-next.presenter.js')
+const { compareStrings } = require('../../lib/general.lib.js')
 const { formatLicencePoints, formatLicencePurposes, formatConditionTypes } = require('../licence.presenter.js')
 const { formatLongDate, formatVersionReason } = require('../base.presenter.js')
-const { compareStrings } = require('../../lib/general.lib.js')
 
 /**
  * Formats data for the `/licence-versions/{id}` page
@@ -46,6 +47,24 @@ function go(licenceVersionData, auth, conditions) {
   }
 }
 
+/**
+ * The 'NotifyAddressPresenter' is designed for 'recipients'.
+ *
+ * We need to add the name to the expected contact.
+ *
+ * We use a macro to render address, and it expects an array of address lines.
+ *
+ * @private
+ */
+function _address(licenceVersion) {
+  const address = NotifyAddressPresenter.go({
+    name: licenceVersion.company.name,
+    ...licenceVersion.address
+  })
+
+  return Object.values(address)
+}
+
 function _errorInDataEmail(billingAndDataRole) {
   if (billingAndDataRole) {
     return null
@@ -56,11 +75,11 @@ function _errorInDataEmail(billingAndDataRole) {
 
 function _licenceDetails(licenceVersion) {
   return {
-    address: licenceVersion.licenceVersionHolder.$address(),
+    address: _address(licenceVersion),
     applicationNumber: licenceVersion.applicationNumber,
     endDate: formatLongDate(licenceVersion.endDate),
     issueDate: formatLongDate(licenceVersion.issueDate),
-    licenceHolderName: licenceVersion.licenceVersionHolder.derivedName,
+    licenceHolderName: licenceVersion.company.name,
     startDate: formatLongDate(licenceVersion.startDate)
   }
 }

--- a/app/presenters/licence-versions/view.presenter.js
+++ b/app/presenters/licence-versions/view.presenter.js
@@ -8,9 +8,9 @@
 const NotifyAddressPresenter = require('../notices/setup/notify-address.presenter.js')
 const NotifyConfig = require('../../../config/notify.config.js')
 const PreviousAndNextPresenter = require('../previous-and-next.presenter.js')
+const { formatLongDate, formatVersionReason } = require('../base.presenter.js')
 const { compareStrings } = require('../../lib/general.lib.js')
 const { formatLicencePoints, formatLicencePurposes, formatConditionTypes } = require('../licence.presenter.js')
-const { formatLongDate, formatVersionReason } = require('../base.presenter.js')
 
 /**
  * Formats data for the `/licence-versions/{id}` page
@@ -48,8 +48,8 @@ function go(licenceVersionData, auth, conditions) {
 }
 
 /**
- * The name is always set to address line 1 when using the notify address presenter. We need to remove this, specfically
- * for this page as the name is show directyl above and would look like a duplciate.
+ * The name is always set to address line 1 when using the notify address presenter. We need to remove this, specifically
+ * for this page as the name is shown directly above and would look like a duplicate.
  *
  * @private
  */

--- a/app/services/licence-versions/view.service.js
+++ b/app/services/licence-versions/view.service.js
@@ -7,7 +7,7 @@
  */
 
 const FetchConditionsService = require('../licences/fetch-conditions.service.js')
-const FetchLicenceVersionService = require('../../dal/licence-versions/fetch-licence-version.dal.js')
+const FetchLicenceVersionDal = require('../../dal/licence-versions/fetch-licence-version.dal.js')
 const ViewPresenter = require('../../presenters/licence-versions/view.presenter.js')
 
 /**
@@ -19,7 +19,7 @@ const ViewPresenter = require('../../presenters/licence-versions/view.presenter.
  * @returns {Promise<object>} The data formatted for the view template
  */
 async function go(licenceVersionId, auth) {
-  const licenceVersionData = await FetchLicenceVersionService.go(licenceVersionId)
+  const licenceVersionData = await FetchLicenceVersionDal.go(licenceVersionId)
   const conditions = await FetchConditionsService.go(licenceVersionId)
 
   const pageData = ViewPresenter.go(licenceVersionData, auth, conditions)

--- a/app/services/licence-versions/view.service.js
+++ b/app/services/licence-versions/view.service.js
@@ -7,7 +7,7 @@
  */
 
 const FetchConditionsService = require('../licences/fetch-conditions.service.js')
-const FetchLicenceVersionService = require('./fetch-licence-version.service.js')
+const FetchLicenceVersionService = require('../../dal/licence-versions/fetch-licence-version.dal.js')
 const ViewPresenter = require('../../presenters/licence-versions/view.presenter.js')
 
 /**

--- a/test/dal/licence-versions/fetch-licence-version.dal.test.js
+++ b/test/dal/licence-versions/fetch-licence-version.dal.test.js
@@ -8,8 +8,6 @@ const { describe, it, before } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const AddressHelper = require('../../support/helpers/address.helper.js')
-const CompanyHelper = require('../../support/helpers/company.helper.js')
 const LicenceHelper = require('../../support/helpers/licence.helper.js')
 const LicenceVersionHelper = require('../../support/helpers/licence-version.helper.js')
 const LicenceVersionPurposeHelper = require('../../support/helpers/licence-version-purpose.helper.js')
@@ -17,6 +15,7 @@ const LicenceVersionPurposePointHelper = require('../../support/helpers/licence-
 const PointHelper = require('../../support/helpers/point.helper.js')
 const PurposeHelper = require('../../support/helpers/purpose.helper.js')
 const SourceHelper = require('../../support/helpers/source.helper.js')
+const CRMContactsSeeder = require('../../support/seeders/crm-contacts.seeder.js')
 
 // Thing under test
 const FetchLicenceVersionDal = require('../../../app/dal/licence-versions/fetch-licence-version.dal.js')
@@ -24,42 +23,33 @@ const FetchLicenceVersionDal = require('../../../app/dal/licence-versions/fetch-
 describe('Licence Versions - Fetch licence version dal', () => {
   let additionalLicenceVersionOne
   let additionalLicenceVersionTwo
-  let address
-  let company
   let licence
   let licenceVersion
   let licenceVersionPurpose
   let point
   let purpose
   let source
+  let licenceHolder
 
   describe('when there is licence version', () => {
     before(async () => {
       licence = await LicenceHelper.add()
 
-      address = await AddressHelper.add()
+      licenceHolder = await CRMContactsSeeder.licenceHolder({ licence }, 'Example Trading Ltd')
 
-      company = await CompanyHelper.add()
-
-      licenceVersion = await LicenceVersionHelper.add({
-        licenceId: licence.id,
-        startDate: new Date('2023-01-02'),
-        endDate: null,
-        addressId: address.id,
-        companyId: company.id
-      })
+      licenceVersion = licenceHolder.licenceVersion
 
       // Add additional licence for the pagination array
       additionalLicenceVersionOne = await LicenceVersionHelper.add({
         licenceId: licence.id,
-        startDate: new Date('2023-01-01'),
-        endDate: new Date('2023-01-01')
+        startDate: new Date('2021-01-01'),
+        endDate: new Date('2021-12-31')
       })
 
       additionalLicenceVersionTwo = await LicenceVersionHelper.add({
         licenceId: licence.id,
         startDate: new Date('2019-01-01'),
-        endDate: new Date('2022-12-30')
+        endDate: new Date('2021-12-31')
       })
 
       purpose = PurposeHelper.select()
@@ -83,20 +73,20 @@ describe('Licence Versions - Fetch licence version dal', () => {
       expect(result).to.equal({
         licenceVersion: {
           address: {
-            address1: 'ENVIRONMENT AGENCY',
-            address2: 'HORIZON HOUSE',
-            address3: 'DEANERY ROAD',
-            address4: 'BRISTOL',
+            address1: '4',
+            address2: 'Privet Drive',
+            address3: 'Little Whinging',
+            address4: 'Surrey',
             address5: null,
             address6: null,
-            country: 'United Kingdom',
-            id: address.id,
-            postcode: 'BS1 5AH'
+            country: null,
+            id: licenceHolder.address.id,
+            postcode: 'WD25 7LR'
           },
           administrative: null,
           applicationNumber: null,
           company: {
-            id: company.id,
+            id: licenceHolder.company.id,
             name: 'Example Trading Ltd'
           },
           createdAt: licenceVersion.createdAt,
@@ -164,11 +154,11 @@ describe('Licence Versions - Fetch licence version dal', () => {
           },
           {
             id: additionalLicenceVersionOne.id,
-            startDate: new Date('2023-01-01')
+            startDate: new Date('2021-01-01')
           },
           {
             id: licenceVersion.id,
-            startDate: new Date('2023-01-02')
+            startDate: new Date('2022-01-01')
           }
         ]
       })

--- a/test/dal/licence-versions/fetch-licence-version.dal.test.js
+++ b/test/dal/licence-versions/fetch-licence-version.dal.test.js
@@ -8,9 +8,10 @@ const { describe, it, before } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
+const AddressHelper = require('../../support/helpers/address.helper.js')
+const CompanyHelper = require('../../support/helpers/company.helper.js')
 const LicenceHelper = require('../../support/helpers/licence.helper.js')
 const LicenceVersionHelper = require('../../support/helpers/licence-version.helper.js')
-const LicenceVersionHolderHelper = require('../../support/helpers/licence-version-holder.helper.js')
 const LicenceVersionPurposeHelper = require('../../support/helpers/licence-version-purpose.helper.js')
 const LicenceVersionPurposePointHelper = require('../../support/helpers/licence-version-purpose-point.helper.js')
 const PointHelper = require('../../support/helpers/point.helper.js')
@@ -18,14 +19,15 @@ const PurposeHelper = require('../../support/helpers/purpose.helper.js')
 const SourceHelper = require('../../support/helpers/source.helper.js')
 
 // Thing under test
-const FetchLicenceVersionService = require('../../../app/services/licence-versions/fetch-licence-version.service.js')
+const FetchLicenceVersionDal = require('../../../app/dal/licence-versions/fetch-licence-version.dal.js')
 
-describe('Licence Versions - Fetch licence version service', () => {
+describe('Licence Versions - Fetch licence version dal', () => {
   let additionalLicenceVersionOne
   let additionalLicenceVersionTwo
+  let address
+  let company
   let licence
   let licenceVersion
-  let licenceVersionHolder
   let licenceVersionPurpose
   let point
   let purpose
@@ -35,10 +37,16 @@ describe('Licence Versions - Fetch licence version service', () => {
     before(async () => {
       licence = await LicenceHelper.add()
 
+      address = await AddressHelper.add()
+
+      company = await CompanyHelper.add()
+
       licenceVersion = await LicenceVersionHelper.add({
         licenceId: licence.id,
         startDate: new Date('2023-01-02'),
-        endDate: null
+        endDate: null,
+        addressId: address.id,
+        companyId: company.id
       })
 
       // Add additional licence for the pagination array
@@ -61,10 +69,6 @@ describe('Licence Versions - Fetch licence version service', () => {
         purposeId: purpose.id
       })
 
-      licenceVersionHolder = await LicenceVersionHolderHelper.add({
-        licenceVersionId: licenceVersion.id
-      })
-
       source = SourceHelper.select()
       point = await PointHelper.add({ sourceId: source.id })
       await LicenceVersionPurposePointHelper.add({
@@ -74,12 +78,27 @@ describe('Licence Versions - Fetch licence version service', () => {
     })
 
     it('returns the matching licence version and the pagination array (in order)', async () => {
-      const result = await FetchLicenceVersionService.go(licenceVersion.id)
+      const result = await FetchLicenceVersionDal.go(licenceVersion.id)
 
       expect(result).to.equal({
         licenceVersion: {
+          address: {
+            address1: 'ENVIRONMENT AGENCY',
+            address2: 'HORIZON HOUSE',
+            address3: 'DEANERY ROAD',
+            address4: 'BRISTOL',
+            address5: null,
+            address6: null,
+            country: 'United Kingdom',
+            id: address.id,
+            postcode: 'BS1 5AH'
+          },
           administrative: null,
           applicationNumber: null,
+          company: {
+            id: company.id,
+            name: 'Example Trading Ltd'
+          },
           createdAt: licenceVersion.createdAt,
           endDate: null,
           id: licenceVersion.id,
@@ -87,18 +106,6 @@ describe('Licence Versions - Fetch licence version service', () => {
           licence: {
             id: licence.id,
             licenceRef: licence.licenceRef
-          },
-          licenceVersionHolder: {
-            id: licenceVersionHolder.id,
-            addressLine1: null,
-            addressLine2: null,
-            addressLine3: null,
-            addressLine4: null,
-            country: null,
-            county: null,
-            derivedName: null,
-            postcode: null,
-            town: null
           },
           licenceVersionPurposes: [
             {

--- a/test/dal/licence-versions/fetch-licence-version.dal.test.js
+++ b/test/dal/licence-versions/fetch-licence-version.dal.test.js
@@ -8,6 +8,7 @@ const { describe, it, before, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
+const CRMContactsSeeder = require('../../support/seeders/crm-contacts.seeder.js')
 const LicenceHelper = require('../../support/helpers/licence.helper.js')
 const LicenceVersionHelper = require('../../support/helpers/licence-version.helper.js')
 const LicenceVersionPurposeHelper = require('../../support/helpers/licence-version-purpose.helper.js')
@@ -15,7 +16,6 @@ const LicenceVersionPurposePointHelper = require('../../support/helpers/licence-
 const PointHelper = require('../../support/helpers/point.helper.js')
 const PurposeHelper = require('../../support/helpers/purpose.helper.js')
 const SourceHelper = require('../../support/helpers/source.helper.js')
-const CRMContactsSeeder = require('../../support/seeders/crm-contacts.seeder.js')
 
 // Thing under test
 const FetchLicenceVersionDal = require('../../../app/dal/licence-versions/fetch-licence-version.dal.js')
@@ -24,13 +24,13 @@ describe('Licence Versions - Fetch licence version dal', () => {
   let additionalLicenceVersionOne
   let additionalLicenceVersionTwo
   let licence
+  let licenceHolder
   let licenceVersion
   let licenceVersionPurpose
   let licenceVersionPurposePoint
   let point
   let purpose
   let source
-  let licenceHolder
 
   describe('when there is licence version', () => {
     before(async () => {

--- a/test/dal/licence-versions/fetch-licence-version.dal.test.js
+++ b/test/dal/licence-versions/fetch-licence-version.dal.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -26,6 +26,7 @@ describe('Licence Versions - Fetch licence version dal', () => {
   let licence
   let licenceVersion
   let licenceVersionPurpose
+  let licenceVersionPurposePoint
   let point
   let purpose
   let source
@@ -61,10 +62,22 @@ describe('Licence Versions - Fetch licence version dal', () => {
 
       source = SourceHelper.select()
       point = await PointHelper.add({ sourceId: source.id })
-      await LicenceVersionPurposePointHelper.add({
+
+      licenceVersionPurposePoint = await LicenceVersionPurposePointHelper.add({
         licenceVersionPurposeId: licenceVersionPurpose.id,
         pointId: point.id
       })
+    })
+
+    afterEach(async () => {
+      await licenceHolder.clean()
+
+      await licence.$query().delete()
+      await additionalLicenceVersionOne.$query().delete()
+      await additionalLicenceVersionTwo.$query().delete()
+      await licenceVersionPurpose.$query().delete()
+      await licenceVersionPurposePoint.$query().delete()
+      await point.$query().delete()
     })
 
     it('returns the matching licence version and the pagination array (in order)', async () => {

--- a/test/presenters/licence-versions/view.presenter.test.js
+++ b/test/presenters/licence-versions/view.presenter.test.js
@@ -18,7 +18,7 @@ const NotifyConfig = require('../../../config/notify.config.js')
 // Thing under test
 const ViewPresenter = require('../../../app/presenters/licence-versions/view.presenter.js')
 
-describe('Licence Versions - View presenter', () => {
+describe.only('Licence Versions - View presenter', () => {
   let auth
   let conditions
   let licenceVersion
@@ -60,7 +60,7 @@ describe('Licence Versions - View presenter', () => {
         conditionTypes: [],
         errorInDataEmail: 'notify@test.gov.uk',
         licenceDetails: {
-          address: ['ORDER OF THE PHOENIX', '12 GRIMMAULD PLACE', 'ISLINGTON', 'LONDON', 'GREATER LONDON', 'N1 9LX'],
+          address: ['12 GRIMMAULD PLACE', 'ISLINGTON', 'LONDON', 'GREATER LONDON', 'N1 9LX'],
           applicationNumber: null,
           endDate: null,
           issueDate: null,
@@ -172,7 +172,7 @@ describe('Licence Versions - View presenter', () => {
         const result = ViewPresenter.go(licenceVersionData, auth, conditions)
 
         expect(result.licenceDetails).to.equal({
-          address: ['ORDER OF THE PHOENIX', '12 GRIMMAULD PLACE', 'ISLINGTON', 'LONDON', 'GREATER LONDON', 'N1 9LX'],
+          address: ['12 GRIMMAULD PLACE', 'ISLINGTON', 'LONDON', 'GREATER LONDON', 'N1 9LX'],
           applicationNumber: 'R.1',
           endDate: '1 February 2024',
           issueDate: '3 March 2023',
@@ -187,7 +187,7 @@ describe('Licence Versions - View presenter', () => {
         const result = ViewPresenter.go(licenceVersionData, auth, conditions)
 
         expect(result.licenceDetails).to.equal({
-          address: ['ORDER OF THE PHOENIX', '12 GRIMMAULD PLACE', 'ISLINGTON', 'LONDON', 'GREATER LONDON', 'N1 9LX'],
+          address: ['12 GRIMMAULD PLACE', 'ISLINGTON', 'LONDON', 'GREATER LONDON', 'N1 9LX'],
           applicationNumber: null,
           endDate: null,
           issueDate: null,

--- a/test/presenters/licence-versions/view.presenter.test.js
+++ b/test/presenters/licence-versions/view.presenter.test.js
@@ -18,7 +18,7 @@ const NotifyConfig = require('../../../config/notify.config.js')
 // Thing under test
 const ViewPresenter = require('../../../app/presenters/licence-versions/view.presenter.js')
 
-describe.only('Licence Versions - View presenter', () => {
+describe('Licence Versions - View presenter', () => {
   let auth
   let conditions
   let licenceVersion

--- a/test/presenters/licence-versions/view.presenter.test.js
+++ b/test/presenters/licence-versions/view.presenter.test.js
@@ -30,6 +30,7 @@ describe('Licence Versions - View presenter', () => {
         scope: []
       }
     }
+
     licenceVersion = ViewLicencesFixture.licenceVersion()
 
     licenceVersionData = {
@@ -59,7 +60,7 @@ describe('Licence Versions - View presenter', () => {
         conditionTypes: [],
         errorInDataEmail: 'notify@test.gov.uk',
         licenceDetails: {
-          address: ['12 GRIMMAULD PLACE', 'ISLINGTON', 'LONDON', 'GREATER LONDON', 'N1 9LX'],
+          address: ['ORDER OF THE PHOENIX', '12 GRIMMAULD PLACE', 'ISLINGTON', 'LONDON', 'GREATER LONDON', 'N1 9LX'],
           applicationNumber: null,
           endDate: null,
           issueDate: null,
@@ -171,7 +172,7 @@ describe('Licence Versions - View presenter', () => {
         const result = ViewPresenter.go(licenceVersionData, auth, conditions)
 
         expect(result.licenceDetails).to.equal({
-          address: ['12 GRIMMAULD PLACE', 'ISLINGTON', 'LONDON', 'GREATER LONDON', 'N1 9LX'],
+          address: ['ORDER OF THE PHOENIX', '12 GRIMMAULD PLACE', 'ISLINGTON', 'LONDON', 'GREATER LONDON', 'N1 9LX'],
           applicationNumber: 'R.1',
           endDate: '1 February 2024',
           issueDate: '3 March 2023',
@@ -186,7 +187,7 @@ describe('Licence Versions - View presenter', () => {
         const result = ViewPresenter.go(licenceVersionData, auth, conditions)
 
         expect(result.licenceDetails).to.equal({
-          address: ['12 GRIMMAULD PLACE', 'ISLINGTON', 'LONDON', 'GREATER LONDON', 'N1 9LX'],
+          address: ['ORDER OF THE PHOENIX', '12 GRIMMAULD PLACE', 'ISLINGTON', 'LONDON', 'GREATER LONDON', 'N1 9LX'],
           applicationNumber: null,
           endDate: null,
           issueDate: null,

--- a/test/services/licence-versions/view.service.test.js
+++ b/test/services/licence-versions/view.service.test.js
@@ -13,7 +13,7 @@ const ViewLicencesFixture = require('../../support/fixtures/view-licences.fixtur
 
 // Things we need to stub
 const FetchConditionsService = require('../../../app/services/licences/fetch-conditions.service.js')
-const FetchLicenceVersionService = require('../../../app/services/licence-versions/fetch-licence-version.service.js')
+const FetchLicenceVersionDal = require('../../../app/dal/licence-versions/fetch-licence-version.dal.js')
 const NotifyConfig = require('../../../config/notify.config.js')
 
 // Thing under test
@@ -35,7 +35,7 @@ describe('Licence Versions - View service', () => {
 
     conditions = []
 
-    Sinon.stub(FetchLicenceVersionService, 'go').returns({
+    Sinon.stub(FetchLicenceVersionDal, 'go').returns({
       licenceVersion,
       licenceVersionsForPagination: [licenceVersion]
     })
@@ -62,7 +62,7 @@ describe('Licence Versions - View service', () => {
         conditionTypes: [],
         errorInDataEmail: 'notify@test.gov.uk',
         licenceDetails: {
-          address: ['12 GRIMMAULD PLACE', 'ISLINGTON', 'LONDON', 'GREATER LONDON', 'N1 9LX'],
+          address: ['ORDER OF THE PHOENIX', '12 GRIMMAULD PLACE', 'ISLINGTON', 'LONDON', 'GREATER LONDON', 'N1 9LX'],
           applicationNumber: null,
           endDate: null,
           issueDate: null,

--- a/test/services/licence-versions/view.service.test.js
+++ b/test/services/licence-versions/view.service.test.js
@@ -62,7 +62,7 @@ describe('Licence Versions - View service', () => {
         conditionTypes: [],
         errorInDataEmail: 'notify@test.gov.uk',
         licenceDetails: {
-          address: ['ORDER OF THE PHOENIX', '12 GRIMMAULD PLACE', 'ISLINGTON', 'LONDON', 'GREATER LONDON', 'N1 9LX'],
+          address: ['12 GRIMMAULD PLACE', 'ISLINGTON', 'LONDON', 'GREATER LONDON', 'N1 9LX'],
           applicationNumber: null,
           endDate: null,
           issueDate: null,

--- a/test/support/fixtures/view-licences.fixture.js
+++ b/test/support/fixtures/view-licences.fixture.js
@@ -5,7 +5,6 @@
  */
 
 const LicenceModel = require('../../../app/models/licence.model.js')
-const LicenceVersionHolderModel = require('../../../app/models/licence-version-holder.model.js')
 const LicenceVersionModel = require('../../../app/models/licence-version.model.js')
 const PointModel = require('../../../app/models/point.model.js')
 const { generateLicenceRef } = require('../helpers/licence.helper.js')
@@ -76,27 +75,24 @@ function licence() {
  * @returns {object} - licence version
  */
 function licenceVersion() {
-  const licenceVersionHolder = LicenceVersionHolderModel.fromJson({
-    addressLine1: '12 GRIMMAULD PLACE',
-    addressLine2: 'ISLINGTON',
-    addressLine3: null,
-    addressLine4: null,
-    county: 'GREATER LONDON',
-    country: 'UNITED KINGDOM',
-    derivedName: 'ORDER OF THE PHOENIX',
-    forename: null,
-    holderType: 'organisation',
-    id: generateUUID(),
-    initials: null,
-    postcode: 'N1 9LX',
-    name: 'ORDER OF THE PHOENIX',
-    salutation: null,
-    town: 'LONDON'
-  })
-
   return LicenceVersionModel.fromJson({
+    address: {
+      address1: '12 GRIMMAULD PLACE',
+      address2: 'ISLINGTON',
+      address3: 'LONDON',
+      address4: 'GREATER LONDON',
+      address5: null,
+      address6: null,
+      country: 'UNITED KINGDOM',
+      id: generateUUID(),
+      postcode: 'N1 9LX'
+    },
     administrative: null,
     applicationNumber: null,
+    company: {
+      id: generateUUID(),
+      name: 'ORDER OF THE PHOENIX'
+    },
     createdAt: new Date('2022-01-01'),
     endDate: null,
     id: generateUUID(),
@@ -106,7 +102,6 @@ function licenceVersion() {
       licenceRef: generateLicenceRef()
     },
     licenceVersionPurposes: [],
-    licenceVersionHolder,
     modLogs: [
       {
         id: generateUUID(),


### PR DESCRIPTION
We no longer require the 'licence version holder' view. The licence version now has a company and address id. We are moving away from the licence version holder (we intend to remove it).

This change updates the licence version page to get the company and address based on the licence versions company id and address id.

This also means we can use the notify address presenter to show the address consistently across the service.