### PR TITLE
Add cooldown option to dependabot workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,16 @@
 version: 2
 updates:
   - package-ecosystem: npm
-    cooldown: 7
+    cooldown:
+      default-days: 7
     directory: '/'
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     versioning-strategy: lockfile-only
   - package-ecosystem: 'github-actions'
-    cooldown: 7
+    cooldown:
+      default-days: 7
     # Workflow files stored in the default location of `.github/workflows`
     directory: '/'
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,12 +4,14 @@
 version: 2
 updates:
   - package-ecosystem: npm
+    cooldown: 7
     directory: '/'
     schedule:
       interval: daily
     open-pull-requests-limit: 10
     versioning-strategy: lockfile-only
   - package-ecosystem: 'github-actions'
+    cooldown: 7
     # Workflow files stored in the default location of `.github/workflows`
     directory: '/'
     schedule:


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5681

Update `.github/dependabot.yml`. Set cooldown to 7 (days) for both the npm and github-actions ecosystems.