### PR TITLE
Remove licence version holder from queries

### DIFF
--- a/app/dal/companies/fetch-company-crm-data.dal.js
+++ b/app/dal/companies/fetch-company-crm-data.dal.js
@@ -79,10 +79,8 @@ function _query(paginationAndOrderBy = '') {
         1
       FROM
         public.licence_versions lv
-      INNER JOIN public.licence_version_holders lvh
-        ON lvh.licence_version_id = lv.id
       INNER JOIN company c
-        ON c.company_id = lvh.company_id
+        ON c.company_id = lv.company_id
       WHERE lv.licence_id = l.id
     )
   ),

--- a/app/dal/companies/fetch-history.dal.js
+++ b/app/dal/companies/fetch-history.dal.js
@@ -6,7 +6,6 @@
  */
 
 const LicenceModel = require('../../models/licence.model.js')
-const LicenceVersionModel = require('../../models/licence-version.model.js')
 
 const DatabaseConfig = require('../../../config/database.config.js')
 

--- a/app/dal/companies/fetch-history.dal.js
+++ b/app/dal/companies/fetch-history.dal.js
@@ -27,19 +27,13 @@ async function go(companyId, page = '1') {
 async function _fetch(companyId, page) {
   return LicenceModel.query()
     .select(['expiredDate', 'id', 'lapsedDate', 'licenceRef', 'revokedDate', 'startDate'])
-    .whereExists(
-      LicenceModel.relatedQuery('licenceVersions')
-        .innerJoinRelated('licenceVersionHolder')
-        .where('licenceVersionHolder.companyId', companyId)
-    )
+    .whereExists(LicenceModel.relatedQuery('licenceVersions').where('licenceVersions.companyId', companyId))
     .withGraphFetched('licenceVersions')
     .modifyGraph('licenceVersions', (licenceVersionsBuilder) => {
       licenceVersionsBuilder
         .select(['endDate', 'id', 'startDate'])
         .modify('changeType')
-        .whereExists(
-          LicenceVersionModel.relatedQuery('licenceVersionHolder').where('licenceVersionHolder.companyId', companyId)
-        )
+        .where('companyId', companyId)
         .orderBy([
           { column: 'startDate', order: 'desc' },
           { column: 'issue', order: 'desc' },

--- a/app/dal/companies/fetch-licences.dal.js
+++ b/app/dal/companies/fetch-licences.dal.js
@@ -55,11 +55,7 @@ async function go(companyId, page = '1') {
 async function _fetch(companyId, page) {
   return LicenceModel.query()
     .select(['licences.id'])
-    .whereExists(
-      LicenceModel.relatedQuery('licenceVersions')
-        .innerJoinRelated('licenceVersionHolder')
-        .where('licenceVersionHolder.companyId', companyId)
-    )
+    .whereExists(LicenceModel.relatedQuery('licenceVersions').where('licenceVersions.companyId', companyId))
     .orderBy([{ column: 'licenceRef', order: 'asc' }])
     .page(Number(page) - 1, DatabaseConfig.defaultPageSize)
 }
@@ -101,17 +97,17 @@ async function _fetchDetail(licenceIds) {
       'licences.revokedDate',
       'licences.startDate',
       'latest_holder.company_id AS currentLicenceHolderId',
-      'latest_holder.derived_name AS currentLicenceHolder'
+      'latest_holder.name AS currentLicenceHolder'
     ])
     .whereIn('id', licenceIds)
     .joinRaw(
       `LEFT JOIN LATERAL (
       SELECT
-        lvh.company_id,
-        lvh.derived_name
+        lv.company_id,
+        c.name
       FROM public.licence_versions lv
-      INNER JOIN public.licence_version_holders lvh
-        ON lvh.licence_version_id = lv.id
+      INNER JOIN public.companies c
+        ON c.id = lv.company_id
       WHERE
         lv.licence_id = licences.id
       ORDER BY

--- a/app/services/licences/fetch-licence-crm-data.service.js
+++ b/app/services/licences/fetch-licence-crm-data.service.js
@@ -100,14 +100,14 @@ function _query(paginationAndOrderBy = '') {
     ),
     licence_holder AS (
       SELECT
-        lvh.company_id AS id,
-        lvh.derived_name AS "contactName",
+        lv.company_id AS id,
+        c.name AS "contactName",
         'licence-holder' AS "contactType",
-        lvh.address_id AS "addressId"
+        lv.address_id AS "addressId"
       FROM
         public.licence_versions lv
-      INNER JOIN public.licence_version_holders lvh
-        ON lv.id = lvh.licence_version_id
+      INNER JOIN public.companies c
+        ON c.id = lv.company_id
       INNER JOIN licence l
         ON l.licence_id = lv.licence_id
       ORDER BY

--- a/test/dal/companies/fetch-history.dal.test.js
+++ b/test/dal/companies/fetch-history.dal.test.js
@@ -5,14 +5,13 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, beforeEach, before, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const CompanyHelper = require('../../support/helpers/company.helper.js')
+const CRMContactsSeeder = require('../../support/seeders/crm-contacts.seeder.js')
 const LicenceHelper = require('../../support/helpers/licence.helper.js')
 const LicenceVersionHelper = require('../../support/helpers/licence-version.helper.js')
-const LicenceVersionHolder = require('../../support/helpers/licence-version-holder.helper.js')
 const { generateUUID } = require('../../../app/lib/general.lib.js')
 
 // Things we need to stub
@@ -22,52 +21,30 @@ const DatabaseConfig = require('../../../config/database.config.js')
 const FetchHistoryDal = require('../../../app/dal/companies/fetch-history.dal.js')
 
 describe('Companies - Fetch History dal', () => {
-  let company
   let licence
-  let licenceVersion
-  let licenceVersionHolder
-  let licenceVersionSameLicenceNoCompany
-  let licenceVersionSameLicenceHolderNoCompany
-  let licenceVersionHolderSameLicenceDifferentCompany
+  let licenceHolder
   let licenceVersionSameLicenceDifferentCompany
+  let licenceVersionSameLicenceNoCompany
   let pageNumber
 
   before(async () => {
-    company = await CompanyHelper.add()
     licence = await LicenceHelper.add()
 
-    // A licence version/holder linked to the company
-    licenceVersion = await LicenceVersionHelper.add({
-      licenceId: licence.id
-    })
+    // A licence version linked to the company
+    licenceHolder = await CRMContactsSeeder.licenceHolder({ licence }, 'Example Trading Ltd')
 
-    licenceVersionHolder = await LicenceVersionHolder.add({
-      companyId: company.id,
-      licenceVersionId: licenceVersion.id
-    })
-
-    // A licence version/holder not linked to the company
+    // A licence version not linked to the company
     licenceVersionSameLicenceDifferentCompany = await LicenceVersionHelper.add({
-      licenceId: licence.id
+      licenceId: licence.id,
+      companyId: generateUUID()
     })
 
-    licenceVersionHolderSameLicenceDifferentCompany = await LicenceVersionHolder.add({
-      companyId: generateUUID(),
-      licenceVersionId: licenceVersionSameLicenceDifferentCompany.id
-    })
-
-    // A licence version/holder not linked to any company
+    // A licence version not linked to any company
     licenceVersionSameLicenceNoCompany = await LicenceVersionHelper.add({
-      licenceId: licence.id
+      licenceId: licence.id,
+      companyId: generateUUID()
     })
 
-    licenceVersionSameLicenceHolderNoCompany = await LicenceVersionHolder.add({
-      companyId: null,
-      licenceVersionId: licenceVersionSameLicenceNoCompany.id
-    })
-  })
-
-  beforeEach(() => {
     pageNumber = '1'
 
     // NOTE: We set the default page size to 1000 to ensure we get all records and avoid failed tests when run as
@@ -75,24 +52,19 @@ describe('Companies - Fetch History dal', () => {
     Sinon.stub(DatabaseConfig, 'defaultPageSize').value(1000)
   })
 
-  afterEach(() => {
-    Sinon.restore()
-  })
+  after(async () => {
+    await licenceHolder.clean()
 
-  afterEach(async () => {
-    await company.$query().delete()
     await licence.$query().delete()
-    await licenceVersion.$query().delete()
-    await licenceVersionHolder.$query().delete()
     await licenceVersionSameLicenceDifferentCompany.$query().delete()
-    await licenceVersionHolderSameLicenceDifferentCompany.$query().delete()
     await licenceVersionSameLicenceNoCompany.$query().delete()
-    await licenceVersionSameLicenceHolderNoCompany.$query().delete()
+
+    Sinon.restore()
   })
 
   describe('when called', () => {
     it('returns licences linked to the company where it is the licence holder', async () => {
-      const result = await FetchHistoryDal.go(company.id, pageNumber)
+      const result = await FetchHistoryDal.go(licenceHolder.company.id, pageNumber)
 
       expect(result).to.equal({
         licences: [
@@ -105,7 +77,7 @@ describe('Companies - Fetch History dal', () => {
               {
                 administrative: null,
                 endDate: null,
-                id: licenceVersion.id,
+                id: licenceHolder.licenceVersion.id,
                 startDate: new Date('2022-01-01')
               }
             ],

--- a/test/dal/companies/fetch-history.dal.test.js
+++ b/test/dal/companies/fetch-history.dal.test.js
@@ -23,8 +23,8 @@ const FetchHistoryDal = require('../../../app/dal/companies/fetch-history.dal.js
 describe('Companies - Fetch History dal', () => {
   let licence
   let licenceHolder
+  let licenceVersionDifferentLicenceAndCompany
   let licenceVersionSameLicenceDifferentCompany
-  let licenceVersionSameLicenceNoCompany
   let pageNumber
 
   before(async () => {
@@ -39,9 +39,9 @@ describe('Companies - Fetch History dal', () => {
       companyId: generateUUID()
     })
 
-    // A licence version not linked to any company
-    licenceVersionSameLicenceNoCompany = await LicenceVersionHelper.add({
-      licenceId: licence.id,
+    // A licence version not linked to the company or licence
+    licenceVersionDifferentLicenceAndCompany = await LicenceVersionHelper.add({
+      licenceId: generateUUID(),
       companyId: generateUUID()
     })
 
@@ -56,8 +56,8 @@ describe('Companies - Fetch History dal', () => {
     await licenceHolder.clean()
 
     await licence.$query().delete()
+    await licenceVersionDifferentLicenceAndCompany.$query().delete()
     await licenceVersionSameLicenceDifferentCompany.$query().delete()
-    await licenceVersionSameLicenceNoCompany.$query().delete()
 
     Sinon.restore()
   })

--- a/test/dal/companies/fetch-history.dal.test.js
+++ b/test/dal/companies/fetch-history.dal.test.js
@@ -31,7 +31,7 @@ describe('Companies - Fetch History dal', () => {
     licence = await LicenceHelper.add()
 
     // A licence version linked to the company
-    licenceHolder = await CRMContactsSeeder.licenceHolder({ licence }, 'Example Trading Ltd')
+    licenceHolder = await CRMContactsSeeder.licenceHolder({ licence }, 'Omni Consumer Products')
 
     // A licence version not linked to the company
     licenceVersionSameLicenceDifferentCompany = await LicenceVersionHelper.add({

--- a/test/dal/companies/fetch-licences.dal.test.js
+++ b/test/dal/companies/fetch-licences.dal.test.js
@@ -41,8 +41,6 @@ describe('Companies - Fetch Licences dal', () => {
 
     companyId = licenceHolder.company.id
 
-    //startDate: new Date('2022-01-01'),
-
     // This is an older licence version linked to a different company. This confirms we are getting the right current
     // licence holder details
     olderLicenceVersion = await LicenceVersionHelper.add({

--- a/test/dal/companies/fetch-licences.dal.test.js
+++ b/test/dal/companies/fetch-licences.dal.test.js
@@ -37,7 +37,7 @@ describe('Companies - Fetch Licences dal', () => {
       licenceRef: `02/${generateRandomInteger(10, 99)}/${generateRandomInteger(100, 999)}`
     })
 
-    licenceHolder = await CRMContactsSeeder.licenceHolder({ licence }, 'Example Trading Ltd')
+    licenceHolder = await CRMContactsSeeder.licenceHolder({ licence }, 'Kanemitsu Corporation')
 
     companyId = licenceHolder.company.id
 

--- a/test/dal/companies/fetch-licences.dal.test.js
+++ b/test/dal/companies/fetch-licences.dal.test.js
@@ -9,9 +9,9 @@ const { describe, it, beforeEach, before, afterEach, after } = (exports.lab = La
 const { expect } = Code
 
 // Test helpers
+const CRMContactsSeeder = require('../../support/seeders/crm-contacts.seeder.js')
 const LicenceHelper = require('../../support/helpers/licence.helper.js')
 const LicenceVersionHelper = require('../../support/helpers/licence-version.helper.js')
-const LicenceVersionHolderHelper = require('../../support/helpers/licence-version-holder.helper.js')
 const { generateRandomInteger, generateUUID } = require('../../../app/lib/general.lib.js')
 
 // Things we need to stub
@@ -23,36 +23,25 @@ const FetchLicencesDal = require('../../../app/dal/companies/fetch-licences.dal.
 describe('Companies - Fetch Licences dal', () => {
   let anotherLicence
   let anotherLicenceVersion
-  let anotherLicenceVersionHolder
   let companyId
   let licence
-  let licenceVersion
-  let licenceVersionHolder
+  let licenceHolder
   let olderLicenceVersion
-  let olderLicenceVersionHolder
   let otherLicence
   let otherLicenceVersion
-  let otherLicenceVersionHolder
   let pageNumber
 
   before(async () => {
-    companyId = generateUUID()
-
     // This is the licence and details we expect to retrieve
     licence = await LicenceHelper.add({
       licenceRef: `02/${generateRandomInteger(10, 99)}/${generateRandomInteger(100, 999)}`
     })
-    licenceVersion = await LicenceVersionHelper.add({
-      increment: 0,
-      issue: 2,
-      licenceId: licence.id,
-      startDate: new Date('2025-04-01')
-    })
-    licenceVersionHolder = await LicenceVersionHolderHelper.add({
-      companyId,
-      derivedName: 'Kanemitsu Corporation',
-      licenceVersionId: licenceVersion.id
-    })
+
+    licenceHolder = await CRMContactsSeeder.licenceHolder({ licence }, 'Example Trading Ltd')
+
+    companyId = licenceHolder.company.id
+
+    //startDate: new Date('2022-01-01'),
 
     // This is an older licence version linked to a different company. This confirms we are getting the right current
     // licence holder details
@@ -60,12 +49,8 @@ describe('Companies - Fetch Licences dal', () => {
       increment: 0,
       issue: 1,
       licenceId: licence.id,
-      startDate: new Date('2022-01-01')
-    })
-    olderLicenceVersionHolder = await LicenceVersionHolderHelper.add({
-      companyId: generateUUID(),
-      derivedName: 'Omni Consumer Products',
-      licenceVersionId: olderLicenceVersion.id
+      startDate: new Date('2021-12-31'),
+      companyId: generateUUID()
     })
 
     // This is another licence for the same company and details we expect to retrieve. This should appear first
@@ -73,16 +58,13 @@ describe('Companies - Fetch Licences dal', () => {
     anotherLicence = await LicenceHelper.add({
       licenceRef: `01/${generateRandomInteger(10, 99)}/${generateRandomInteger(100, 999)}`
     })
+
     anotherLicenceVersion = await LicenceVersionHelper.add({
       increment: 0,
       issue: 1,
       licenceId: anotherLicence.id,
-      startDate: new Date('2025-04-01')
-    })
-    anotherLicenceVersionHolder = await LicenceVersionHolderHelper.add({
-      companyId,
-      derivedName: 'Kanemitsu Corporation',
-      licenceVersionId: anotherLicenceVersion.id
+      startDate: new Date('2025-04-01'),
+      companyId: licenceHolder.company.id
     })
 
     // This is a different licence linked to a different company. This confirms we are only getting licences for the
@@ -92,12 +74,8 @@ describe('Companies - Fetch Licences dal', () => {
       increment: 0,
       issue: 2,
       licenceId: otherLicence.id,
-      startDate: new Date('2025-04-01')
-    })
-    otherLicenceVersionHolder = await LicenceVersionHolderHelper.add({
-      companyId: generateUUID(),
-      derivedName: 'Kanemitsu Corporation',
-      licenceVersionId: otherLicenceVersion.id
+      startDate: new Date('2025-04-01'),
+      companyId: generateUUID()
     })
   })
 
@@ -114,19 +92,13 @@ describe('Companies - Fetch Licences dal', () => {
   })
 
   after(async () => {
-    await otherLicenceVersionHolder.$query().delete()
+    await licenceHolder.clean()
+
     await otherLicenceVersion.$query().delete()
     await otherLicence.$query().delete()
-
-    await anotherLicenceVersionHolder.$query().delete()
     await anotherLicenceVersion.$query().delete()
     await anotherLicence.$query().delete()
-
-    await olderLicenceVersionHolder.$query().delete()
     await olderLicenceVersion.$query().delete()
-
-    await licenceVersionHolder.$query().delete()
-    await licenceVersion.$query().delete()
     await licence.$query().delete()
   })
 
@@ -143,8 +115,8 @@ describe('Companies - Fetch Licences dal', () => {
             licenceRef: anotherLicence.licenceRef,
             revokedDate: null,
             startDate: new Date('2022-01-01'),
-            currentLicenceHolderId: anotherLicenceVersionHolder.companyId,
-            currentLicenceHolder: anotherLicenceVersionHolder.derivedName
+            currentLicenceHolderId: licenceHolder.company.id,
+            currentLicenceHolder: licenceHolder.company.name
           },
           {
             expiredDate: null,
@@ -153,8 +125,8 @@ describe('Companies - Fetch Licences dal', () => {
             licenceRef: licence.licenceRef,
             revokedDate: null,
             startDate: new Date('2022-01-01'),
-            currentLicenceHolderId: licenceVersionHolder.companyId,
-            currentLicenceHolder: licenceVersionHolder.derivedName
+            currentLicenceHolderId: licenceHolder.company.id,
+            currentLicenceHolder: licenceHolder.company.name
           }
         ],
         totalNumber: 2

--- a/test/support/seeders/crm.seeder.js
+++ b/test/support/seeders/crm.seeder.js
@@ -18,7 +18,6 @@ const LicenceEntityRoleHelper = require('../helpers/licence-entity-role.helper.j
 const LicenceHelper = require('../helpers/licence.helper.js')
 const LicenceRoleHelper = require('../../support/helpers/licence-role.helper.js')
 const LicenceVersionHelper = require('../helpers/licence-version.helper.js')
-const LicenceVersionHolderHelper = require('../helpers/licence-version-holder.helper.js')
 const UserModel = require('../helpers/user.helper.js')
 const { generateLicenceRef } = require('../helpers/licence.helper.js')
 
@@ -320,13 +319,8 @@ async function _licence(company) {
   const licence = await LicenceHelper.add()
 
   const licenceVersion = await LicenceVersionHelper.add({
-    licenceId: licence.id
-  })
-
-  const licenceVersionHolder = await LicenceVersionHolderHelper.add({
-    companyId: company.record.id,
-    derivedName: company.record.name,
-    licenceVersionId: licenceVersion.id
+    licenceId: licence.id,
+    companyId: company.record.id
   })
 
   return {
@@ -334,7 +328,6 @@ async function _licence(company) {
     clean: async () => {
       await licence.$query().delete()
       await licenceVersion.$query().delete()
-      await licenceVersionHolder.$query().delete()
     }
   }
 }


### PR DESCRIPTION
We no longer require the 'licence version holder' view. The licence version now has a company and address id. We are moving away from the licence version holder (we intend to remove it).

This change removes the use of licence version holder from any remaining queries.

We will remove the model and relations in another change, as we want to show clearly the business logic changes. 