### PR TITLE
Fix mistake in CRM teardown company cleanup

### DIFF
--- a/app/services/data/tear-down/crm-schema.service.js
+++ b/app/services/data/tear-down/crm-schema.service.js
@@ -47,7 +47,11 @@ async function _deleteAllTestData() {
       USING "crm_v2"."invoice_accounts" AS "ia",
     "crm_v2"."companies" AS "c"
   WHERE
-    ("c"."is_test" = TRUE OR "c"."name" IN ('Big Farm Co Ltd', 'Test Farm Co Ltd'))
+    (
+      "c"."is_test" = TRUE
+      OR "c"."name" IN ('Big Farm Co Ltd', 'Test Farm Co Ltd')
+      OR "c"."name" LIKE 'Big Farm Co Ltd%'
+    )
     AND "iaa"."invoice_account_id" = "ia"."invoice_account_id"
     AND "ia"."company_id" = "c"."company_id";
 
@@ -62,7 +66,11 @@ async function _deleteAllTestData() {
     "crm_v2"."invoice_accounts" AS "ia"
       USING "crm_v2"."companies" AS "c"
   WHERE
-    ("c"."is_test" = TRUE OR "c"."name" IN ('Big Farm Co Ltd', 'Test Farm Co Ltd'))
+    (
+      "c"."is_test" = TRUE
+      OR "c"."name" IN ('Big Farm Co Ltd', 'Test Farm Co Ltd')
+      OR "c"."name" LIKE 'Big Farm Co Ltd%'
+    )
     AND "ia"."company_id" = "c"."company_id";
 
   DELETE
@@ -73,10 +81,11 @@ async function _deleteAllTestData() {
 
   DELETE
   FROM
-    "crm_v2"."companies"
+    "crm_v2"."companies" AS "c"
   WHERE
-    "is_test" = TRUE
-    OR "name" IN ('Big Farm Co Ltd', 'Test Farm Co Ltd');
+    "c"."is_test" = TRUE
+    OR "c"."name" IN ('Big Farm Co Ltd', 'Test Farm Co Ltd')
+    OR "c"."name" LIKE 'Big Farm Co Ltd%';
 
   DELETE
   FROM


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5696

In [clean up missed CRM data in teardown](https://github.com/DEFRA/water-abstraction-system/pull/3483), we tweaked the CRM teardown to ensure that some CRM entities previously cleaned were included.

In that change, we also tweaked the WHERE clause for cleaning companies, changing from a `LIKE` to an `IN` clause.

This was there for a reason. The old billing tests that still use the JSON fixtures create a series of companies: 'Big Farm Co Ltd 01', 'Big Farm Co Ltd 02', 'Big Farm Co Ltd 03', and 'Big Farm Co Ltd 04'. Our change meant the cleanup was missing these, but deleting anything related to them.

This led to tests breaking.

This change fixes it! (We've fully tested this time)