### PR TITLE
Update unregister licence recording - Create view, model & legacy migration

### DIFF
--- a/app/models/licence-unregistration.model.js
+++ b/app/models/licence-unregistration.model.js
@@ -1,0 +1,39 @@
+'use strict'
+
+/**
+ * Model for licence_unregistrations (water.licence_unregistrations)
+ * @module LicenceUnregistrationModel
+ */
+
+const { Model } = require('objection')
+
+const BaseModel = require('./base.model.js')
+
+class LicenceUnregistrationModel extends BaseModel {
+  static get tableName() {
+    return 'licenceUnregistrations'
+  }
+
+  static get relationMappings() {
+    return {
+      licence: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'licence.model',
+        join: {
+          from: 'licenceUnregistrations.licenceId',
+          to: 'licences.id'
+        }
+      },
+      user: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'user.model',
+        join: {
+          from: 'licenceUnregistrations.createdBy',
+          to: 'users.id'
+        }
+      }
+    }
+  }
+}
+
+module.exports = LicenceUnregistrationModel

--- a/app/models/licence.model.js
+++ b/app/models/licence.model.js
@@ -82,6 +82,14 @@ class LicenceModel extends BaseModel {
           to: 'licenceSupplementaryYears.licenceId'
         }
       },
+      licenceUnregistrations: {
+        relation: Model.HasManyRelation,
+        modelClass: 'licence-unregistration.model',
+        join: {
+          from: 'licences.id',
+          to: 'licenceUnregistrations.licenceId'
+        }
+      },
       licenceVersions: {
         relation: Model.HasManyRelation,
         modelClass: 'licence-version.model',

--- a/app/models/user.model.js
+++ b/app/models/user.model.js
@@ -63,6 +63,14 @@ class UserModel extends BaseModel {
           to: 'licenceMonitoringStations.createdBy'
         }
       },
+      licenceUnregistrations: {
+        relation: Model.HasManyRelation,
+        modelClass: 'licence-unregistration.model',
+        join: {
+          from: 'users.id',
+          to: 'licenceUnregistrations.createdBy'
+        }
+      },
       returnVersions: {
         relation: Model.HasManyRelation,
         modelClass: 'return-version.model',

--- a/db/migrations/legacy/20260625160122_water-licence-unregistrations.js
+++ b/db/migrations/legacy/20260625160122_water-licence-unregistrations.js
@@ -1,0 +1,21 @@
+'use strict'
+
+const tableName = 'licence_unregistrations'
+
+exports.up = function (knex) {
+  return knex.schema.withSchema('water').createTable(tableName, (table) => {
+    // Primary Key
+    table.uuid('id').primary().defaultTo(knex.raw('gen_random_uuid()'))
+
+    // Data
+    table.uuid('created_by').notNullable()
+    table.uuid('licence_id').notNullable()
+
+    // Timestamps
+    table.timestamp('created_at', { useTz: false }).notNullable().defaultTo(knex.fn.now())
+  })
+}
+
+exports.down = function (knex) {
+  return knex.schema.withSchema('water').dropTableIfExists(tableName)
+}

--- a/db/migrations/public/20260625154952_create-licence-unregistrations-view.js
+++ b/db/migrations/public/20260625154952_create-licence-unregistrations-view.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const viewName = 'licence_unregistrations'
+
+exports.up = function (knex) {
+  return knex.schema.createView(viewName, (view) => {
+    view.as(
+      knex(viewName)
+        .withSchema('water')
+        .select([
+          'id',
+          'created_by',
+          'licence_id',
+          'created_at'
+        ])
+    )
+  })
+}
+
+exports.down = function (knex) {
+  return knex.schema.dropViewIfExists(viewName)
+}

--- a/db/migrations/public/20260625154952_create-licence-unregistrations-view.js
+++ b/db/migrations/public/20260625154952_create-licence-unregistrations-view.js
@@ -4,16 +4,7 @@ const viewName = 'licence_unregistrations'
 
 exports.up = function (knex) {
   return knex.schema.createView(viewName, (view) => {
-    view.as(
-      knex(viewName)
-        .withSchema('water')
-        .select([
-          'id',
-          'created_by',
-          'licence_id',
-          'created_at'
-        ])
-    )
+    view.as(knex(viewName).withSchema('water').select(['id', 'created_by', 'licence_id', 'created_at']))
   })
 }
 

--- a/test/models/licence-unregistration.model.test.js
+++ b/test/models/licence-unregistration.model.test.js
@@ -1,0 +1,79 @@
+'use strict'
+
+// Test framework dependencies
+const Lab = require('@hapi/lab')
+const Code = require('@hapi/code')
+
+const { describe, it, before } = (exports.lab = Lab.script())
+const { expect } = Code
+
+// Test helpers
+const LicenceHelper = require('../support/helpers/licence.helper.js')
+const LicenceModel = require('../../app/models/licence.model.js')
+const LicenceUnregistrationHelper = require('../support/helpers/licence-unregistration.helper.js')
+const UserHelper = require('../support/helpers/user.helper.js')
+const UserModel = require('../../app/models/user.model.js')
+
+// Thing under test
+const LicenceUnregistrationModel = require('../../app/models/licence-unregistration.model.js')
+
+const { SKIP_COMPARE_LIST: skip } = UserHelper
+
+describe('Licence Unregistration model', () => {
+  let testLicence
+  let testRecord
+  let testUser
+
+  before(async () => {
+    testLicence = await LicenceHelper.add()
+    testUser = UserHelper.select()
+    testRecord = await LicenceUnregistrationHelper.add({ createdBy: testUser.id, licenceId: testLicence.id })
+  })
+
+  describe('Basic query', () => {
+    it('can successfully run a basic query', async () => {
+      const result = await LicenceUnregistrationModel.query().findById(testRecord.id)
+
+      expect(result).to.be.an.instanceOf(LicenceUnregistrationModel)
+      expect(result.id).to.be.equal(testRecord.id)
+    })
+  })
+
+  describe('Relationships', () => {
+    describe('when linking to licence', () => {
+      it('can successfully run a related query', async () => {
+        const query = await LicenceUnregistrationModel.query().innerJoinRelated('licence')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the licence', async () => {
+        const result = await LicenceUnregistrationModel.query().findById(testRecord.id).withGraphFetched('licence')
+
+        expect(result).to.be.instanceOf(LicenceUnregistrationModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.licence).to.be.instanceOf(LicenceModel)
+        expect(result.licence).to.equal(testLicence)
+      })
+    })
+
+    describe('when linking to user', () => {
+      it('can successfully run a related query', async () => {
+        const query = await LicenceUnregistrationModel.query().innerJoinRelated('user')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the user', async () => {
+        const result = await LicenceUnregistrationModel.query().findById(testRecord.id).withGraphFetched('user')
+
+        expect(result).to.be.instanceOf(LicenceUnregistrationModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.user).to.be.instanceOf(UserModel)
+        expect(result.user).to.equal(testUser, { skip })
+      })
+    })
+  })
+})

--- a/test/models/licence.model.test.js
+++ b/test/models/licence.model.test.js
@@ -28,6 +28,8 @@ const LicenceMonitoringStationHelper = require('../support/helpers/licence-monit
 const LicenceMonitoringStationModel = require('../../app/models/licence-monitoring-station.model.js')
 const LicenceSupplementaryYearHelper = require('../support/helpers/licence-supplementary-year.helper.js')
 const LicenceSupplementaryYearModel = require('../../app/models/licence-supplementary-year.model.js')
+const LicenceUnregistrationHelper = require('../support/helpers/licence-unregistration.helper.js')
+const LicenceUnregistrationModel = require('../../app/models/licence-unregistration.model.js')
 const LicenceVersionHelper = require('../support/helpers/licence-version.helper.js')
 const LicenceVersionModel = require('../../app/models/licence-version.model.js')
 const ModLogHelper = require('../support/helpers/mod-log.helper.js')
@@ -59,6 +61,7 @@ describe('Licence model', () => {
   let licenceEndDateChanges
   let licenceMonitoringStations
   let licenceSupplementaryYears
+  let licenceUnregistrations
   let licenceVersions
   let modLogs
   let region
@@ -79,6 +82,7 @@ describe('Licence model', () => {
     licenceEndDateChanges = []
     licenceMonitoringStations = []
     licenceSupplementaryYears = []
+    licenceUnregistrations = []
     licenceVersions = []
     modLogs = []
     returnLogs = []
@@ -117,6 +121,10 @@ describe('Licence model', () => {
       // Create test licence supplementary years
       const licenceSupplementaryYear = await LicenceSupplementaryYearHelper.add({ licenceId: testRecord.id })
       licenceSupplementaryYears.push(licenceSupplementaryYear)
+
+      // Create test licence unregistrations
+      const licenceUnregistration = await LicenceUnregistrationHelper.add({ licenceId: testRecord.id })
+      licenceUnregistrations.push(licenceUnregistration)
 
       // Create test licence versions
       const licenceVersion = await LicenceVersionHelper.add({ licenceId: testRecord.id })
@@ -177,6 +185,10 @@ describe('Licence model', () => {
 
     for (const licenceSupplementaryYear of licenceSupplementaryYears) {
       await licenceSupplementaryYear.$query().delete()
+    }
+
+    for (const licenceUnregistration of licenceUnregistrations) {
+      await licenceUnregistration.$query().delete()
     }
 
     for (const licenceMonitoringStation of licenceMonitoringStations) {
@@ -365,6 +377,26 @@ describe('Licence model', () => {
         expect(result.licenceSupplementaryYears[0]).to.be.an.instanceOf(LicenceSupplementaryYearModel)
         expect(result.licenceSupplementaryYears).to.include(licenceSupplementaryYears[0])
         expect(result.licenceSupplementaryYears).to.include(licenceSupplementaryYears[1])
+      })
+    })
+
+    describe('when linking to licence unregistrations', () => {
+      it('can successfully run a related query', async () => {
+        const query = await LicenceModel.query().innerJoinRelated('licenceUnregistrations')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the licence unregistrations', async () => {
+        const result = await LicenceModel.query().findById(testRecord.id).withGraphFetched('licenceUnregistrations')
+
+        expect(result).to.be.instanceOf(LicenceModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.licenceUnregistrations).to.be.an.array()
+        expect(result.licenceUnregistrations[0]).to.be.an.instanceOf(LicenceUnregistrationModel)
+        expect(result.licenceUnregistrations).to.include(licenceUnregistrations[0])
+        expect(result.licenceUnregistrations).to.include(licenceUnregistrations[1])
       })
     })
 

--- a/test/models/user.model.test.js
+++ b/test/models/user.model.test.js
@@ -21,6 +21,8 @@ const LicenceEntityRoleHelper = require('../support/helpers/licence-entity-role.
 const LicenceHelper = require('../support/helpers/licence.helper.js')
 const LicenceMonitoringStationHelper = require('../support/helpers/licence-monitoring-station.helper.js')
 const LicenceMonitoringStationModel = require('../../app/models/licence-monitoring-station.model.js')
+const LicenceUnregistrationHelper = require('../support/helpers/licence-unregistration.helper.js')
+const LicenceUnregistrationModel = require('../../app/models/licence-unregistration.model.js')
 const ReturnVersionHelper = require('../support/helpers/return-version.helper.js')
 const ReturnVersionModel = require('../../app/models/return-version.model.js')
 const RoleHelper = require('../support/helpers/role.helper.js')
@@ -262,6 +264,41 @@ describe('User model', () => {
         expect(result.licenceMonitoringStations[0]).to.be.an.instanceOf(LicenceMonitoringStationModel)
         expect(result.licenceMonitoringStations).to.include(testLicenceMonitoringStations[0])
         expect(result.licenceMonitoringStations).to.include(testLicenceMonitoringStations[1])
+      })
+    })
+
+    describe('when linking to licence unregistrations', () => {
+      let testLicenceUnregistrations
+
+      beforeEach(async () => {
+        testLicenceUnregistrations = []
+        for (let i = 0; i < 2; i++) {
+          const licenceUnregistration = await LicenceUnregistrationHelper.add({ createdBy: testRecord.id })
+
+          testLicenceUnregistrations.push(licenceUnregistration)
+        }
+      })
+
+      it('can successfully run a related query', async () => {
+        const query = await UserModel.query().innerJoinRelated('licenceUnregistrations')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the licence unregistrations', async () => {
+        const result = await UserModel.query()
+          .findById(testRecord.id)
+          .limit(1)
+          .first()
+          .withGraphFetched('licenceUnregistrations')
+
+        expect(result).to.be.instanceOf(UserModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.licenceUnregistrations).to.be.an.array()
+        expect(result.licenceUnregistrations[0]).to.be.an.instanceOf(LicenceUnregistrationModel)
+        expect(result.licenceUnregistrations).to.include(testLicenceUnregistrations[0])
+        expect(result.licenceUnregistrations).to.include(testLicenceUnregistrations[1])
       })
     })
 

--- a/test/support/helpers/licence-unregistration.helper.js
+++ b/test/support/helpers/licence-unregistration.helper.js
@@ -1,0 +1,55 @@
+'use strict'
+
+/**
+ * @module LicenceUnregistrationHelper
+ */
+
+const LicenceUnregistrationModel = require('../../../app/models/licence-unregistration.model.js')
+const { generateUUID } = require('../../../app/lib/general.lib.js')
+
+/**
+ * Add a new licence unregistration
+ *
+ * If no `data` is provided, default values will be used. These are
+ *
+ * - `createdBy` - [random UUID]
+ * - `licenceId` - [random UUID]
+ *
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
+ *
+ * @returns {Promise<module:LicenceUnregistrationModel>} The instance of the newly created record
+ */
+function add(data = {}) {
+  const insertData = defaults(data)
+
+  return LicenceUnregistrationModel.query()
+    .insert({ ...insertData })
+    .returning('*')
+}
+
+/**
+ * Returns the defaults used
+ *
+ * It will override or append to them any data provided. Mainly used by the `add()` method, we make it available
+ * for use in tests to avoid having to duplicate values.
+ *
+ * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
+ *
+ * @returns {object} - Returns the set defaults with the override data spread
+ */
+function defaults(data = {}) {
+  const defaults = {
+    createdBy: generateUUID(),
+    licenceId: generateUUID()
+  }
+
+  return {
+    ...defaults,
+    ...data
+  }
+}
+
+module.exports = {
+  add,
+  defaults
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5699

Create a view, model and legacy migration for the new table `water.licence_unregistrations` that was created in PR https://github.com/DEFRA/water-abstraction-service/pull/2829