### PR TITLE
Update Model unit tests for consistency

### DIFF
--- a/app/models/review-charge-element-return.model.js
+++ b/app/models/review-charge-element-return.model.js
@@ -23,6 +23,14 @@ class ReviewChargeElementReturnModel extends BaseModel {
           from: 'reviewChargeElementReturns.reviewChargeElementId',
           to: 'reviewChargeElements.id'
         }
+      },
+      reviewReturn: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'review-return.model',
+        join: {
+          from: 'reviewChargeElementReturns.reviewReturnId',
+          to: 'reviewReturns.id'
+        }
       }
     }
   }

--- a/app/models/review-charge-element-return.model.js
+++ b/app/models/review-charge-element-return.model.js
@@ -5,11 +5,26 @@
  * @module ReviewChargeElementReturnModel
  */
 
+const { Model } = require('objection')
+
 const BaseModel = require('./base.model.js')
 
 class ReviewChargeElementReturnModel extends BaseModel {
   static get tableName() {
     return 'reviewChargeElementReturns'
+  }
+
+  static get relationMappings() {
+    return {
+      reviewChargeElement: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'review-charge-element.model',
+        join: {
+          from: 'reviewChargeElementReturns.reviewChargeElementId',
+          to: 'reviewChargeElements.id'
+        }
+      }
+    }
   }
 }
 

--- a/app/models/review-charge-element.model.js
+++ b/app/models/review-charge-element.model.js
@@ -16,6 +16,22 @@ class ReviewChargeElementModel extends BaseModel {
 
   static get relationMappings() {
     return {
+      chargeElement: {
+        relation: Model.BelongsToOneRelation,
+        modelClass: 'charge-element.model',
+        join: {
+          from: 'reviewChargeElements.chargeElementId',
+          to: 'chargeElements.id'
+        }
+      },
+      reviewChargeElementReturns: {
+        relation: Model.HasManyRelation,
+        modelClass: 'review-charge-element-return.model',
+        join: {
+          from: 'reviewChargeElements.id',
+          to: 'reviewChargeElementReturns.reviewChargeElementId'
+        }
+      },
       reviewChargeReference: {
         relation: Model.BelongsToOneRelation,
         modelClass: 'review-charge-reference.model',
@@ -34,14 +50,6 @@ class ReviewChargeElementModel extends BaseModel {
             to: 'reviewChargeElementReturns.reviewReturnId'
           },
           to: 'reviewReturns.id'
-        }
-      },
-      chargeElement: {
-        relation: Model.BelongsToOneRelation,
-        modelClass: 'charge-element.model',
-        join: {
-          from: 'reviewChargeElements.chargeElementId',
-          to: 'chargeElements.id'
         }
       }
     }

--- a/app/models/review-return.model.js
+++ b/app/models/review-return.model.js
@@ -41,6 +41,14 @@ class ReviewReturnModel extends BaseModel {
           to: 'reviewChargeElements.id'
         }
       },
+      reviewChargeElementReturns: {
+        relation: Model.HasManyRelation,
+        modelClass: 'review-charge-element-return.model',
+        join: {
+          from: 'reviewReturns.id',
+          to: 'reviewChargeElementReturns.reviewReturnId'
+        }
+      },
       reviewLicence: {
         relation: Model.BelongsToOneRelation,
         modelClass: 'review-licence.model',

--- a/test/models/bill-licence.model.test.js
+++ b/test/models/bill-licence.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -28,15 +28,12 @@ describe('Bill Licence model', () => {
   before(async () => {
     // Link bills
     testBill = await BillHelper.add()
-    const { id: billId } = testBill
 
     // Linking licences
     testLicence = await LicenceHelper.add()
 
-    const { id: licenceId } = testLicence
-
     // Test record
-    testRecord = await BillLicenceHelper.add({ billId, licenceId })
+    testRecord = await BillLicenceHelper.add({ billId: testBill.id, licenceId: testLicence.id })
     const { id } = testRecord
 
     // Link transactions
@@ -46,6 +43,17 @@ describe('Bill Licence model', () => {
 
       testTransactions.push(transaction)
     }
+  })
+
+  after(async () => {
+    await testBill.$query().delete()
+    await testLicence.$query().delete()
+
+    for (const transaction of testTransactions) {
+      await transaction.$query().delete()
+    }
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/bill-run-charge-version-year.model.test.js
+++ b/test/models/bill-run-charge-version-year.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -25,14 +25,22 @@ describe('Bill Run Charge Version Year model', () => {
   before(async () => {
     // Link bill runs
     testBillRun = await BillRunHelper.add()
-    const { id: billRunId } = testBillRun
 
     // Link charge versions
     testChargeVersion = await ChargeVersionHelper.add()
-    const { id: chargeVersionId } = testChargeVersion
 
     // Test record
-    testRecord = await BillRunChargeVersionYearHelper.add({ billRunId, chargeVersionId })
+    testRecord = await BillRunChargeVersionYearHelper.add({
+      billRunId: testBillRun.id,
+      chargeVersionId: testChargeVersion.id
+    })
+  })
+
+  after(async () => {
+    await testBillRun.$query().delete()
+    await testChargeVersion.$query().delete()
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/bill-run-volume.model.test.js
+++ b/test/models/bill-run-volume.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -25,14 +25,23 @@ describe('Bill Run Volume model', () => {
   before(async () => {
     // Link bill runs
     testBillRun = await BillRunHelper.add()
-    const { id: billRunId } = testBillRun
 
     // Link charge references
     testChargeReference = await ChargeReferenceHelper.add()
-    const { id: chargeReferenceId } = testChargeReference
 
     // Test record
-    testRecord = await BillRunVolumeHelper.add({ billRunId, chargeReferenceId, twoPartTariffStatus: 90 })
+    testRecord = await BillRunVolumeHelper.add({
+      billRunId: testBillRun.id,
+      chargeReferenceId: testChargeReference.id,
+      twoPartTariffStatus: 90
+    })
+  })
+
+  after(async () => {
+    await testBillRun.$query().delete()
+    await testChargeReference.$query().delete()
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/bill-run.model.test.js
+++ b/test/models/bill-run.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -31,16 +31,14 @@ describe('Bill Run model', () => {
   before(async () => {
     // Link regions
     testRegion = RegionHelper.select()
-    const { id: regionId } = testRegion
 
     // Test record
-    testRecord = await BillRunHelper.add({ regionId })
-    const { id } = testRecord
+    testRecord = await BillRunHelper.add({ regionId: testRegion.id })
 
     // Link bills
     testBills = []
     for (let i = 0; i < 2; i++) {
-      const bill = await BillHelper.add({ financialYearEnding: 2023, billRunId: id })
+      const bill = await BillHelper.add({ financialYearEnding: 2023, billRunId: testRecord.id })
 
       testBills.push(bill)
     }
@@ -48,7 +46,7 @@ describe('Bill Run model', () => {
     // Link to bill run volumes
     testBillRunVolumes = []
     for (let i = 0; i < 2; i++) {
-      const billRunVolume = await BillRunVolumeHelper.add({ billRunId: id })
+      const billRunVolume = await BillRunVolumeHelper.add({ billRunId: testRecord.id })
 
       testBillRunVolumes.push(billRunVolume)
     }
@@ -56,10 +54,26 @@ describe('Bill Run model', () => {
     // Link to review licences
     testReviewLicences = []
     for (let i = 0; i < 2; i++) {
-      const reviewLicence = await ReviewLicenceHelper.add({ billRunId: id })
+      const reviewLicence = await ReviewLicenceHelper.add({ billRunId: testRecord.id })
 
       testReviewLicences.push(reviewLicence)
     }
+  })
+
+  after(async () => {
+    for (const bill of testBills) {
+      await bill.$query().delete()
+    }
+
+    for (const billRunVolume of testBillRunVolumes) {
+      await billRunVolume.$query().delete()
+    }
+
+    for (const reviewLicence of testReviewLicences) {
+      await reviewLicence.$query().delete()
+    }
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/bill.model.test.js
+++ b/test/models/bill.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -28,14 +28,12 @@ describe('Bill model', () => {
   before(async () => {
     // Link bill runs
     testBillRun = await BillRunHelper.add()
-    const { id: billRunId } = testBillRun
 
     // Link billing accounts
     testBillingAccount = await BillingAccountHelper.add()
-    const { id: billingAccountId } = testBillingAccount
 
     // Test record
-    testRecord = await BillHelper.add({ billingAccountId, billRunId })
+    testRecord = await BillHelper.add({ billingAccountId: testBillingAccount.id, billRunId: testBillRun.id })
     const { id } = testRecord
 
     // Link bill licences
@@ -45,6 +43,17 @@ describe('Bill model', () => {
 
       testBillLicences.push(billLicence)
     }
+  })
+
+  after(async () => {
+    await testBillRun.$query().delete()
+    await testBillingAccount.$query().delete()
+
+    for (const billLicence of testBillLicences) {
+      await billLicence.$query().delete()
+    }
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/billing-account-address.model.test.js
+++ b/test/models/billing-account-address.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -31,22 +31,32 @@ describe('Billing Account Address model', () => {
   before(async () => {
     // Link contact
     testContact = await ContactHelper.add()
-    const { id: contactId } = testContact
 
     // Link billing account
     testBillingAccount = await BillingAccountHelper.add()
-    const { id: billingAccountId } = testBillingAccount
 
     // Link company
     testCompany = await CompanyHelper.add()
-    const { id: companyId } = testCompany
 
     // Link address
     testAddress = await AddressHelper.add()
-    const { id: addressId } = testAddress
 
     // Test record
-    testRecord = await BillingAccountAddressHelper.add({ addressId, companyId, billingAccountId, contactId })
+    testRecord = await BillingAccountAddressHelper.add({
+      addressId: testAddress.id,
+      companyId: testCompany.id,
+      billingAccountId: testBillingAccount.id,
+      contactId: testContact.id
+    })
+  })
+
+  after(async () => {
+    await testContact.$query().delete()
+    await testBillingAccount.$query().delete()
+    await testCompany.$query().delete()
+    await testAddress.$query().delete()
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/billing-account.model.test.js
+++ b/test/models/billing-account.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -63,6 +63,24 @@ describe('Billing Account model', () => {
 
       testChargeVersions.push(chargeVersion)
     }
+  })
+
+  after(async () => {
+    await testCompany.$query().delete()
+
+    for (const billingAccountAddress of testBillingAccountAddresses) {
+      await billingAccountAddress.$query().delete()
+    }
+
+    for (const bill of testBills) {
+      await bill.$query().delete()
+    }
+
+    for (const chargeVersion of testChargeVersions) {
+      await chargeVersion.$query().delete()
+    }
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/change-reason.model.test.js
+++ b/test/models/change-reason.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -23,14 +23,19 @@ describe('Change Reason model', () => {
 
   before(async () => {
     testRecord = ChangeReasonHelper.select(CHANGE_REASON_SUCCESSION_REMAINDER_INDEX)
-    const { id } = testRecord
 
     // Link charge versions
     testChargeVersions = []
     for (let i = 0; i < 2; i++) {
-      const chargeVersion = await ChargeVersionHelper.add({ changeReasonId: id })
+      const chargeVersion = await ChargeVersionHelper.add({ changeReasonId: testRecord.id })
 
       testChargeVersions.push(chargeVersion)
+    }
+  })
+
+  after(async () => {
+    for (const chargeVersion of testChargeVersions) {
+      await chargeVersion.$query().delete()
     }
   })
 

--- a/test/models/charge-category.model.test.js
+++ b/test/models/charge-category.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -21,14 +21,22 @@ describe('Charge Category model', () => {
 
   before(async () => {
     testRecord = ChargeCategoryHelper.select()
-    const { id } = testRecord
 
     // Link charge references
     testChargeReferences = []
     for (let i = 0; i < 2; i++) {
-      const chargeReference = await ChargeReferenceHelper.add({ description: `CE ${i}`, chargeCategoryId: id })
+      const chargeReference = await ChargeReferenceHelper.add({
+        description: `CE ${i}`,
+        chargeCategoryId: testRecord.id
+      })
 
       testChargeReferences.push(chargeReference)
+    }
+  })
+
+  after(async () => {
+    for (const chargeReference of testChargeReferences) {
+      await chargeReference.$query().delete()
     }
   })
 

--- a/test/models/charge-element.model.test.js
+++ b/test/models/charge-element.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -28,14 +28,12 @@ describe('Charge Element model', () => {
   before(async () => {
     // Link charge reference
     testChargeReference = await ChargeReferenceHelper.add()
-    const { id: chargeReferenceId } = testChargeReference
 
     // Link purpose
     testPurpose = PurposeHelper.select()
-    const { id: purposeId } = testPurpose
 
     // Test record
-    testRecord = await ChargeElementHelper.add({ chargeReferenceId, purposeId })
+    testRecord = await ChargeElementHelper.add({ chargeReferenceId: testChargeReference.id, purposeId: testPurpose.id })
 
     // Link review charge elements
     testReviewChargeElements = []
@@ -44,6 +42,16 @@ describe('Charge Element model', () => {
 
       testReviewChargeElements.push(reviewChargeElement)
     }
+  })
+
+  after(async () => {
+    await testChargeReference.$query().delete()
+
+    for (const reviewChargeElement of testReviewChargeElements) {
+      await reviewChargeElement.$query().delete()
+    }
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/charge-reference.model.test.js
+++ b/test/models/charge-reference.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -40,18 +40,19 @@ describe('Charge Reference model', () => {
   before(async () => {
     // Link purpose
     testPurpose = PurposeHelper.select()
-    const { id: purposeId } = testPurpose
 
     // Link charge version
     testChargeVersion = await ChargeVersionHelper.add()
-    const { id: chargeVersionId } = testChargeVersion
 
     // Link charge category
     testChargeCategory = ChargeCategoryHelper.select()
-    const { id: chargeCategoryId } = testChargeCategory
 
     // Test record
-    testRecord = await ChargeReferenceHelper.add({ chargeCategoryId, chargeVersionId, purposeId })
+    testRecord = await ChargeReferenceHelper.add({
+      chargeCategoryId: testChargeCategory.id,
+      chargeVersionId: testChargeVersion.id,
+      purposeId: testPurpose.id
+    })
     const { id } = testRecord
 
     // Link bill run volumes
@@ -85,6 +86,28 @@ describe('Charge Reference model', () => {
 
       testTransactions.push(transaction)
     }
+  })
+
+  after(async () => {
+    await testChargeVersion.$query().delete()
+
+    for (const billRunVolume of testBillRunVolumes) {
+      await billRunVolume.$query().delete()
+    }
+
+    for (const chargeElement of testChargeElements) {
+      await chargeElement.$query().delete()
+    }
+
+    for (const reviewChargeReference of testReviewChargeReferences) {
+      await reviewChargeReference.$query().delete()
+    }
+
+    for (const transaction of testTransactions) {
+      await transaction.$query().delete()
+    }
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/charge-version-note.model.test.js
+++ b/test/models/charge-version-note.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -28,6 +28,12 @@ describe('Charge Version Note model', () => {
     testUser = UserHelper.select()
     testRecord = await ChargeVersionNoteHelper.add({ userId: testUser.userId })
     testChargeVersion = await ChargeVersionHelper.add({ noteId: testRecord.id })
+  })
+
+  after(async () => {
+    await testChargeVersion.$query().delete()
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/charge-version.model.test.js
+++ b/test/models/charge-version.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, after, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -19,7 +19,6 @@ const ChargeReferenceModel = require('../../app/models/charge-reference.model.js
 const ChargeVersionHelper = require('../support/helpers/charge-version.helper.js')
 const ChargeVersionNoteHelper = require('../support/helpers/charge-version-note.helper.js')
 const ChargeVersionNoteModel = require('../../app/models/charge-version-note.model.js')
-const { generateRandomInteger } = require('../../app/lib/general.lib.js')
 const LicenceHelper = require('../support/helpers/licence.helper.js')
 const LicenceModel = require('../../app/models/licence.model.js')
 const ModLogHelper = require('../support/helpers/mod-log.helper.js')
@@ -27,6 +26,7 @@ const ModLogModel = require('../../app/models/mod-log.model.js')
 const ReviewChargeVersionHelper = require('../support/helpers/review-charge-version.helper.js')
 const ReviewChargeVersionModel = require('../../app/models/review-charge-version.model.js')
 const UserHelper = require('../support/helpers/user.helper.js')
+const { generateRandomInteger } = require('../../app/lib/general.lib.js')
 
 const CHANGE_REASON_NEW_LICENCE_PART_INDEX = 10
 
@@ -34,7 +34,6 @@ const CHANGE_REASON_NEW_LICENCE_PART_INDEX = 10
 const ChargeVersionModel = require('../../app/models/charge-version.model.js')
 
 describe('Charge Version model', () => {
-  let chargeVersionId
   let testBillingAccount
   let testBillRunChargeVersionYears
   let testChangeReason
@@ -49,22 +48,23 @@ describe('Charge Version model', () => {
   before(async () => {
     // Link billing account
     testBillingAccount = await BillingAccountHelper.add()
-    const { id: billingAccountId } = testBillingAccount
 
     // Link change reason
     testChangeReason = ChangeReasonHelper.select(CHANGE_REASON_NEW_LICENCE_PART_INDEX)
-    const { id: changeReasonId } = testChangeReason
 
     // Link charge version note
     testNote = await ChargeVersionNoteHelper.add()
-    const { id: noteId } = testNote
 
     // Link licence
     testLicence = await LicenceHelper.add()
-    const { id: licenceId } = testLicence
 
     // Test record
-    testRecord = await ChargeVersionHelper.add({ billingAccountId, changeReasonId, noteId, licenceId })
+    testRecord = await ChargeVersionHelper.add({
+      billingAccountId: testBillingAccount.id,
+      changeReasonId: testChangeReason.id,
+      noteId: testNote.id,
+      licenceId: testLicence.id
+    })
 
     // Link bill run charge version years
     testBillRunChargeVersionYears = []
@@ -100,6 +100,31 @@ describe('Charge Version model', () => {
 
       testReviewChargeVersions.push(reviewChargeVersion)
     }
+  })
+
+  after(async () => {
+    for (const billRunChargeVersionYear of testBillRunChargeVersionYears) {
+      await billRunChargeVersionYear.$query().delete()
+    }
+
+    for (const chargeReference of testChargeReferences) {
+      await chargeReference.$query().delete()
+    }
+
+    for (const modLog of testModLogs) {
+      await modLog.$query().delete()
+    }
+
+    for (const reviewChargeVersion of testReviewChargeVersions) {
+      await reviewChargeVersion.$query().delete()
+    }
+
+    // NOTE: Must delete parent record before child records
+    await testRecord.$query().delete()
+
+    await testBillingAccount.$query().delete()
+    await testNote.$query().delete()
+    await testLicence.$query().delete()
   })
 
   describe('Basic query', () => {
@@ -268,21 +293,36 @@ describe('Charge Version model', () => {
   })
 
   describe('$createdAt', () => {
-    beforeEach(async () => {
-      const { id } = await ChargeVersionHelper.add()
+    let fetchedRecord
+    let createdAtTestRecord
+    let createdAtModLogs
 
-      chargeVersionId = id
+    beforeEach(async () => {
+      createdAtTestRecord = await ChargeVersionHelper.add()
+
+      createdAtModLogs = []
+    })
+
+    afterEach(async () => {
+      for (const modLog of createdAtModLogs) {
+        await modLog.$query().delete()
+      }
+
+      await createdAtTestRecord.$query().delete()
     })
 
     describe('when the charge version has no mod log history', () => {
       beforeEach(async () => {
-        testRecord = await ChargeVersionModel.query().select(['licenceId']).findById(chargeVersionId).modify('history')
+        fetchedRecord = await ChargeVersionModel.query()
+          .select(['licenceId'])
+          .findById(createdAtTestRecord.id)
+          .modify('history')
       })
 
       it('returns the charge version "created at" time stamp', () => {
-        const result = testRecord.$createdAt()
+        const result = fetchedRecord.$createdAt()
 
-        expect(result).to.equal(testRecord.createdAt)
+        expect(result).to.equal(fetchedRecord.createdAt)
       })
     })
 
@@ -291,22 +331,26 @@ describe('Charge Version model', () => {
         const regionCode = generateRandomInteger(1, 9)
         const firstNaldId = generateRandomInteger(100, 99998)
 
-        await ModLogHelper.add({
-          externalId: `${regionCode}:${firstNaldId}`,
-          naldDate: new Date('2012-06-01'),
-          chargeVersionId
-        })
-        await ModLogHelper.add({
-          externalId: `${regionCode}:${firstNaldId + 1}`,
-          naldDate: new Date('2012-06-02'),
-          chargeVersionId
-        })
+        createdAtModLogs.push(
+          await ModLogHelper.add({
+            externalId: `${regionCode}:${firstNaldId}`,
+            naldDate: new Date('2012-06-01'),
+            chargeVersionId: createdAtTestRecord.id
+          })
+        )
+        createdAtModLogs.push(
+          await ModLogHelper.add({
+            externalId: `${regionCode}:${firstNaldId + 1}`,
+            naldDate: new Date('2012-06-02'),
+            chargeVersionId: createdAtTestRecord.id
+          })
+        )
 
-        testRecord = await ChargeVersionModel.query().findById(chargeVersionId).modify('history')
+        fetchedRecord = await ChargeVersionModel.query().findById(createdAtTestRecord.id).modify('history')
       })
 
       it('returns the first mod log NALD date', () => {
-        const result = testRecord.$createdAt()
+        const result = fetchedRecord.$createdAt()
 
         expect(result).to.equal(new Date('2012-06-01'))
       })
@@ -314,25 +358,39 @@ describe('Charge Version model', () => {
   })
 
   describe('$createdBy', () => {
+    let fetchedRecord
+    let createdByModLogs
+    let createdByTestRecord
+
+    beforeEach(() => {
+      createdByModLogs = []
+    })
+
+    afterEach(async () => {
+      for (const modLog of createdByModLogs) {
+        await modLog.$query().delete()
+      }
+
+      await createdByTestRecord.$query().delete()
+    })
+
     describe('when the charge version was created in WRLS', () => {
       beforeEach(async () => {
         testUser = UserHelper.select()
 
-        const { id } = await ChargeVersionHelper.add({
+        createdByTestRecord = await ChargeVersionHelper.add({
           source: 'wrls',
           createdBy: { id: testUser.id, email: testUser.username }
         })
-
-        chargeVersionId = id
       })
 
       describe('and it has no mod log history', () => {
         beforeEach(async () => {
-          testRecord = await ChargeVersionModel.query().findById(chargeVersionId).modify('history')
+          fetchedRecord = await ChargeVersionModel.query().findById(createdByTestRecord.id).modify('history')
         })
 
         it('returns the WRLS user name', () => {
-          const result = testRecord.$createdBy()
+          const result = fetchedRecord.$createdBy()
 
           expect(result).to.equal(testUser.username)
         })
@@ -340,13 +398,13 @@ describe('Charge Version model', () => {
 
       describe('though it has mod log history', () => {
         beforeEach(async () => {
-          await ModLogHelper.add({ chargeVersionId })
+          createdByModLogs.push(await ModLogHelper.add({ chargeVersionId: createdByTestRecord.id }))
 
-          testRecord = await ChargeVersionModel.query().findById(chargeVersionId).modify('history')
+          fetchedRecord = await ChargeVersionModel.query().findById(createdByTestRecord.id).modify('history')
         })
 
         it('still returns the WRLS user name', () => {
-          const result = testRecord.$createdBy()
+          const result = fetchedRecord.$createdBy()
 
           expect(result).to.equal(testUser.username)
         })
@@ -355,18 +413,16 @@ describe('Charge Version model', () => {
 
     describe('when the charge version was created in NALD', () => {
       beforeEach(async () => {
-        const { id } = await ChargeVersionHelper.add({ source: 'nald' })
-
-        chargeVersionId = id
+        createdByTestRecord = await ChargeVersionHelper.add({ source: 'nald' })
       })
 
       describe('and has no mod log history', () => {
         beforeEach(async () => {
-          testRecord = await ChargeVersionModel.query().findById(chargeVersionId).modify('history')
+          fetchedRecord = await ChargeVersionModel.query().findById(createdByTestRecord.id).modify('history')
         })
 
         it('returns null', () => {
-          const result = testRecord.$createdBy()
+          const result = fetchedRecord.$createdBy()
 
           expect(result).to.be.null()
         })
@@ -377,14 +433,26 @@ describe('Charge Version model', () => {
           const regionCode = generateRandomInteger(1, 9)
           const firstNaldId = generateRandomInteger(100, 99998)
 
-          await ModLogHelper.add({ externalId: `${regionCode}:${firstNaldId}`, chargeVersionId, userId: 'FIRST' })
-          await ModLogHelper.add({ externalId: `${regionCode}:${firstNaldId + 1}`, chargeVersionId, userId: 'SECOND' })
+          createdByModLogs.push(
+            await ModLogHelper.add({
+              externalId: `${regionCode}:${firstNaldId}`,
+              chargeVersionId: createdByTestRecord.id,
+              userId: 'FIRST'
+            })
+          )
+          createdByModLogs.push(
+            await ModLogHelper.add({
+              externalId: `${regionCode}:${firstNaldId + 1}`,
+              chargeVersionId: createdByTestRecord.id,
+              userId: 'SECOND'
+            })
+          )
 
-          testRecord = await ChargeVersionModel.query().findById(chargeVersionId).modify('history')
+          fetchedRecord = await ChargeVersionModel.query().findById(createdByTestRecord.id).modify('history')
         })
 
         it('returns the first mod log NALD user ID', () => {
-          const result = testRecord.$createdBy()
+          const result = fetchedRecord.$createdBy()
 
           expect(result).to.equal('FIRST')
         })
@@ -393,16 +461,37 @@ describe('Charge Version model', () => {
   })
 
   describe('$notes', () => {
+    let fetchedRecord
+    let notesChargeVersionNote
+    let notesModLogs
+    let notesTestRecord
+
+    beforeEach(() => {
+      notesModLogs = []
+    })
+
+    afterEach(async () => {
+      if (notesChargeVersionNote) {
+        await notesChargeVersionNote.$query().delete()
+      }
+
+      for (const modLog of notesModLogs) {
+        await modLog.$query().delete()
+      }
+
+      await notesTestRecord.$query().delete()
+    })
+
     describe('when the charge version was created in WRLS', () => {
       describe('but no note was added', () => {
         beforeEach(async () => {
-          const { id } = await ChargeVersionHelper.add({ source: 'wrls' })
+          notesTestRecord = await ChargeVersionHelper.add({ source: 'wrls' })
 
-          testRecord = await ChargeVersionModel.query().findById(id).modify('history')
+          fetchedRecord = await ChargeVersionModel.query().findById(notesTestRecord.id).modify('history')
         })
 
         it('returns an empty array', () => {
-          const result = testRecord.$notes()
+          const result = fetchedRecord.$notes()
 
           expect(result).to.be.an.array()
           expect(result).to.be.empty()
@@ -411,14 +500,14 @@ describe('Charge Version model', () => {
 
       describe('and a note was added', () => {
         beforeEach(async () => {
-          const { id: noteId } = await ChargeVersionNoteHelper.add({ note: 'Top site bore hole' })
-          const { id } = await ChargeVersionHelper.add({ noteId, source: 'nald' })
+          notesChargeVersionNote = await ChargeVersionNoteHelper.add({ note: 'Top site bore hole' })
+          notesTestRecord = await ChargeVersionHelper.add({ noteId: notesChargeVersionNote.id, source: 'nald' })
 
-          testRecord = await ChargeVersionModel.query().findById(id).modify('history')
+          fetchedRecord = await ChargeVersionModel.query().findById(notesTestRecord.id).modify('history')
         })
 
         it('returns an array containing just the single note', () => {
-          const result = testRecord.$notes()
+          const result = fetchedRecord.$notes()
 
           expect(result).to.equal(['Top site bore hole'])
         })
@@ -427,18 +516,16 @@ describe('Charge Version model', () => {
 
     describe('when the charge version was created in NALD', () => {
       beforeEach(async () => {
-        const { id } = await ChargeVersionHelper.add({ source: 'nald' })
-
-        chargeVersionId = id
+        notesTestRecord = await ChargeVersionHelper.add({ source: 'nald' })
       })
 
       describe('and has no mod log history', () => {
         beforeEach(async () => {
-          testRecord = await ChargeVersionModel.query().findById(chargeVersionId).modify('history')
+          fetchedRecord = await ChargeVersionModel.query().findById(notesTestRecord.id).modify('history')
         })
 
         it('returns an empty array', () => {
-          const result = testRecord.$notes()
+          const result = fetchedRecord.$notes()
 
           expect(result).to.be.an.array()
           expect(result).to.be.empty()
@@ -451,22 +538,26 @@ describe('Charge Version model', () => {
             const regionCode = generateRandomInteger(1, 9)
             const firstNaldId = generateRandomInteger(100, 99998)
 
-            await ModLogHelper.add({
-              externalId: `${regionCode}:${firstNaldId}`,
-              note: null,
-              chargeVersionId
-            })
-            await ModLogHelper.add({
-              externalId: `${regionCode}:${firstNaldId + 1}`,
-              note: null,
-              chargeVersionId
-            })
+            notesModLogs.push(
+              await ModLogHelper.add({
+                externalId: `${regionCode}:${firstNaldId}`,
+                note: null,
+                chargeVersionId: notesTestRecord.id
+              })
+            )
+            notesModLogs.push(
+              await ModLogHelper.add({
+                externalId: `${regionCode}:${firstNaldId + 1}`,
+                note: null,
+                chargeVersionId: notesTestRecord.id
+              })
+            )
 
-            testRecord = await ChargeVersionModel.query().findById(chargeVersionId).modify('history')
+            fetchedRecord = await ChargeVersionModel.query().findById(notesTestRecord.id).modify('history')
           })
 
           it('returns an empty array', () => {
-            const result = testRecord.$notes()
+            const result = fetchedRecord.$notes()
 
             expect(result).to.be.an.array()
             expect(result).to.be.empty()
@@ -478,22 +569,26 @@ describe('Charge Version model', () => {
             const regionCode = generateRandomInteger(1, 9)
             const firstNaldId = generateRandomInteger(100, 99998)
 
-            await ModLogHelper.add({
-              externalId: `${regionCode}:${firstNaldId}`,
-              note: null,
-              chargeVersionId
-            })
-            await ModLogHelper.add({
-              externalId: `${regionCode}:${firstNaldId + 1}`,
-              note: 'Transfer per app 12-DEF',
-              chargeVersionId
-            })
+            notesModLogs.push(
+              await ModLogHelper.add({
+                externalId: `${regionCode}:${firstNaldId}`,
+                note: null,
+                chargeVersionId: notesTestRecord.id
+              })
+            )
+            notesModLogs.push(
+              await ModLogHelper.add({
+                externalId: `${regionCode}:${firstNaldId + 1}`,
+                note: 'Transfer per app 12-DEF',
+                chargeVersionId: notesTestRecord.id
+              })
+            )
 
-            testRecord = await ChargeVersionModel.query().findById(chargeVersionId).modify('history')
+            fetchedRecord = await ChargeVersionModel.query().findById(notesTestRecord.id).modify('history')
           })
 
           it('returns an array containing just the notes from the mod logs with them', () => {
-            const result = testRecord.$notes()
+            const result = fetchedRecord.$notes()
 
             expect(result).to.equal(['Transfer per app 12-DEF'])
           })
@@ -503,15 +598,31 @@ describe('Charge Version model', () => {
   })
 
   describe('$reason', () => {
+    let fetchedRecord
+    let reasonModLogs
+    let reasonTestRecord
+
+    beforeEach(() => {
+      reasonModLogs = []
+    })
+
+    afterEach(async () => {
+      for (const modLog of reasonModLogs) {
+        await modLog.$query().delete()
+      }
+
+      await reasonTestRecord.$query().delete()
+    })
+
     describe('when the charge version was created in WRLS', () => {
       beforeEach(async () => {
-        const { id } = await ChargeVersionHelper.add({ changeReasonId: testChangeReason.id, source: 'wrls' })
+        reasonTestRecord = await ChargeVersionHelper.add({ changeReasonId: testChangeReason.id, source: 'wrls' })
 
-        testRecord = await ChargeVersionModel.query().findById(id).modify('history')
+        fetchedRecord = await ChargeVersionModel.query().findById(reasonTestRecord.id).modify('history')
       })
 
       it('returns the charge version reason', () => {
-        const result = testRecord.$reason()
+        const result = fetchedRecord.$reason()
 
         expect(result).to.equal(testChangeReason.description)
       })
@@ -519,18 +630,16 @@ describe('Charge Version model', () => {
 
     describe('when the charge version was created in NALD', () => {
       beforeEach(async () => {
-        const { id } = await ChargeVersionHelper.add({ source: 'nald' })
-
-        chargeVersionId = id
+        reasonTestRecord = await ChargeVersionHelper.add({ source: 'nald' })
       })
 
       describe('and has no mod log history', () => {
         beforeEach(async () => {
-          testRecord = await ChargeVersionModel.query().findById(chargeVersionId).modify('history')
+          fetchedRecord = await ChargeVersionModel.query().findById(reasonTestRecord.id).modify('history')
         })
 
         it('returns null', () => {
-          const result = testRecord.$reason()
+          const result = fetchedRecord.$reason()
 
           expect(result).to.be.null()
         })
@@ -542,22 +651,26 @@ describe('Charge Version model', () => {
             const regionCode = generateRandomInteger(1, 9)
             const firstNaldId = generateRandomInteger(100, 99998)
 
-            await ModLogHelper.add({
-              externalId: `${regionCode}:${firstNaldId}`,
-              reasonDescription: null,
-              chargeVersionId
-            })
-            await ModLogHelper.add({
-              externalId: `${regionCode}:${firstNaldId + 1}`,
-              reasonDescription: 'Transferred',
-              chargeVersionId
-            })
+            reasonModLogs.push(
+              await ModLogHelper.add({
+                externalId: `${regionCode}:${firstNaldId}`,
+                reasonDescription: null,
+                chargeVersionId: reasonTestRecord.id
+              })
+            )
+            reasonModLogs.push(
+              await ModLogHelper.add({
+                externalId: `${regionCode}:${firstNaldId + 1}`,
+                reasonDescription: 'Transferred',
+                chargeVersionId: reasonTestRecord.id
+              })
+            )
 
-            testRecord = await ChargeVersionModel.query().findById(chargeVersionId).modify('history')
+            fetchedRecord = await ChargeVersionModel.query().findById(reasonTestRecord.id).modify('history')
           })
 
           it('returns null', () => {
-            const result = testRecord.$reason()
+            const result = fetchedRecord.$reason()
 
             expect(result).to.be.null()
           })
@@ -569,22 +682,26 @@ describe('Charge Version model', () => {
           const regionCode = generateRandomInteger(1, 9)
           const firstNaldId = generateRandomInteger(100, 99998)
 
-          await ModLogHelper.add({
-            externalId: `${regionCode}:${firstNaldId}`,
-            reasonDescription: 'Formal Variation',
-            chargeVersionId
-          })
-          await ModLogHelper.add({
-            externalId: `${regionCode}:${firstNaldId + 1}`,
-            reasonDescription: 'Transferred',
-            chargeVersionId
-          })
+          reasonModLogs.push(
+            await ModLogHelper.add({
+              externalId: `${regionCode}:${firstNaldId}`,
+              reasonDescription: 'Formal Variation',
+              chargeVersionId: reasonTestRecord.id
+            })
+          )
+          reasonModLogs.push(
+            await ModLogHelper.add({
+              externalId: `${regionCode}:${firstNaldId + 1}`,
+              reasonDescription: 'Transferred',
+              chargeVersionId: reasonTestRecord.id
+            })
+          )
 
-          testRecord = await ChargeVersionModel.query().findById(chargeVersionId).modify('history')
+          fetchedRecord = await ChargeVersionModel.query().findById(reasonTestRecord.id).modify('history')
         })
 
         it('returns the NALD reason description', () => {
-          const result = testRecord.$reason()
+          const result = fetchedRecord.$reason()
 
           expect(result).to.equal('Formal Variation')
         })

--- a/test/models/company-address.model.test.js
+++ b/test/models/company-address.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -28,18 +28,26 @@ describe('Company Address model', () => {
   before(async () => {
     // Link licence role
     testLicenceRole = await LicenceRoleHelper.select()
-    const { id: licenceRoleId } = testLicenceRole
 
     // Link company
     testCompany = await CompanyHelper.add()
-    const { id: companyId } = testCompany
 
     // Link address
     testAddress = await AddressHelper.add()
-    const { id: addressId } = testAddress
 
     // Test record
-    testRecord = await CompanyAddressHelper.add({ addressId, companyId, licenceRoleId })
+    testRecord = await CompanyAddressHelper.add({
+      addressId: testAddress.id,
+      companyId: testCompany.id,
+      licenceRoleId: testLicenceRole.id
+    })
+  })
+
+  after(async () => {
+    await testCompany.$query().delete()
+    await testAddress.$query().delete()
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/company-contact.model.test.js
+++ b/test/models/company-contact.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, before, after, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -33,26 +33,34 @@ describe('Company Contacts model', () => {
   before(async () => {
     // Link licence role
     testLicenceRole = await LicenceRoleHelper.select()
-    const { id: licenceRoleId } = testLicenceRole
 
     // Link contact
     testContact = await ContactHelper.add()
-    const { id: contactId } = testContact
 
     // Link company
     testCompany = await CompanyHelper.add()
-    const { id: companyId } = testCompany
 
     // Link to user for createdBy
     testCreatedByUser = await UserHelper.select(0)
-    const { id: createdBy } = testCreatedByUser
 
     // Link to user for updatedBy
     testUpdatedByUser = await UserHelper.select(1)
-    const { id: updatedBy } = testUpdatedByUser
 
     // Test record
-    testRecord = await CompanyContactHelper.add({ companyId, contactId, createdBy, licenceRoleId, updatedBy })
+    testRecord = await CompanyContactHelper.add({
+      companyId: testCompany.id,
+      contactId: testContact.id,
+      createdBy: testCreatedByUser.id,
+      licenceRoleId: testLicenceRole.id,
+      updatedBy: testUpdatedByUser.id
+    })
+  })
+
+  after(async () => {
+    await testCompany.$query().delete()
+    await testContact.$query().delete()
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {
@@ -161,37 +169,47 @@ describe('Company Contacts model', () => {
   })
 
   describe('$abstractionAlertType', () => {
+    let abstractionAlertTypeTestRecord
+
+    afterEach(async () => {
+      await abstractionAlertTypeTestRecord.$query().delete()
+    })
+
     describe('when "abstractionAlerts" is disabled', () => {
+      beforeEach(async () => {
+        abstractionAlertTypeTestRecord = await CompanyContactHelper.add({ abstractionAlerts: false })
+      })
+
       it('returns "no"', () => {
-        const result = testRecord.$abstractionAlertType()
+        const result = abstractionAlertTypeTestRecord.$abstractionAlertType()
 
         expect(result).to.equal('no')
       })
     })
 
     describe('when "abstractionAlerts" is enabled', () => {
-      before(async () => {
-        testRecord = await CompanyContactHelper.add({ abstractionAlerts: true })
+      beforeEach(async () => {
+        abstractionAlertTypeTestRecord = await CompanyContactHelper.add({ abstractionAlerts: true })
       })
 
       describe('and "abstractionAlertLicences" is null', () => {
         it('returns "yes"', () => {
-          const result = testRecord.$abstractionAlertType()
+          const result = abstractionAlertTypeTestRecord.$abstractionAlertType()
 
           expect(result).to.equal('yes')
         })
       })
 
       describe('and "abstractionAlertLicences" is populated', () => {
-        before(async () => {
-          testRecord = await CompanyContactHelper.add({
+        beforeEach(async () => {
+          abstractionAlertTypeTestRecord = await CompanyContactHelper.add({
             abstractionAlertLicences: JSON.stringify([generateUUID()]),
             abstractionAlerts: true
           })
         })
 
         it('returns "some"', () => {
-          const result = testRecord.$abstractionAlertType()
+          const result = abstractionAlertTypeTestRecord.$abstractionAlertType()
 
           expect(result).to.equal('some')
         })

--- a/test/models/company.model.test.js
+++ b/test/models/company.model.test.js
@@ -42,7 +42,6 @@ describe('Company model', () => {
 
     // Test record
     testRecord = await CompanyHelper.add({ regionId: region.id })
-    const { id: companyId } = testRecord
 
     billingAccountAddresses = []
     billingAccounts = []
@@ -57,32 +56,32 @@ describe('Company model', () => {
       // NOTE: A constraint in the billing_account_addresses table means you cannot have 2 records with the same
       // billingAccountId and start date
       const startDate = i === 0 ? new Date(2023, 8, 4) : new Date(2023, 8, 3)
-      const billingAccountAddress = await BillingAccountAddressHelper.add({ startDate, companyId })
+      const billingAccountAddress = await BillingAccountAddressHelper.add({ startDate, companyId: testRecord.id })
 
       billingAccountAddresses.push(billingAccountAddress)
 
       // Link billing accounts
-      const billingAccount = await BillingAccountHelper.add({ companyId })
+      const billingAccount = await BillingAccountHelper.add({ companyId: testRecord.id })
 
       billingAccounts.push(billingAccount)
 
       // Link company addresses
-      const companyAddress = await CompanyAddressHelper.add({ companyId })
+      const companyAddress = await CompanyAddressHelper.add({ companyId: testRecord.id })
 
       companyAddresses.push(companyAddress)
 
       // Link company contacts
-      const companyContact = await CompanyContactHelper.add({ companyId })
+      const companyContact = await CompanyContactHelper.add({ companyId: testRecord.id })
 
       companyContacts.push(companyContact)
 
       // Link licence document roles
-      const licenceDocumentRole = await LicenceDocumentRoleHelper.add({ companyId })
+      const licenceDocumentRole = await LicenceDocumentRoleHelper.add({ companyId: testRecord.id })
 
       licenceDocumentRoles.push(licenceDocumentRole)
 
       // Link licence versions
-      const licenceVersion = await LicenceVersionHelper.add({ companyId })
+      const licenceVersion = await LicenceVersionHelper.add({ companyId: testRecord.id })
 
       licenceVersions.push(licenceVersion)
     }

--- a/test/models/contact.model.test.js
+++ b/test/models/contact.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -28,7 +28,6 @@ describe('Contact model', () => {
   before(async () => {
     // Test record
     testRecord = await ContactHelper.add()
-    const { id: contactId } = testRecord
 
     // Link billing account addresses
     testBillingAccountAddresses = []
@@ -36,7 +35,7 @@ describe('Contact model', () => {
       // NOTE: A constraint in the billing_account_addresses table means you cannot have 2 records with the same
       // billingAccountId and start date
       const startDate = i === 0 ? new Date(2023, 8, 4) : new Date(2023, 8, 3)
-      const billingAccountAddress = await BillingAccountAddressHelper.add({ startDate, contactId })
+      const billingAccountAddress = await BillingAccountAddressHelper.add({ startDate, contactId: testRecord.id })
 
       testBillingAccountAddresses.push(billingAccountAddress)
     }
@@ -44,7 +43,7 @@ describe('Contact model', () => {
     // Link company contacts
     testCompanyContacts = []
     for (let i = 0; i < 2; i++) {
-      const companyContact = await CompanyContactHelper.add({ contactId })
+      const companyContact = await CompanyContactHelper.add({ contactId: testRecord.id })
 
       testCompanyContacts.push(companyContact)
     }
@@ -52,10 +51,26 @@ describe('Contact model', () => {
     // Link licence document roles
     testLicenceDocumentRoles = []
     for (let i = 0; i < 2; i++) {
-      const licenceDocumentRole = await LicenceDocumentRoleHelper.add({ contactId })
+      const licenceDocumentRole = await LicenceDocumentRoleHelper.add({ contactId: testRecord.id })
 
       testLicenceDocumentRoles.push(licenceDocumentRole)
     }
+  })
+
+  after(async () => {
+    for (const billingAccountAddress of testBillingAccountAddresses) {
+      await billingAccountAddress.$query().delete()
+    }
+
+    for (const companyContact of testCompanyContacts) {
+      await companyContact.$query().delete()
+    }
+
+    for (const licenceDocumentRole of testLicenceDocumentRoles) {
+      await licenceDocumentRole.$query().delete()
+    }
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {
@@ -134,10 +149,10 @@ describe('Contact model', () => {
   // populated. We don't test what would happen if last name wasn't because analysis of the data confirms this would
   // never happen. See the method's documentation for more details.
   describe('$name', () => {
-    let contactRecord
+    let nameTestRecord
 
     beforeEach(() => {
-      contactRecord = {
+      nameTestRecord = ContactModel.fromJson({
         contactType: null,
         dataSource: null,
         department: null,
@@ -147,80 +162,80 @@ describe('Contact model', () => {
         middleInitials: null,
         salutation: null,
         suffix: null
-      }
+      })
     })
 
     describe('when the contact was imported in NALD', () => {
       beforeEach(() => {
-        contactRecord.dataSource = 'nald'
+        nameTestRecord.dataSource = 'nald'
       })
 
       describe('and has a last name of "Villar"', () => {
         beforeEach(() => {
-          contactRecord.lastName = 'Villar'
+          nameTestRecord.lastName = 'Villar'
         })
 
         it('returns "Villar"', () => {
-          testRecord = ContactModel.fromJson(contactRecord)
+          const result = nameTestRecord.$name()
 
-          expect(testRecord.$name()).to.equal('Villar')
+          expect(result).to.equal('Villar')
         })
 
         describe('and the salutation "Mrs"', () => {
           beforeEach(() => {
-            contactRecord.salutation = 'Mrs'
+            nameTestRecord.salutation = 'Mrs'
           })
 
           it('returns "Mrs Villar"', () => {
-            testRecord = ContactModel.fromJson(contactRecord)
+            const result = nameTestRecord.$name()
 
-            expect(testRecord.$name()).to.equal('Mrs Villar')
+            expect(result).to.equal('Mrs Villar')
           })
 
           describe('and the initial "J"', () => {
             beforeEach(() => {
-              contactRecord.initials = 'J'
+              nameTestRecord.initials = 'J'
             })
 
             it('returns "Mrs J Villar"', () => {
-              testRecord = ContactModel.fromJson(contactRecord)
+              const result = nameTestRecord.$name()
 
-              expect(testRecord.$name()).to.equal('Mrs J Villar')
+              expect(result).to.equal('Mrs J Villar')
             })
           })
         })
 
         describe('and a first name of "Margherita"', () => {
           beforeEach(() => {
-            contactRecord.firstName = 'Margherita'
+            nameTestRecord.firstName = 'Margherita'
           })
 
           it('returns "Margherita Villar"', () => {
-            testRecord = ContactModel.fromJson(contactRecord)
+            const result = nameTestRecord.$name()
 
-            expect(testRecord.$name()).to.equal('Margherita Villar')
+            expect(result).to.equal('Margherita Villar')
           })
 
           describe('and the salutation "Mrs"', () => {
             beforeEach(() => {
-              contactRecord.salutation = 'Mrs'
+              nameTestRecord.salutation = 'Mrs'
             })
 
             it('returns "Mrs Margherita Villar"', () => {
-              testRecord = ContactModel.fromJson(contactRecord)
+              const result = nameTestRecord.$name()
 
-              expect(testRecord.$name()).to.equal('Mrs Margherita Villar')
+              expect(result).to.equal('Mrs Margherita Villar')
             })
 
             describe('and the initial "J"', () => {
               beforeEach(() => {
-                contactRecord.initials = 'J'
+                nameTestRecord.initials = 'J'
               })
 
               it('returns "Mrs J Villar"', () => {
-                testRecord = ContactModel.fromJson(contactRecord)
+                const result = nameTestRecord.$name()
 
-                expect(testRecord.$name()).to.equal('Mrs J Villar')
+                expect(result).to.equal('Mrs J Villar')
               })
             })
           })
@@ -230,68 +245,68 @@ describe('Contact model', () => {
 
     describe('when the contact was entered into WRLS', () => {
       beforeEach(() => {
-        contactRecord.dataSource = 'wrls'
+        nameTestRecord.dataSource = 'wrls'
       })
 
       describe('and it is a department named "Humanoid Risk Assessment"', () => {
         beforeEach(() => {
-          contactRecord.contactType = 'department'
-          contactRecord.department = 'Humanoid Risk Assessment'
+          nameTestRecord.contactType = 'department'
+          nameTestRecord.department = 'Humanoid Risk Assessment'
         })
 
         it('returns "Humanoid Risk Assessment"', () => {
-          testRecord = ContactModel.fromJson(contactRecord)
+          const result = nameTestRecord.$name()
 
-          expect(testRecord.$name()).to.equal('Humanoid Risk Assessment')
+          expect(result).to.equal('Humanoid Risk Assessment')
         })
       })
 
       describe('and it is a "person"', () => {
         beforeEach(() => {
-          contactRecord.contactType = 'person'
-          contactRecord.firstName = 'Vincent'
-          contactRecord.lastName = 'Anderson'
+          nameTestRecord.contactType = 'person'
+          nameTestRecord.firstName = 'Vincent'
+          nameTestRecord.lastName = 'Anderson'
         })
 
         describe('with the name "Vincent Anderson"', () => {
           it('returns "Vincent Anderson"', () => {
-            testRecord = ContactModel.fromJson(contactRecord)
+            const result = nameTestRecord.$name()
 
-            expect(testRecord.$name()).to.equal('Vincent Anderson')
+            expect(result).to.equal('Vincent Anderson')
           })
         })
 
         describe('and the salutation "Mr"', () => {
           beforeEach(() => {
-            contactRecord.salutation = 'Mr'
+            nameTestRecord.salutation = 'Mr'
           })
 
           it('returns "Mr Vincent Anderson"', () => {
-            testRecord = ContactModel.fromJson(contactRecord)
+            const result = nameTestRecord.$name()
 
-            expect(testRecord.$name()).to.equal('Mr Vincent Anderson')
+            expect(result).to.equal('Mr Vincent Anderson')
           })
 
           describe('and the middle initial "P"', () => {
             beforeEach(() => {
-              contactRecord.middleInitials = 'P'
+              nameTestRecord.middleInitials = 'P'
             })
 
-            it('returns Mr V P Anderson', () => {
-              testRecord = ContactModel.fromJson(contactRecord)
+            it('returns "Mr V P Anderson"', () => {
+              const result = nameTestRecord.$name()
 
-              expect(testRecord.$name()).to.equal('Mr V P Anderson')
+              expect(result).to.equal('Mr V P Anderson')
             })
 
             describe('and the suffix "MBE"', () => {
               beforeEach(() => {
-                contactRecord.suffix = 'MBE'
+                nameTestRecord.suffix = 'MBE'
               })
 
               it('returns "Mr V P Anderson MBE"', () => {
-                testRecord = ContactModel.fromJson(contactRecord)
+                const result = nameTestRecord.$name()
 
-                expect(testRecord.$name()).to.equal('Mr V P Anderson MBE')
+                expect(result).to.equal('Mr V P Anderson MBE')
               })
             })
           })
@@ -299,24 +314,24 @@ describe('Contact model', () => {
 
         describe('and the middle initial "P"', () => {
           beforeEach(() => {
-            contactRecord.middleInitials = 'P'
+            nameTestRecord.middleInitials = 'P'
           })
 
           it('returns "V P Anderson"', () => {
-            testRecord = ContactModel.fromJson(contactRecord)
+            const result = nameTestRecord.$name()
 
-            expect(testRecord.$name()).to.equal('V P Anderson')
+            expect(result).to.equal('V P Anderson')
           })
 
           describe('and the suffix "MBE"', () => {
             beforeEach(() => {
-              contactRecord.suffix = 'MBE'
+              nameTestRecord.suffix = 'MBE'
             })
 
             it('returns "V P Anderson MBE"', () => {
-              testRecord = ContactModel.fromJson(contactRecord)
+              const result = nameTestRecord.$name()
 
-              expect(testRecord.$name()).to.equal('V P Anderson MBE')
+              expect(result).to.equal('V P Anderson MBE')
             })
           })
         })

--- a/test/models/event.model.test.js
+++ b/test/models/event.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -30,6 +30,14 @@ describe('Event model', () => {
 
       testNotifications.push(notification)
     }
+  })
+
+  after(async () => {
+    for (const notification of testNotifications) {
+      await notification.$query().delete()
+    }
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/financial-agreement.model.test.js
+++ b/test/models/financial-agreement.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -32,6 +32,14 @@ describe('Financial Agreement model', () => {
 
       testLicenceAgreements.push(licenceAgreement)
     }
+  })
+
+  after(async () => {
+    for (const licenceAgreement of testLicenceAgreements) {
+      await licenceAgreement.$query().delete()
+    }
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/licence-agreement.model.test.js
+++ b/test/models/licence-agreement.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -27,14 +27,21 @@ describe('Licence Agreement model', () => {
   before(async () => {
     // Link to financial agreement
     testFinancialAgreement = FinancialAgreementHelper.select(FINANCIAL_AGREEMENT_MCHG_INDEX)
-    const { id: financialAgreementId } = testFinancialAgreement
 
     // Link to licence
     testLicence = await LicenceHelper.add()
-    const { licenceRef } = testLicence
 
     // Test record
-    testRecord = await LicenceAgreementHelper.add({ financialAgreementId, licenceRef })
+    testRecord = await LicenceAgreementHelper.add({
+      financialAgreementId: testFinancialAgreement.id,
+      licenceRef: testLicence.licenceRef
+    })
+  })
+
+  after(async () => {
+    await testLicence.$query().delete()
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/licence-document-header.model.test.js
+++ b/test/models/licence-document-header.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -30,6 +30,13 @@ describe('Licence Document Header model', () => {
       companyEntityId: testLicenceEntityRole.companyEntityId,
       licenceRef: testLicence.licenceRef
     })
+  })
+
+  after(async () => {
+    await testLicenceEntityRole.$query().delete()
+    await testLicence.$query().delete()
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/licence-document-role.model.test.js
+++ b/test/models/licence-document-role.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -34,32 +34,36 @@ describe('Licence Document Role model', () => {
   before(async () => {
     // Link address
     testAddress = await AddressHelper.add()
-    const { id: addressId } = testAddress
 
     // Link company
     testCompany = await CompanyHelper.add()
-    const { id: companyId } = testCompany
 
     // Link contact
     testContact = await ContactHelper.add()
-    const { id: contactId } = testContact
 
     // Link licence document
     testLicenceDocument = await LicenceDocumentHelper.add()
-    const { id: licenceDocumentId } = testLicenceDocument
 
     // Link licence role
     testLicenceRole = await LicenceRoleHelper.select()
-    const { id: licenceRoleId } = testLicenceRole
 
     // Test record
     testRecord = await LicenceDocumentRoleHelper.add({
-      addressId,
-      companyId,
-      contactId,
-      licenceDocumentId,
-      licenceRoleId
+      addressId: testAddress.id,
+      companyId: testCompany.id,
+      contactId: testContact.id,
+      licenceDocumentId: testLicenceDocument.id,
+      licenceRoleId: testLicenceRole.id
     })
+  })
+
+  after(async () => {
+    await testAddress.$query().delete()
+    await testCompany.$query().delete()
+    await testContact.$query().delete()
+    await testLicenceDocument.$query().delete()
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/licence-document.model.test.js
+++ b/test/models/licence-document.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -25,19 +25,27 @@ describe('Licence Document model', () => {
   before(async () => {
     // Link to licence
     testLicence = await LicenceHelper.add()
-    const { licenceRef } = testLicence
 
     // Test record
-    testRecord = await LicenceDocumentHelper.add({ licenceRef })
-    const { id: licenceDocumentId } = testRecord
+    testRecord = await LicenceDocumentHelper.add({ licenceRef: testLicence.licenceRef })
 
     // Link to licence document roles
     testLicenceDocumentRoles = []
     for (let i = 0; i < 2; i++) {
-      const licenceDocumentRole = await LicenceDocumentRoleHelper.add({ licenceDocumentId })
+      const licenceDocumentRole = await LicenceDocumentRoleHelper.add({ licenceDocumentId: testRecord.id })
 
       testLicenceDocumentRoles.push(licenceDocumentRole)
     }
+  })
+
+  after(async () => {
+    await testLicence.$query().delete()
+
+    for (const licenceDocumentRole of testLicenceDocumentRoles) {
+      await licenceDocumentRole.$query().delete()
+    }
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/licence-end-date-change.model.test.js
+++ b/test/models/licence-end-date-change.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -25,6 +25,12 @@ describe('Licence End Date Change model', () => {
 
     // Test record
     testRecord = await LicenceEndDateChangeHelper.add({ licenceId: testLicence.id })
+  })
+
+  after(async () => {
+    await testLicence.$query().delete()
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/licence-entity-role.model.test.js
+++ b/test/models/licence-entity-role.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -31,6 +31,14 @@ describe('Licence Entity Role model', () => {
       licenceEntityId: testLicenceEntity.id,
       regimeEntityId: testRegimeEntity.id
     })
+  })
+
+  after(async () => {
+    await testCompanyEntity.$query().delete()
+    await testLicenceEntity.$query().delete()
+    await testRegimeEntity.$query().delete()
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/licence-monitoring-station.model.test.js
+++ b/test/models/licence-monitoring-station.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -52,6 +52,19 @@ describe('Licence Monitoring Station model', () => {
 
       testNotifications.push(billLicence)
     }
+  })
+
+  after(async () => {
+    await testLicence.$query().delete()
+    await testLicenceVersionPurposeCondition.$query().delete()
+    await testMonitoringStation.$query().delete()
+    await testUser.$query().delete()
+
+    for (const notification of testNotifications) {
+      await notification.$query().delete()
+    }
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/licence-role.model.test.js
+++ b/test/models/licence-role.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -28,12 +28,11 @@ describe('Licence Role model', () => {
   before(async () => {
     // Test record
     testRecord = await LicenceRoleHelper.select()
-    const { id: licenceRoleId } = testRecord
 
     // Link company addresses
     testCompanyAddresses = []
     for (let i = 0; i < 2; i++) {
-      const companyAddress = await CompanyAddressHelper.add({ licenceRoleId })
+      const companyAddress = await CompanyAddressHelper.add({ licenceRoleId: testRecord.id })
 
       testCompanyAddresses.push(companyAddress)
     }
@@ -41,7 +40,7 @@ describe('Licence Role model', () => {
     // Link company contacts
     testCompanyContacts = []
     for (let i = 0; i < 2; i++) {
-      const companyContact = await CompanyContactHelper.add({ licenceRoleId })
+      const companyContact = await CompanyContactHelper.add({ licenceRoleId: testRecord.id })
 
       testCompanyContacts.push(companyContact)
     }
@@ -49,9 +48,23 @@ describe('Licence Role model', () => {
     // Link licence document roles
     testLicenceDocumentRoles = []
     for (let i = 0; i < 2; i++) {
-      const licenceDocumentRole = await LicenceDocumentRoleHelper.add({ licenceRoleId })
+      const licenceDocumentRole = await LicenceDocumentRoleHelper.add({ licenceRoleId: testRecord.id })
 
       testLicenceDocumentRoles.push(licenceDocumentRole)
+    }
+  })
+
+  after(async () => {
+    for (const companyAddress of testCompanyAddresses) {
+      await companyAddress.$query().delete()
+    }
+
+    for (const companyContact of testCompanyContacts) {
+      await companyContact.$query().delete()
+    }
+
+    for (const licenceDocumentRole of testLicenceDocumentRoles) {
+      await licenceDocumentRole.$query().delete()
     }
   })
 

--- a/test/models/licence-supplementary-year.model.test.js
+++ b/test/models/licence-supplementary-year.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -27,6 +27,13 @@ describe('Licence Supplementary Year model', () => {
     testLicence = await LicenceHelper.add()
 
     testRecord = await LicenceSupplementaryYearHelper.add({ billRunId: testBillRun.id, licenceId: testLicence.id })
+  })
+
+  after(async () => {
+    await testBillRun.$query().delete()
+    await testLicence.$query().delete()
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/licence-unregistration.model.test.js
+++ b/test/models/licence-unregistration.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -28,6 +28,12 @@ describe('Licence Unregistration model', () => {
     testLicence = await LicenceHelper.add()
     testUser = UserHelper.select()
     testRecord = await LicenceUnregistrationHelper.add({ createdBy: testUser.id, licenceId: testLicence.id })
+  })
+
+  after(async () => {
+    await testLicence.$query().delete()
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/licence-version-purpose-condition-type.model.test.js
+++ b/test/models/licence-version-purpose-condition-type.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -25,6 +25,10 @@ describe('Licence Version Purposes Condition Type model', () => {
     testLicenceVersionPurposeCondition = await LicenceVersionPurposeConditionHelper.add({
       licenceVersionPurposeConditionTypeId: testRecord.id
     })
+  })
+
+  after(async () => {
+    await testLicenceVersionPurposeCondition.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/licence-version-purpose-condition.model.test.js
+++ b/test/models/licence-version-purpose-condition.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -42,6 +42,16 @@ describe('Licence Version Purpose Condition model', () => {
 
       testLicenceMonitoringStations.push(licenceMonitoringStation)
     }
+  })
+
+  after(async () => {
+    await testLicenceVersionPurpose.$query().delete()
+
+    for (const licenceMonitoringStation of testLicenceMonitoringStations) {
+      await licenceMonitoringStation.$query().delete()
+    }
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/licence-version-purpose-point.model.test.js
+++ b/test/models/licence-version-purpose-point.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -30,6 +30,13 @@ describe('Licence Version Purpose Point model', () => {
       licenceVersionPurposeId: testLicenceVersionPurpose.id,
       pointId: testPoint.id
     })
+  })
+
+  after(async () => {
+    await testLicenceVersionPurpose.$query().delete()
+    await testPoint.$query().delete()
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/licence-version-purpose.model.test.js
+++ b/test/models/licence-version-purpose.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -70,6 +70,21 @@ describe('Licence Version Purpose model', () => {
       testLicenceVersionPurposeConditions.push(licenceVersionPurposeCondition)
       testLicenceVersionPurposePoints.push(licenceVersionPurposePoint)
     }
+  })
+
+  after(async () => {
+    await testLicenceVersion.$query().delete()
+    await testPoint.$query().delete()
+
+    for (const licenceVersionPurposeCondition of testLicenceVersionPurposeConditions) {
+      await licenceVersionPurposeCondition.$query().delete()
+    }
+
+    for (const licenceVersionPurposePoint of testLicenceVersionPurposePoints) {
+      await licenceVersionPurposePoint.$query().delete()
+    }
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/mod-log.model.test.js
+++ b/test/models/mod-log.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -47,6 +47,15 @@ describe('Mod Log model', () => {
       licenceVersionId: testLicenceVersion.id,
       returnVersionId: testReturnVersion.id
     })
+  })
+
+  after(async () => {
+    await testLicence.$query().delete()
+    await testChargeVersion.$query().delete()
+    await testLicenceVersion.$query().delete()
+    await testReturnVersion.$query().delete()
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/monitoring-station.model.test.js
+++ b/test/models/monitoring-station.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -28,6 +28,14 @@ describe('Monitoring Station model', () => {
 
       testLicenceMonitoringStations.push(licenceMonitoringStation)
     }
+  })
+
+  after(async () => {
+    for (const licenceMonitoringStation of testLicenceMonitoringStations) {
+      await licenceMonitoringStation.$query().delete()
+    }
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/notification.model.test.js
+++ b/test/models/notification.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -30,6 +30,13 @@ describe('Notification model', () => {
       eventId: testEvent.id,
       licenceMonitoringStationId: testLicenceMonitoringStation.id
     })
+  })
+
+  after(async () => {
+    await testEvent.$query().delete()
+    await testLicenceMonitoringStation.$query().delete()
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/point.model.test.js
+++ b/test/models/point.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -42,6 +42,13 @@ describe('Point model', () => {
       licenceVersionPurposeId: testLicenceVersionPurpose.id,
       pointId: testRecord.id
     })
+  })
+
+  after(async () => {
+    await testReturnRequirement.$query().delete()
+    await testLicenceVersionPurpose.$query().delete()
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {
@@ -116,18 +123,20 @@ describe('Point model', () => {
   })
 
   describe('$describe', () => {
+    let pointTestRecord
+
     describe('when the instance represents a "point" (1 grid reference)', () => {
       beforeEach(() => {
-        testRecord = PointModel.fromJson({ ngr1: 'ST 58212 72697' })
+        pointTestRecord = PointModel.fromJson({ ngr1: 'ST 58212 72697' })
       })
 
       describe('and it has a supplementary description', () => {
         beforeEach(() => {
-          testRecord.description = 'Head office'
+          pointTestRecord.description = 'Head office'
         })
 
         it('returns a "point" description including the supplementary', () => {
-          const result = testRecord.$describe()
+          const result = pointTestRecord.$describe()
 
           expect(result).to.equal('At National Grid Reference ST 58212 72697 (Head office)')
         })
@@ -135,7 +144,7 @@ describe('Point model', () => {
 
       describe('and it does not have a supplementary description', () => {
         it('returns just the "point" description', () => {
-          const result = testRecord.$describe()
+          const result = pointTestRecord.$describe()
 
           expect(result).to.equal('At National Grid Reference ST 58212 72697')
         })
@@ -144,16 +153,16 @@ describe('Point model', () => {
 
     describe('when the instance represents a "reach" (2 grid references)', () => {
       beforeEach(() => {
-        testRecord = PointModel.fromJson({ ngr1: 'ST 58212 72697', ngr2: 'ST 58151 72683' })
+        pointTestRecord = PointModel.fromJson({ ngr1: 'ST 58212 72697', ngr2: 'ST 58151 72683' })
       })
 
       describe('and it has a supplementary description', () => {
         beforeEach(() => {
-          testRecord.description = 'Head office'
+          pointTestRecord.description = 'Head office'
         })
 
         it('returns a "reach" description including the supplementary', () => {
-          const result = testRecord.$describe()
+          const result = pointTestRecord.$describe()
 
           expect(result).to.equal('Between National Grid References ST 58212 72697 and ST 58151 72683 (Head office)')
         })
@@ -161,7 +170,7 @@ describe('Point model', () => {
 
       describe('and it does not have a supplementary description', () => {
         it('returns just the "reach" description', () => {
-          const result = testRecord.$describe()
+          const result = pointTestRecord.$describe()
 
           expect(result).to.equal('Between National Grid References ST 58212 72697 and ST 58151 72683')
         })
@@ -170,7 +179,7 @@ describe('Point model', () => {
 
     describe('when the instance represents an "area" (4 grid references)', () => {
       beforeEach(() => {
-        testRecord = PointModel.fromJson({
+        pointTestRecord = PointModel.fromJson({
           ngr1: 'ST 58212 72697',
           ngr2: 'ST 58151 72683',
           ngr3: 'ST 58145 72727',
@@ -180,11 +189,11 @@ describe('Point model', () => {
 
       describe('and it has a supplementary description', () => {
         beforeEach(() => {
-          testRecord.description = 'Head office'
+          pointTestRecord.description = 'Head office'
         })
 
         it('returns an "area" description including the supplementary', () => {
-          const result = testRecord.$describe()
+          const result = pointTestRecord.$describe()
 
           expect(result).to.equal(
             'Within the area formed by the straight lines running between National Grid References ST 58212 72697, ST 58151 72683, ST 58145 72727 and ST 58222 72744 (Head office)'
@@ -194,7 +203,7 @@ describe('Point model', () => {
 
       describe('and it does not have a supplementary description', () => {
         it('returns just the "area" description', () => {
-          const result = testRecord.$describe()
+          const result = pointTestRecord.$describe()
 
           expect(result).to.equal(
             'Within the area formed by the straight lines running between National Grid References ST 58212 72697, ST 58151 72683, ST 58145 72727 and ST 58222 72744'

--- a/test/models/primary-purpose.model.test.js
+++ b/test/models/primary-purpose.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -43,6 +43,16 @@ describe('Primary Purpose model', () => {
       })
 
       testReturnRequirementPurposes.push(returnRequirementPurpose)
+    }
+  })
+
+  after(async () => {
+    for (const licenceVersionPurpose of testLicenceVersionPurposes) {
+      await licenceVersionPurpose.$query().delete()
+    }
+
+    for (const returnRequirementPurpose of testReturnRequirementPurposes) {
+      await returnRequirementPurpose.$query().delete()
     }
   })
 

--- a/test/models/purpose.model.test.js
+++ b/test/models/purpose.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -57,6 +57,24 @@ describe('Purpose model', () => {
       const returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({ purposeId: testRecord.id })
 
       testReturnRequirementPurposes.push(returnRequirementPurpose)
+    }
+  })
+
+  after(async () => {
+    for (const chargeElement of testChargeElements) {
+      await chargeElement.$query().delete()
+    }
+
+    for (const chargeReference of testChargeReferences) {
+      await chargeReference.$query().delete()
+    }
+
+    for (const licenceVersionPurpose of testLicenceVersionPurposes) {
+      await licenceVersionPurpose.$query().delete()
+    }
+
+    for (const returnRequirementPurpose of testReturnRequirementPurposes) {
+      await returnRequirementPurpose.$query().delete()
     }
   })
 

--- a/test/models/region.model.test.js
+++ b/test/models/region.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -50,6 +50,20 @@ describe('Region model', () => {
       })
 
       testLicences.push(licence)
+    }
+  })
+
+  after(async () => {
+    for (const billRun of testBillRuns) {
+      await billRun.$query().delete()
+    }
+
+    for (const company of testCompanies) {
+      await company.$query().delete()
+    }
+
+    for (const licence of testLicences) {
+      await licence.$query().delete()
     }
   })
 

--- a/test/models/return-cycle.model.test.js
+++ b/test/models/return-cycle.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -27,6 +27,12 @@ describe('Return Cycle model', () => {
       const returnLog = await ReturnLogHelper.add({ returnCycleId: testRecord.id })
 
       testReturnLogs.push(returnLog)
+    }
+  })
+
+  after(async () => {
+    for (const returnLog of testReturnLogs) {
+      await returnLog.$query().delete()
     }
   })
 

--- a/test/models/return-log.model.test.js
+++ b/test/models/return-log.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -56,6 +56,21 @@ describe('Return Log model', () => {
 
       testReviewReturns.push(reviewReturn)
     }
+  })
+
+  after(async () => {
+    await testLicence.$query().delete()
+    await testReturnRequirements.$query().delete()
+
+    for (const returnSubmission of testReturnSubmissions) {
+      await returnSubmission.$query().delete()
+    }
+
+    for (const reviewReturn of testReviewReturns) {
+      await reviewReturn.$query().delete()
+    }
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/return-requirement-point.model.test.js
+++ b/test/models/return-requirement-point.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -30,6 +30,13 @@ describe('Return Requirement Point model', () => {
       pointId: testPoint.id,
       returnRequirementId: testReturnRequirement.id
     })
+  })
+
+  after(async () => {
+    await testPoint.$query().delete()
+    await testReturnRequirement.$query().delete()
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/return-requirement-purpose.model.test.js
+++ b/test/models/return-requirement-purpose.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -40,6 +40,12 @@ describe('Return Requirement Purpose model', () => {
       returnRequirementId: testReturnRequirement.id,
       secondaryPurposeId: testSecondaryPurpose.id
     })
+  })
+
+  after(async () => {
+    await testReturnRequirement.$query().delete()
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/return-requirement.model.test.js
+++ b/test/models/return-requirement.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -53,6 +53,21 @@ describe('Return Requirement model', () => {
 
       testReturnLogs.push(returnLog)
     }
+  })
+
+  after(async () => {
+    await testReturnVersion.$query().delete()
+    await testPoint.$query().delete()
+
+    for (const returnRequirementPurpose of testReturnRequirementPurposes) {
+      await returnRequirementPurpose.$query().delete()
+    }
+
+    for (const returnLog of testReturnLogs) {
+      await returnLog.$query().delete()
+    }
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/return-submission-line.model.test.js
+++ b/test/models/return-submission-line.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -23,6 +23,12 @@ describe('Return Submission Line model', () => {
     testReturnSubmission = await ReturnSubmissionHelper.add()
 
     testRecord = await ReturnSubmissionLineHelper.add({ returnSubmissionId: testReturnSubmission.id })
+  })
+
+  after(async () => {
+    await testReturnSubmission.$query().delete()
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/return-submission.model.test.js
+++ b/test/models/return-submission.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -21,12 +21,39 @@ const { unitNames } = require('../../app/lib/static-lookups.lib.js')
 
 describe('Return Submission model', () => {
   let testRecord
+  let testReturnLog
+  let testReturnSubmissionLines
+
+  before(async () => {
+    testReturnLog = await ReturnLogHelper.add()
+
+    testRecord = await ReturnSubmissionHelper.add({ returnLogId: testReturnLog.id })
+
+    testReturnSubmissionLines = []
+    for (let i = 0; i < 2; i++) {
+      // NOTE: A constraint in the lines table means you cannot have 2 records with the same returnSubmissionId,
+      // startDate and endDate
+      const returnSubmissionLine = await ReturnSubmissionLineHelper.add({
+        returnSubmissionId: testRecord.id,
+        startDate: new Date(2022, 11, 1 + i),
+        endDate: new Date(2022, 11, 2 + i)
+      })
+
+      testReturnSubmissionLines.push(returnSubmissionLine)
+    }
+  })
+
+  after(async () => {
+    await testReturnLog.$query().delete()
+
+    for (const returnSubmissionLine of testReturnSubmissionLines) {
+      await returnSubmissionLine.$query().delete()
+    }
+
+    await testRecord.$query().delete()
+  })
 
   describe('Basic query', () => {
-    beforeEach(async () => {
-      testRecord = await ReturnSubmissionHelper.add()
-    })
-
     it('can successfully run a basic query', async () => {
       const result = await ReturnSubmissionModel.query().findById(testRecord.id)
 
@@ -37,13 +64,6 @@ describe('Return Submission model', () => {
 
   describe('Relationships', () => {
     describe('when linking to return log', () => {
-      let testReturnLog
-
-      beforeEach(async () => {
-        testReturnLog = await ReturnLogHelper.add()
-        testRecord = await ReturnSubmissionHelper.add({ returnLogId: testReturnLog.id })
-      })
-
       it('can successfully run a related query', async () => {
         const query = await ReturnSubmissionModel.query().innerJoinRelated('returnLog')
 
@@ -62,26 +82,6 @@ describe('Return Submission model', () => {
     })
 
     describe('when linking to return submission lines', () => {
-      let testLines
-
-      beforeEach(async () => {
-        testRecord = await ReturnSubmissionHelper.add()
-        const { id: returnSubmissionId } = testRecord
-
-        testLines = []
-        for (let i = 0; i < 2; i++) {
-          // NOTE: A constraint in the lines table means you cannot have 2 records with the same returnSubmissionId,
-          // startDate and endDate
-          const returnSubmissionLine = await ReturnSubmissionLineHelper.add({
-            returnSubmissionId,
-            startDate: new Date(2022, 11, 1 + i),
-            endDate: new Date(2022, 11, 2 + i)
-          })
-
-          testLines.push(returnSubmissionLine)
-        }
-      })
-
       it('can successfully run a related query', async () => {
         const query = await ReturnSubmissionModel.query().innerJoinRelated('returnSubmissionLines')
 
@@ -98,15 +98,17 @@ describe('Return Submission model', () => {
 
         expect(result.returnSubmissionLines).to.be.an.array()
         expect(result.returnSubmissionLines[0]).to.be.an.instanceOf(ReturnSubmissionLineModel)
-        expect(result.returnSubmissionLines).to.include(testLines[0])
-        expect(result.returnSubmissionLines).to.include(testLines[1])
+        expect(result.returnSubmissionLines).to.include(testReturnSubmissionLines[0])
+        expect(result.returnSubmissionLines).to.include(testReturnSubmissionLines[1])
       })
     })
   })
 
   describe('$applyReadings', () => {
+    let applyReadingsTestRecord
+
     beforeEach(() => {
-      testRecord = ReturnSubmissionModel.fromJson({
+      applyReadingsTestRecord = ReturnSubmissionModel.fromJson({
         metadata: {
           meters: [
             {
@@ -126,18 +128,20 @@ describe('Return Submission model', () => {
     })
 
     it('applies readings to the return submission lines', () => {
-      testRecord.$applyReadings()
+      applyReadingsTestRecord.$applyReadings()
 
-      expect(testRecord.returnSubmissionLines[0].reading).to.equal(1)
-      expect(testRecord.returnSubmissionLines[1].reading).to.equal(2)
-      expect(testRecord.returnSubmissionLines[2].reading).be.null()
+      expect(applyReadingsTestRecord.returnSubmissionLines[0].reading).to.equal(1)
+      expect(applyReadingsTestRecord.returnSubmissionLines[1].reading).to.equal(2)
+      expect(applyReadingsTestRecord.returnSubmissionLines[2].reading).be.null()
     })
   })
 
   describe('$meter', () => {
+    let meterTestRecord
+
     describe('when the return submission contains meters', () => {
-      beforeEach(async () => {
-        testRecord = ReturnSubmissionModel.fromJson({
+      beforeEach(() => {
+        meterTestRecord = ReturnSubmissionModel.fromJson({
           metadata: {
             meters: [{ serialNumber: 'METER_1' }, { serialNumber: 'METER_2' }]
           }
@@ -145,7 +149,7 @@ describe('Return Submission model', () => {
       })
 
       it('returns the first meter', () => {
-        const result = testRecord.$meter()
+        const result = meterTestRecord.$meter()
 
         expect(result).to.equal({ serialNumber: 'METER_1' })
       })
@@ -153,11 +157,11 @@ describe('Return Submission model', () => {
 
     describe('when the return submission contains no meters', () => {
       beforeEach(async () => {
-        testRecord = ReturnSubmissionModel.fromJson()
+        meterTestRecord = ReturnSubmissionModel.fromJson()
       })
 
       it('returns null', () => {
-        const result = testRecord.$meter()
+        const result = meterTestRecord.$meter()
 
         expect(result).to.be.null()
       })
@@ -165,13 +169,15 @@ describe('Return Submission model', () => {
   })
 
   describe('$method', () => {
+    let methodTestRecord
+
     describe('when the return submission contains the method', () => {
       beforeEach(async () => {
-        testRecord = ReturnSubmissionModel.fromJson({ metadata: { method: 'METHOD' } })
+        methodTestRecord = ReturnSubmissionModel.fromJson({ metadata: { method: 'METHOD' } })
       })
 
       it('returns the method', () => {
-        const result = testRecord.$method()
+        const result = methodTestRecord.$method()
 
         expect(result).to.equal('METHOD')
       })
@@ -179,11 +185,11 @@ describe('Return Submission model', () => {
 
     describe('when the return submission contains no method', () => {
       beforeEach(async () => {
-        testRecord = ReturnSubmissionModel.fromJson()
+        methodTestRecord = ReturnSubmissionModel.fromJson()
       })
 
       it('returns the method as abstractionVolumes', () => {
-        const result = testRecord.$method()
+        const result = methodTestRecord.$method()
 
         expect(result).to.equal('abstractionVolumes')
       })
@@ -191,13 +197,15 @@ describe('Return Submission model', () => {
   })
 
   describe('$units', () => {
+    let unitsTestRecord
+
     describe('when the return submission contains the unit', () => {
       beforeEach(async () => {
-        testRecord = ReturnSubmissionModel.fromJson({ metadata: { units: 'UNITS' } })
+        unitsTestRecord = ReturnSubmissionModel.fromJson({ metadata: { units: 'UNITS' } })
       })
 
       it('returns the unit', () => {
-        const result = testRecord.$units()
+        const result = unitsTestRecord.$units()
 
         expect(result).to.equal('UNITS')
       })
@@ -205,11 +213,11 @@ describe('Return Submission model', () => {
 
     describe('when the return submission contains no unit', () => {
       beforeEach(async () => {
-        testRecord = ReturnSubmissionModel.fromJson()
+        unitsTestRecord = ReturnSubmissionModel.fromJson()
       })
 
       it('returns the units as cubic metres', () => {
-        const result = testRecord.$units()
+        const result = unitsTestRecord.$units()
 
         expect(result).to.equal(unitNames.CUBIC_METRES)
       })

--- a/test/models/return-version.model.test.js
+++ b/test/models/return-version.model.test.js
@@ -4,12 +4,10 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, beforeEach, before, after, afterEach } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
-const { generateRandomInteger } = require('../../app/lib/general.lib.js')
-const { randomRegionCode } = require('../support/general.js')
 const LicenceHelper = require('../support/helpers/licence.helper.js')
 const LicenceModel = require('../../app/models/licence.model.js')
 const ModLogHelper = require('../support/helpers/mod-log.helper.js')
@@ -19,6 +17,8 @@ const ReturnRequirementModel = require('../../app/models/return-requirement.mode
 const ReturnVersionHelper = require('../support/helpers/return-version.helper.js')
 const UserModel = require('../../app/models/user.model.js')
 const UserHelper = require('../support/helpers/user.helper.js')
+const { generateRandomInteger } = require('../../app/lib/general.lib.js')
+const { randomRegionCode } = require('../support/general.js')
 
 // Thing under test
 const ReturnVersionModel = require('../../app/models/return-version.model.js')
@@ -26,25 +26,50 @@ const ReturnVersionModel = require('../../app/models/return-version.model.js')
 const { SKIP_COMPARE_LIST: skip } = UserHelper
 
 describe('Return Version model', () => {
-  let modLogs
-  let returnVersionId
+  let testLicence
+  let testModLogs
   let testRecord
+  let testReturnRequirements
+  let testUser
 
-  beforeEach(async () => {
-    modLogs = []
-  })
+  before(async () => {
+    testLicence = await LicenceHelper.add()
 
-  afterEach(async () => {
-    for (const modLog of modLogs) {
-      await modLog.$query().delete()
+    testUser = UserHelper.select()
+
+    testRecord = await ReturnVersionHelper.add({ createdBy: testUser.userId, licenceId: testLicence.id })
+
+    testModLogs = []
+    for (let i = 0; i < 2; i++) {
+      const modLog = await ModLogHelper.add({ returnVersionId: testRecord.id })
+
+      testModLogs.push(modLog)
+    }
+
+    testReturnRequirements = []
+    for (let i = 0; i < 2; i++) {
+      const returnRequirement = await ReturnRequirementHelper.add({
+        siteDescription: `TEST RTN REQ ${i}`,
+        returnVersionId: testRecord.id
+      })
+
+      testReturnRequirements.push(returnRequirement)
     }
   })
 
-  describe('Basic query', () => {
-    beforeEach(async () => {
-      testRecord = await ReturnVersionHelper.add()
-    })
+  after(async () => {
+    for (const modLog of testModLogs) {
+      await modLog.$query().delete()
+    }
 
+    for (const returnRequirement of testReturnRequirements) {
+      await returnRequirement.$query().delete()
+    }
+
+    await testRecord.$query().delete()
+  })
+
+  describe('Basic query', () => {
     it('can successfully run a basic query', async () => {
       const result = await ReturnVersionModel.query().findById(testRecord.id)
 
@@ -55,16 +80,6 @@ describe('Return Version model', () => {
 
   describe('Relationships', () => {
     describe('when linking to licence', () => {
-      let testLicence
-
-      beforeEach(async () => {
-        testLicence = await LicenceHelper.add()
-
-        const { id: licenceId } = testLicence
-
-        testRecord = await ReturnVersionHelper.add({ licenceId })
-      })
-
       it('can successfully run a related query', async () => {
         const query = await ReturnVersionModel.query().innerJoinRelated('licence')
 
@@ -83,19 +98,6 @@ describe('Return Version model', () => {
     })
 
     describe('when linking to mod logs', () => {
-      let testModLogs
-
-      beforeEach(async () => {
-        testRecord = await ReturnVersionHelper.add()
-
-        testModLogs = []
-        for (let i = 0; i < 2; i++) {
-          const modLog = await ModLogHelper.add({ returnVersionId: testRecord.id })
-
-          testModLogs.push(modLog)
-        }
-      })
-
       it('can successfully run a related query', async () => {
         const query = await ReturnVersionModel.query().innerJoinRelated('modLogs')
 
@@ -116,22 +118,6 @@ describe('Return Version model', () => {
     })
 
     describe('when linking to return requirements', () => {
-      let testReturnRequirements
-
-      beforeEach(async () => {
-        testRecord = await ReturnVersionHelper.add()
-
-        testReturnRequirements = []
-        for (let i = 0; i < 2; i++) {
-          const returnRequirement = await ReturnRequirementHelper.add({
-            siteDescription: `TEST RTN REQ ${i}`,
-            returnVersionId: testRecord.id
-          })
-
-          testReturnRequirements.push(returnRequirement)
-        }
-      })
-
       it('can successfully run a related query', async () => {
         const query = await ReturnVersionModel.query().innerJoinRelated('returnRequirements')
 
@@ -152,16 +138,6 @@ describe('Return Version model', () => {
     })
 
     describe('when linking to user', () => {
-      let testUser
-
-      beforeEach(async () => {
-        testUser = UserHelper.select()
-
-        const { userId: createdBy } = testUser
-
-        testRecord = await ReturnVersionHelper.add({ createdBy })
-      })
-
       it('can successfully run a related query', async () => {
         const query = await ReturnVersionModel.query().innerJoinRelated('user')
 
@@ -181,21 +157,33 @@ describe('Return Version model', () => {
   })
 
   describe('$createdAt', () => {
-    beforeEach(async () => {
-      const { id } = await ReturnVersionHelper.add()
+    let createdAtModLogs
+    let createdAtTestRecord
+    let fetchedRecord
 
-      returnVersionId = id
+    beforeEach(async () => {
+      createdAtTestRecord = await ReturnVersionHelper.add()
+
+      createdAtModLogs = []
+    })
+
+    afterEach(async () => {
+      for (const modLog of createdAtModLogs) {
+        await modLog.$query().delete()
+      }
+
+      await createdAtTestRecord.$query().delete()
     })
 
     describe('when a return version has no mod log history', () => {
       beforeEach(async () => {
-        testRecord = await ReturnVersionModel.query().findById(returnVersionId).modify('history')
+        fetchedRecord = await ReturnVersionModel.query().findById(createdAtTestRecord.id).modify('history')
       })
 
       it('returns the return version "created at" time stamp', () => {
-        const result = testRecord.$createdAt()
+        const result = fetchedRecord.$createdAt()
 
-        expect(result).to.equal(testRecord.createdAt)
+        expect(result).to.equal(createdAtTestRecord.createdAt)
       })
     })
 
@@ -204,22 +192,26 @@ describe('Return Version model', () => {
         const regionCode = randomRegionCode()
         const firstNaldId = generateRandomInteger(100, 99998)
 
-        await ModLogHelper.add({
-          externalId: `${regionCode}:${firstNaldId}`,
-          naldDate: new Date('2012-06-01'),
-          returnVersionId
-        })
-        await ModLogHelper.add({
-          externalId: `${regionCode}:${firstNaldId + 1}`,
-          naldDate: new Date('2012-06-02'),
-          returnVersionId
-        })
+        createdAtModLogs.push(
+          await ModLogHelper.add({
+            externalId: `${regionCode}:${firstNaldId}`,
+            naldDate: new Date('2012-06-01'),
+            returnVersionId: createdAtTestRecord.id
+          })
+        )
+        createdAtModLogs.push(
+          await ModLogHelper.add({
+            externalId: `${regionCode}:${firstNaldId + 1}`,
+            naldDate: new Date('2012-06-02'),
+            returnVersionId: createdAtTestRecord.id
+          })
+        )
 
-        testRecord = await ReturnVersionModel.query().findById(returnVersionId).modify('history')
+        fetchedRecord = await ReturnVersionModel.query().findById(createdAtTestRecord.id).modify('history')
       })
 
       it('returns the first mod log NALD date', () => {
-        const result = testRecord.$createdAt()
+        const result = fetchedRecord.$createdAt()
 
         expect(result).to.equal(new Date('2012-06-01'))
       })
@@ -227,24 +219,34 @@ describe('Return Version model', () => {
   })
 
   describe('$createdBy', () => {
+    let createdByModLogs
+    let createdByTestRecord
+    let fetchedRecord
+
+    beforeEach(async () => {
+      createdByModLogs = []
+    })
+
+    afterEach(async () => {
+      for (const modLog of createdByModLogs) {
+        await modLog.$query().delete()
+      }
+
+      await createdByTestRecord.$query().delete()
+    })
+
     describe('when the return version was created in WRLS', () => {
-      let testUser
-
       beforeEach(async () => {
-        testUser = UserHelper.select()
-
-        const { id } = await ReturnVersionHelper.add({ createdBy: testUser.userId })
-
-        returnVersionId = id
+        createdByTestRecord = await ReturnVersionHelper.add({ createdBy: testUser.userId })
       })
 
       describe('and has no mod log history', () => {
         beforeEach(async () => {
-          testRecord = await ReturnVersionModel.query().findById(returnVersionId).modify('history')
+          fetchedRecord = await ReturnVersionModel.query().findById(createdByTestRecord.id).modify('history')
         })
 
         it('returns the WRLS user name', () => {
-          const result = testRecord.$createdBy()
+          const result = fetchedRecord.$createdBy()
 
           expect(result).to.equal(testUser.username)
         })
@@ -252,13 +254,13 @@ describe('Return Version model', () => {
 
       describe('and has mod log history', () => {
         beforeEach(async () => {
-          await ModLogHelper.add({ returnVersionId })
+          createdByModLogs.push(await ModLogHelper.add({ returnVersionId: createdByTestRecord.id }))
 
-          testRecord = await ReturnVersionModel.query().findById(returnVersionId).modify('history')
+          fetchedRecord = await ReturnVersionModel.query().findById(createdByTestRecord.id).modify('history')
         })
 
         it('still returns the WRLS user name', () => {
-          const result = testRecord.$createdBy()
+          const result = fetchedRecord.$createdBy()
 
           expect(result).to.equal(testUser.username)
         })
@@ -267,18 +269,16 @@ describe('Return Version model', () => {
 
     describe('when the return version was created in NALD', () => {
       beforeEach(async () => {
-        const { id } = await ReturnVersionHelper.add()
-
-        returnVersionId = id
+        createdByTestRecord = await ReturnVersionHelper.add()
       })
 
       describe('and has no mod log history', () => {
         beforeEach(async () => {
-          testRecord = await ReturnVersionModel.query().findById(returnVersionId).modify('history')
+          fetchedRecord = await ReturnVersionModel.query().findById(createdByTestRecord.id).modify('history')
         })
 
         it('returns null', () => {
-          const result = testRecord.$createdBy()
+          const result = fetchedRecord.$createdBy()
 
           expect(result).to.be.null()
         })
@@ -289,14 +289,26 @@ describe('Return Version model', () => {
           const regionCode = randomRegionCode()
           const firstNaldId = generateRandomInteger(100, 99998)
 
-          await ModLogHelper.add({ externalId: `${regionCode}:${firstNaldId}`, returnVersionId, userId: 'FIRST' })
-          await ModLogHelper.add({ externalId: `${regionCode}:${firstNaldId + 1}`, returnVersionId, userId: 'SECOND' })
+          createdByModLogs.push(
+            await ModLogHelper.add({
+              externalId: `${regionCode}:${firstNaldId}`,
+              returnVersionId: createdByTestRecord.id,
+              userId: 'FIRST'
+            })
+          )
+          createdByModLogs.push(
+            await ModLogHelper.add({
+              externalId: `${regionCode}:${firstNaldId + 1}`,
+              returnVersionId: createdByTestRecord.id,
+              userId: 'SECOND'
+            })
+          )
 
-          testRecord = await ReturnVersionModel.query().findById(returnVersionId).modify('history')
+          fetchedRecord = await ReturnVersionModel.query().findById(createdByTestRecord.id).modify('history')
         })
 
         it('returns the first mod log NALD user ID', () => {
-          const result = testRecord.$createdBy()
+          const result = fetchedRecord.$createdBy()
 
           expect(result).to.equal('FIRST')
         })
@@ -305,18 +317,32 @@ describe('Return Version model', () => {
   })
 
   describe('$notes', () => {
+    let fetchedRecord
+    let notesModLogs
+    let notesTestRecord
+
+    beforeEach(async () => {
+      notesModLogs = []
+    })
+
+    afterEach(async () => {
+      for (const modLog of notesModLogs) {
+        await modLog.$query().delete()
+      }
+
+      await notesTestRecord.$query().delete()
+    })
+
     describe('when a return version has no mod log history', () => {
       describe('and no notes recorded', () => {
         beforeEach(async () => {
-          const { id } = await ReturnVersionHelper.add({ notes: null })
+          notesTestRecord = await ReturnVersionHelper.add({ notes: null })
 
-          returnVersionId = id
-
-          testRecord = await ReturnVersionModel.query().findById(returnVersionId).modify('history')
+          fetchedRecord = await ReturnVersionModel.query().findById(notesTestRecord.id).modify('history')
         })
 
         it('returns an empty array', () => {
-          const result = testRecord.$notes()
+          const result = fetchedRecord.$notes()
 
           expect(result).to.be.an.array()
           expect(result).to.be.empty()
@@ -325,15 +351,13 @@ describe('Return Version model', () => {
 
       describe('but notes recorded', () => {
         beforeEach(async () => {
-          const { id } = await ReturnVersionHelper.add({ notes: 'Top site bore hole' })
+          notesTestRecord = await ReturnVersionHelper.add({ notes: 'Top site bore hole' })
 
-          returnVersionId = id
-
-          testRecord = await ReturnVersionModel.query().findById(returnVersionId).modify('history')
+          fetchedRecord = await ReturnVersionModel.query().findById(notesTestRecord.id).modify('history')
         })
 
         it('returns an array containing just the single note', () => {
-          const result = testRecord.$notes()
+          const result = fetchedRecord.$notes()
 
           expect(result).to.equal(['Top site bore hole'])
         })
@@ -343,9 +367,7 @@ describe('Return Version model', () => {
     describe('when a return version has mod log history', () => {
       describe('and no notes recorded against the return version', () => {
         beforeEach(async () => {
-          const { id } = await ReturnVersionHelper.add({ notes: null })
-
-          returnVersionId = id
+          notesTestRecord = await ReturnVersionHelper.add({ notes: null })
         })
 
         describe('and none of the mod log history has notes', () => {
@@ -353,22 +375,26 @@ describe('Return Version model', () => {
             const regionCode = randomRegionCode()
             const firstNaldId = generateRandomInteger(100, 99998)
 
-            await ModLogHelper.add({
-              externalId: `${regionCode}:${firstNaldId}`,
-              note: null,
-              returnVersionId
-            })
-            await ModLogHelper.add({
-              externalId: `${regionCode}:${firstNaldId + 1}`,
-              note: null,
-              returnVersionId
-            })
+            notesModLogs.push(
+              await ModLogHelper.add({
+                externalId: `${regionCode}:${firstNaldId}`,
+                note: null,
+                returnVersionId: notesTestRecord.id
+              })
+            )
+            notesModLogs.push(
+              await ModLogHelper.add({
+                externalId: `${regionCode}:${firstNaldId + 1}`,
+                note: null,
+                returnVersionId: notesTestRecord.id
+              })
+            )
 
-            testRecord = await ReturnVersionModel.query().findById(returnVersionId).modify('history')
+            fetchedRecord = await ReturnVersionModel.query().findById(notesTestRecord.id).modify('history')
           })
 
           it('returns an empty array', () => {
-            const result = testRecord.$notes()
+            const result = fetchedRecord.$notes()
 
             expect(result).to.be.an.array()
             expect(result).to.be.empty()
@@ -380,22 +406,26 @@ describe('Return Version model', () => {
             const regionCode = randomRegionCode()
             const firstNaldId = generateRandomInteger(100, 99998)
 
-            await ModLogHelper.add({
-              externalId: `${regionCode}:${firstNaldId}`,
-              note: null,
-              returnVersionId
-            })
-            await ModLogHelper.add({
-              externalId: `${regionCode}:${firstNaldId + 1}`,
-              note: 'Transfer per app 12-DEF',
-              returnVersionId
-            })
+            notesModLogs.push(
+              await ModLogHelper.add({
+                externalId: `${regionCode}:${firstNaldId}`,
+                note: null,
+                returnVersionId: notesTestRecord.id
+              })
+            )
+            notesModLogs.push(
+              await ModLogHelper.add({
+                externalId: `${regionCode}:${firstNaldId + 1}`,
+                note: 'Transfer per app 12-DEF',
+                returnVersionId: notesTestRecord.id
+              })
+            )
 
-            testRecord = await ReturnVersionModel.query().findById(returnVersionId).modify('history')
+            fetchedRecord = await ReturnVersionModel.query().findById(notesTestRecord.id).modify('history')
           })
 
           it('returns an array containing just the notes from the mod logs with them', () => {
-            const result = testRecord.$notes()
+            const result = fetchedRecord.$notes()
 
             expect(result).to.equal(['Transfer per app 12-DEF'])
           })
@@ -405,29 +435,31 @@ describe('Return Version model', () => {
       describe('and notes recorded against the return version', () => {
         describe('and notes in all the mod log history', () => {
           beforeEach(async () => {
-            const { id } = await ReturnVersionHelper.add({ notes: 'Top site bore hole' })
-
-            returnVersionId = id
+            notesTestRecord = await ReturnVersionHelper.add({ notes: 'Top site bore hole' })
 
             const regionCode = randomRegionCode()
             const firstNaldId = generateRandomInteger(100, 99998)
 
-            await ModLogHelper.add({
-              externalId: `${regionCode}:${firstNaldId}`,
-              note: 'New Licence per app 9-ABC',
-              returnVersionId
-            })
-            await ModLogHelper.add({
-              externalId: `${regionCode}:${firstNaldId + 1}`,
-              note: 'Transfer per app 12-DEF',
-              returnVersionId
-            })
+            notesModLogs.push(
+              await ModLogHelper.add({
+                externalId: `${regionCode}:${firstNaldId}`,
+                note: 'New Licence per app 9-ABC',
+                returnVersionId: notesTestRecord.id
+              })
+            )
+            notesModLogs.push(
+              await ModLogHelper.add({
+                externalId: `${regionCode}:${firstNaldId + 1}`,
+                note: 'Transfer per app 12-DEF',
+                returnVersionId: notesTestRecord.id
+              })
+            )
 
-            testRecord = await ReturnVersionModel.query().findById(returnVersionId).modify('history')
+            fetchedRecord = await ReturnVersionModel.query().findById(notesTestRecord.id).modify('history')
           })
 
           it('returns all the notes in one array, mod log first and return version last', () => {
-            const result = testRecord.$notes()
+            const result = fetchedRecord.$notes()
 
             expect(result).to.equal(['New Licence per app 9-ABC', 'Transfer per app 12-DEF', 'Top site bore hole'])
           })
@@ -439,41 +471,56 @@ describe('Return Version model', () => {
   describe('$reason', () => {
     let regionCode
     let firstNaldId
+    let fetchedRecord
+    let reasonModLogs
+    let reasonTestRecord
 
     beforeEach(() => {
+      reasonModLogs = []
+
       // The "first" mod log record is determined by sorting them by external ID ASC and using the first in the
       // list. So, we have to control the external ID used rather than leaving the helper generate one.
       regionCode = randomRegionCode()
       firstNaldId = generateRandomInteger(100, 99998)
     })
 
+    afterEach(async () => {
+      for (const modLog of reasonModLogs) {
+        await modLog.$query().delete()
+      }
+
+      await reasonTestRecord.$query().delete()
+    })
+
     describe('when the return version has a "local" reason recorded against it', () => {
       describe('that maps to a known "reason"', () => {
         beforeEach(async () => {
-          testRecord = await ReturnVersionHelper.add({ reason: 'major-change' })
+          reasonTestRecord = await ReturnVersionHelper.add({ reason: 'major-change' })
         })
 
         describe('even if the version has mod log history', () => {
           beforeEach(async () => {
-            let modLog = await ModLogHelper.add({
-              externalId: `${regionCode}:${firstNaldId}`,
-              reasonDescription: 'New licence',
-              returnVersionId: testRecord.id
-            })
-            modLogs.push(modLog)
+            reasonModLogs.push(
+              await ModLogHelper.add({
+                externalId: `${regionCode}:${firstNaldId}`,
+                reasonDescription: 'New licence',
+                returnVersionId: reasonTestRecord.id
+              })
+            )
 
-            modLog = await ModLogHelper.add({
-              externalId: `${regionCode}:${firstNaldId + 1}`,
-              reasonDescription: 'Minor change',
-              returnVersionId: testRecord.id
-            })
-            modLogs.push(modLog)
+            reasonModLogs.push(
+              await ModLogHelper.add({
+                externalId: `${regionCode}:${firstNaldId + 1}`,
+                reasonDescription: 'Minor change',
+                returnVersionId: reasonTestRecord.id
+              })
+            )
 
-            testRecord = await ReturnVersionModel.query().findById(testRecord.id).modify('history')
+            fetchedRecord = await ReturnVersionModel.query().findById(reasonTestRecord.id).modify('history')
           })
 
           it('returns the mapped reason description', () => {
-            const result = testRecord.$reason()
+            const result = fetchedRecord.$reason()
 
             expect(result).to.equal('Major change')
           })
@@ -482,31 +529,33 @@ describe('Return Version model', () => {
 
       describe('that does not map to a known "reason"', () => {
         beforeEach(async () => {
-          testRecord = await ReturnVersionHelper.add({ reason: 'unknown-reason' })
+          reasonTestRecord = await ReturnVersionHelper.add({ reason: 'unknown-reason' })
         })
 
         describe('if the version has mod log history', () => {
           describe('and it has a reason description', () => {
             beforeEach(async () => {
-              let modLog = await ModLogHelper.add({
-                externalId: `${regionCode}:${firstNaldId}`,
-                reasonDescription: 'New licence',
-                returnVersionId: testRecord.id
-              })
-              modLogs.push(modLog)
+              reasonModLogs.push(
+                await ModLogHelper.add({
+                  externalId: `${regionCode}:${firstNaldId}`,
+                  reasonDescription: 'New licence',
+                  returnVersionId: reasonTestRecord.id
+                })
+              )
 
-              modLog = await ModLogHelper.add({
-                externalId: `${regionCode}:${firstNaldId + 1}`,
-                reasonDescription: 'Minor change',
-                returnVersionId: testRecord.id
-              })
-              modLogs.push(modLog)
+              reasonModLogs.push(
+                await ModLogHelper.add({
+                  externalId: `${regionCode}:${firstNaldId + 1}`,
+                  reasonDescription: 'Minor change',
+                  returnVersionId: reasonTestRecord.id
+                })
+              )
 
-              testRecord = await ReturnVersionModel.query().findById(testRecord.id).modify('history')
+              fetchedRecord = await ReturnVersionModel.query().findById(reasonTestRecord.id).modify('history')
             })
 
             it('returns the NALD reason description', () => {
-              const result = testRecord.$reason()
+              const result = fetchedRecord.$reason()
 
               expect(result).to.equal('New licence')
             })
@@ -514,25 +563,27 @@ describe('Return Version model', () => {
 
           describe('but it does not have a reason description', () => {
             beforeEach(async () => {
-              let modLog = await ModLogHelper.add({
-                externalId: `${regionCode}:${firstNaldId}`,
-                reasonDescription: null,
-                returnVersionId: testRecord.id
-              })
-              modLogs.push(modLog)
+              reasonModLogs.push(
+                await ModLogHelper.add({
+                  externalId: `${regionCode}:${firstNaldId}`,
+                  reasonDescription: null,
+                  returnVersionId: reasonTestRecord.id
+                })
+              )
 
-              modLog = await ModLogHelper.add({
-                externalId: `${regionCode}:${firstNaldId + 1}`,
-                reasonDescription: 'Minor change',
-                returnVersionId: testRecord.id
-              })
-              modLogs.push(modLog)
+              reasonModLogs.push(
+                await ModLogHelper.add({
+                  externalId: `${regionCode}:${firstNaldId + 1}`,
+                  reasonDescription: 'Minor change',
+                  returnVersionId: reasonTestRecord.id
+                })
+              )
 
-              testRecord = await ReturnVersionModel.query().findById(testRecord.id).modify('history')
+              fetchedRecord = await ReturnVersionModel.query().findById(reasonTestRecord.id).modify('history')
             })
 
             it('returns the unknown reason', () => {
-              const result = testRecord.$reason()
+              const result = fetchedRecord.$reason()
 
               expect(result).to.equal('unknown-reason')
             })
@@ -543,16 +594,16 @@ describe('Return Version model', () => {
 
     describe('when the return version does not have a "local" reason recorded against it', () => {
       beforeEach(async () => {
-        testRecord = await ReturnVersionHelper.add({ reason: null })
+        reasonTestRecord = await ReturnVersionHelper.add({ reason: null })
       })
 
       describe('and no mod log history', () => {
         beforeEach(async () => {
-          testRecord = await ReturnVersionModel.query().findById(testRecord.id).modify('history')
+          fetchedRecord = await ReturnVersionModel.query().findById(reasonTestRecord.id).modify('history')
         })
 
         it('returns null', () => {
-          const result = testRecord.$reason()
+          const result = fetchedRecord.$reason()
 
           expect(result).to.be.null()
         })
@@ -561,25 +612,27 @@ describe('Return Version model', () => {
       describe('if the version has mod log history', () => {
         describe('and it has a reason description', () => {
           beforeEach(async () => {
-            let modLog = await ModLogHelper.add({
-              externalId: `${regionCode}:${firstNaldId}`,
-              reasonDescription: 'New licence',
-              returnVersionId: testRecord.id
-            })
-            modLogs.push(modLog)
+            reasonModLogs.push(
+              await ModLogHelper.add({
+                externalId: `${regionCode}:${firstNaldId}`,
+                reasonDescription: 'New licence',
+                returnVersionId: reasonTestRecord.id
+              })
+            )
 
-            modLog = await ModLogHelper.add({
-              externalId: `${regionCode}:${firstNaldId + 1}`,
-              reasonDescription: 'Minor change',
-              returnVersionId: testRecord.id
-            })
-            modLogs.push(modLog)
+            reasonModLogs.push(
+              await ModLogHelper.add({
+                externalId: `${regionCode}:${firstNaldId + 1}`,
+                reasonDescription: 'Minor change',
+                returnVersionId: reasonTestRecord.id
+              })
+            )
 
-            testRecord = await ReturnVersionModel.query().findById(testRecord.id).modify('history')
+            fetchedRecord = await ReturnVersionModel.query().findById(reasonTestRecord.id).modify('history')
           })
 
           it('returns the NALD reason description', () => {
-            const result = testRecord.$reason()
+            const result = fetchedRecord.$reason()
 
             expect(result).to.equal('New licence')
           })
@@ -587,25 +640,27 @@ describe('Return Version model', () => {
 
         describe('but it does not have a reason description', () => {
           beforeEach(async () => {
-            let modLog = await ModLogHelper.add({
-              externalId: `${regionCode}:${firstNaldId}`,
-              reasonDescription: null,
-              returnVersionId: testRecord.id
-            })
-            modLogs.push(modLog)
+            reasonModLogs.push(
+              await ModLogHelper.add({
+                externalId: `${regionCode}:${firstNaldId}`,
+                reasonDescription: null,
+                returnVersionId: reasonTestRecord.id
+              })
+            )
 
-            modLog = await ModLogHelper.add({
-              externalId: `${regionCode}:${firstNaldId + 1}`,
-              reasonDescription: 'Minor change',
-              returnVersionId: testRecord.id
-            })
-            modLogs.push(modLog)
+            reasonModLogs.push(
+              await ModLogHelper.add({
+                externalId: `${regionCode}:${firstNaldId + 1}`,
+                reasonDescription: 'Minor change',
+                returnVersionId: reasonTestRecord.id
+              })
+            )
 
-            testRecord = await ReturnVersionModel.query().findById(testRecord.id).modify('history')
+            fetchedRecord = await ReturnVersionModel.query().findById(reasonTestRecord.id).modify('history')
           })
 
           it('returns null', () => {
-            const result = testRecord.$reason()
+            const result = fetchedRecord.$reason()
 
             expect(result).to.be.null()
           })

--- a/test/models/review-charge-element-return.model.test.js
+++ b/test/models/review-charge-element-return.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -18,6 +18,10 @@ describe('Review Charge Element Return model', () => {
 
   before(async () => {
     testRecord = await ReviewChargeElementReturnHelper.add()
+  })
+
+  after(async () => {
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/review-charge-element-return.model.test.js
+++ b/test/models/review-charge-element-return.model.test.js
@@ -11,6 +11,8 @@ const { expect } = Code
 const ReviewChargeElementHelper = require('../support/helpers/review-charge-element.helper.js')
 const ReviewChargeElementModel = require('../../app/models/review-charge-element.model.js')
 const ReviewChargeElementReturnHelper = require('../support/helpers/review-charge-element-return.helper.js')
+const ReviewReturnHelper = require('../support/helpers/review-return.helper.js')
+const ReviewReturnModel = require('../../app/models/review-return.model.js')
 
 // Thing under test
 const ReviewChargeElementReturnModel = require('../../app/models/review-charge-element-return.model.js')
@@ -18,15 +20,21 @@ const ReviewChargeElementReturnModel = require('../../app/models/review-charge-e
 describe('Review Charge Element Return model', () => {
   let testRecord
   let testReviewChargeElement
+  let testReviewReturn
 
   before(async () => {
     testReviewChargeElement = await ReviewChargeElementHelper.add()
+    testReviewReturn = await ReviewReturnHelper.add()
 
-    testRecord = await ReviewChargeElementReturnHelper.add({ reviewChargeElementId: testReviewChargeElement.id })
+    testRecord = await ReviewChargeElementReturnHelper.add({
+      reviewChargeElementId: testReviewChargeElement.id,
+      reviewReturnId: testReviewReturn.id
+    })
   })
 
   after(async () => {
     await testReviewChargeElement.$query().delete()
+    await testReviewReturn.$query().delete()
 
     await testRecord.$query().delete()
   })
@@ -58,6 +66,26 @@ describe('Review Charge Element Return model', () => {
 
         expect(result.reviewChargeElement).to.be.an.instanceOf(ReviewChargeElementModel)
         expect(result.reviewChargeElement).to.equal(testReviewChargeElement)
+      })
+    })
+
+    describe('when linking to a review return', () => {
+      it('can successfully run a related query', async () => {
+        const query = await ReviewChargeElementReturnModel.query().innerJoinRelated('reviewReturn')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the review return', async () => {
+        const result = await ReviewChargeElementReturnModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('reviewReturn')
+
+        expect(result).to.be.instanceOf(ReviewChargeElementReturnModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.reviewReturn).to.be.an.instanceOf(ReviewReturnModel)
+        expect(result.reviewReturn).to.equal(testReviewReturn)
       })
     })
   })

--- a/test/models/review-charge-element-return.model.test.js
+++ b/test/models/review-charge-element-return.model.test.js
@@ -8,6 +8,8 @@ const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
+const ReviewChargeElementHelper = require('../support/helpers/review-charge-element.helper.js')
+const ReviewChargeElementModel = require('../../app/models/review-charge-element.model.js')
 const ReviewChargeElementReturnHelper = require('../support/helpers/review-charge-element-return.helper.js')
 
 // Thing under test
@@ -15,12 +17,17 @@ const ReviewChargeElementReturnModel = require('../../app/models/review-charge-e
 
 describe('Review Charge Element Return model', () => {
   let testRecord
+  let testReviewChargeElement
 
   before(async () => {
-    testRecord = await ReviewChargeElementReturnHelper.add()
+    testReviewChargeElement = await ReviewChargeElementHelper.add()
+
+    testRecord = await ReviewChargeElementReturnHelper.add({ reviewChargeElementId: testReviewChargeElement.id })
   })
 
   after(async () => {
+    await testReviewChargeElement.$query().delete()
+
     await testRecord.$query().delete()
   })
 
@@ -30,6 +37,28 @@ describe('Review Charge Element Return model', () => {
 
       expect(result).to.be.an.instanceOf(ReviewChargeElementReturnModel)
       expect(result.id).to.equal(testRecord.id)
+    })
+  })
+
+  describe('Relationships', () => {
+    describe('when linking to a review charge element', () => {
+      it('can successfully run a related query', async () => {
+        const query = await ReviewChargeElementReturnModel.query().innerJoinRelated('reviewChargeElement')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the review charge element', async () => {
+        const result = await ReviewChargeElementReturnModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('reviewChargeElement')
+
+        expect(result).to.be.instanceOf(ReviewChargeElementReturnModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.reviewChargeElement).to.be.an.instanceOf(ReviewChargeElementModel)
+        expect(result.reviewChargeElement).to.equal(testReviewChargeElement)
+      })
     })
   })
 })

--- a/test/models/review-charge-element.model.test.js
+++ b/test/models/review-charge-element.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -24,6 +24,7 @@ describe('Review Charge Element model', () => {
   let testChargeElement
   let testRecord
   let testReviewChargeReference
+  let testReviewChargeElementReturns
   let testReviewReturns
 
   before(async () => {
@@ -36,16 +37,34 @@ describe('Review Charge Element model', () => {
     })
 
     testReviewReturns = []
+    testReviewChargeElementReturns = []
     for (let i = 0; i < 2; i++) {
       const testReviewReturn = await ReviewReturnHelper.add()
 
       testReviewReturns.push(testReviewReturn)
 
-      await ReviewChargeElementReturnHelper.add({
+      const testReviewChargeElementReturn = await ReviewChargeElementReturnHelper.add({
         reviewChargeElementId: testRecord.id,
         reviewReturnId: testReviewReturn.id
       })
+
+      testReviewChargeElementReturns.push(testReviewChargeElementReturn)
     }
+  })
+
+  after(async () => {
+    await testChargeElement.$query().delete()
+    await testReviewChargeReference.$query().delete()
+
+    for (const reviewReturn of testReviewReturns) {
+      await reviewReturn.$query().delete()
+    }
+
+    for (const reviewChargeElementReturn of testReviewChargeElementReturns) {
+      await reviewChargeElementReturn.$query().delete()
+    }
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/review-charge-element.model.test.js
+++ b/test/models/review-charge-element.model.test.js
@@ -12,6 +12,7 @@ const ChargeElementHelper = require('../support/helpers/charge-element.helper.js
 const ChargeElementModel = require('../../app/models/charge-element.model.js')
 const ReviewChargeElementHelper = require('../support/helpers/review-charge-element.helper.js')
 const ReviewChargeElementReturnHelper = require('../support/helpers/review-charge-element-return.helper.js')
+const ReviewChargeElementReturnModel = require('../../app/models/review-charge-element-return.model.js')
 const ReviewChargeReferenceHelper = require('../support/helpers/review-charge-reference.helper.js')
 const ReviewChargeReferenceModel = require('../../app/models/review-charge-reference.model.js')
 const ReviewReturnHelper = require('../support/helpers/review-return.helper.js')
@@ -92,6 +93,28 @@ describe('Review Charge Element model', () => {
 
         expect(result.chargeElement).to.be.an.instanceOf(ChargeElementModel)
         expect(result.chargeElement).to.equal(testChargeElement)
+      })
+    })
+
+    describe('when linking to review charge element returns', () => {
+      it('can successfully run a related query', async () => {
+        const query = await ReviewChargeElementModel.query().innerJoinRelated('reviewChargeElementReturns')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the review charge element returns', async () => {
+        const result = await ReviewChargeElementModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('reviewChargeElementReturns')
+
+        expect(result).to.be.instanceOf(ReviewChargeElementModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.reviewChargeElementReturns).to.be.an.array()
+        expect(result.reviewChargeElementReturns[0]).to.be.an.instanceOf(ReviewChargeElementReturnModel)
+        expect(result.reviewChargeElementReturns).to.include(testReviewChargeElementReturns[0])
+        expect(result.reviewChargeElementReturns).to.include(testReviewChargeElementReturns[1])
       })
     })
 

--- a/test/models/review-charge-reference.model.test.js
+++ b/test/models/review-charge-reference.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -35,6 +35,14 @@ describe('Review Charge reference model', () => {
     })
 
     testChargeElement = await ReviewChargeElementHelper.add({ reviewChargeReferenceId: testRecord.id })
+  })
+
+  after(async () => {
+    await testChargeReference.$query().delete()
+    await testReviewChargeVersion.$query().delete()
+    await testChargeElement.$query().delete()
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/review-charge-version.model.test.js
+++ b/test/models/review-charge-version.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -35,6 +35,14 @@ describe('Review Charge Version model', () => {
     })
 
     testChargeReference = await ReviewChargeReferenceHelper.add({ reviewChargeVersionId: testRecord.id })
+  })
+
+  after(async () => {
+    await testChargeVersion.$query().delete()
+    await testReviewLicence.$query().delete()
+    await testChargeReference.$query().delete()
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/review-licence.model.test.js
+++ b/test/models/review-licence.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -47,6 +47,21 @@ describe('Review Licence model', () => {
 
       testReviewReturns.push(reviewReturn)
     }
+  })
+
+  after(async () => {
+    await testBillRun.$query().delete()
+    await testLicence.$query().delete()
+
+    for (const reviewChargeVersion of testReviewChargeVersions) {
+      await reviewChargeVersion.$query().delete()
+    }
+
+    for (const reviewReturn of testReviewReturns) {
+      await reviewReturn.$query().delete()
+    }
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/review-return.model.test.js
+++ b/test/models/review-return.model.test.js
@@ -12,9 +12,10 @@ const ReturnLogHelper = require('../support/helpers/return-log.helper.js')
 const ReturnLogModel = require('../../app/models/return-log.model.js')
 const ReviewChargeElementHelper = require('../support/helpers/review-charge-element.helper.js')
 const ReviewChargeElementModel = require('../../app/models/review-charge-element.model.js')
+const ReviewChargeElementReturnHelper = require('../support/helpers/review-charge-element-return.helper.js')
+const ReviewChargeElementReturnModel = require('../../app/models/review-charge-element-return.model.js')
 const ReviewLicenceHelper = require('../support/helpers/review-licence.helper.js')
 const ReviewLicenceModel = require('../../app/models/review-licence.model.js')
-const ReviewChargeElementReturnHelper = require('../support/helpers/review-charge-element-return.helper.js')
 const ReviewReturnHelper = require('../support/helpers/review-return.helper.js')
 
 // Thing under test
@@ -109,6 +110,28 @@ describe('Review Return model', () => {
         expect(result.reviewChargeElements[0]).to.be.an.instanceOf(ReviewChargeElementModel)
         expect(result.reviewChargeElements).to.include(testReviewChargeElements[0])
         expect(result.reviewChargeElements).to.include(testReviewChargeElements[1])
+      })
+    })
+
+    describe('when linking to review charge element returns', () => {
+      it('can successfully run a related query', async () => {
+        const query = await ReviewReturnModel.query().innerJoinRelated('reviewChargeElementReturns')
+
+        expect(query).to.exist()
+      })
+
+      it('can eager load the review charge element returns', async () => {
+        const result = await ReviewReturnModel.query()
+          .findById(testRecord.id)
+          .withGraphFetched('reviewChargeElementReturns')
+
+        expect(result).to.be.instanceOf(ReviewReturnModel)
+        expect(result.id).to.equal(testRecord.id)
+
+        expect(result.reviewChargeElementReturns).to.be.an.array()
+        expect(result.reviewChargeElementReturns[0]).to.be.an.instanceOf(ReviewChargeElementReturnModel)
+        expect(result.reviewChargeElementReturns).to.include(testReviewChargeElementReturns[0])
+        expect(result.reviewChargeElementReturns).to.include(testReviewChargeElementReturns[1])
       })
     })
 

--- a/test/models/review-return.model.test.js
+++ b/test/models/review-return.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -24,6 +24,7 @@ describe('Review Return model', () => {
   let testRecord
   let testReturnLog
   let testReviewChargeElements
+  let testReviewChargeElementReturns
   let testReviewLicence
 
   before(async () => {
@@ -33,16 +34,34 @@ describe('Review Return model', () => {
     testRecord = await ReviewReturnHelper.add({ returnLogId: testReturnLog.id, reviewLicenceId: testReviewLicence.id })
 
     testReviewChargeElements = []
+    testReviewChargeElementReturns = []
     for (let i = 0; i < 2; i++) {
       const testReviewChargeElement = await ReviewChargeElementHelper.add()
 
       testReviewChargeElements.push(testReviewChargeElement)
 
-      await ReviewChargeElementReturnHelper.add({
+      const reviewChargeElementReturn = await ReviewChargeElementReturnHelper.add({
         reviewReturnId: testRecord.id,
         reviewChargeElementId: testReviewChargeElement.id
       })
+
+      testReviewChargeElementReturns.push(reviewChargeElementReturn)
     }
+  })
+
+  after(async () => {
+    await testReturnLog.$query().delete()
+    await testReviewLicence.$query().delete()
+
+    for (const reviewChargeElement of testReviewChargeElements) {
+      await reviewChargeElement.$query().delete()
+    }
+
+    for (const reviewChargeElementReturn of testReviewChargeElementReturns) {
+      await reviewChargeElementReturn.$query().delete()
+    }
+
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/secondary-purpose.model.test.js
+++ b/test/models/secondary-purpose.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, beforeEach } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -18,7 +18,43 @@ const SecondaryPurposeHelper = require('../support/helpers/secondary-purpose.hel
 const SecondaryPurposeModel = require('../../app/models/secondary-purpose.model.js')
 
 describe('Secondary Purpose model', () => {
-  const testRecordId = SecondaryPurposeHelper.select().id
+  let testRecordId
+  let testLicenceVersionPurposes
+  let testReturnRequirementPurposes
+
+  before(async () => {
+    testRecordId = SecondaryPurposeHelper.select().id
+
+    testLicenceVersionPurposes = []
+    for (let i = 0; i < 2; i++) {
+      const licenceVersionPurpose = await LicenceVersionPurposeHelper.add({
+        notes: `TEST licence Version purpose ${i}`,
+        secondaryPurposeId: testRecordId
+      })
+
+      testLicenceVersionPurposes.push(licenceVersionPurpose)
+    }
+
+    testReturnRequirementPurposes = []
+    for (let i = 0; i < 2; i++) {
+      const returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({
+        alias: `TEST return requirement purpose ${i}`,
+        secondaryPurposeId: testRecordId
+      })
+
+      testReturnRequirementPurposes.push(returnRequirementPurpose)
+    }
+  })
+
+  after(async () => {
+    for (const licenceVersionPurpose of testLicenceVersionPurposes) {
+      await licenceVersionPurpose.$query().delete()
+    }
+
+    for (const returnRequirementPurpose of testReturnRequirementPurposes) {
+      await returnRequirementPurpose.$query().delete()
+    }
+  })
 
   describe('Basic query', () => {
     it('can successfully run a basic query', async () => {
@@ -31,20 +67,6 @@ describe('Secondary Purpose model', () => {
 
   describe('Relationships', () => {
     describe('when linking to licence version purposes', () => {
-      let testLicenceVersionPurposes
-
-      beforeEach(async () => {
-        testLicenceVersionPurposes = []
-        for (let i = 0; i < 2; i++) {
-          const licenceVersionPurpose = await LicenceVersionPurposeHelper.add({
-            notes: `TEST licence Version purpose ${i}`,
-            secondaryPurposeId: testRecordId
-          })
-
-          testLicenceVersionPurposes.push(licenceVersionPurpose)
-        }
-      })
-
       it('can successfully run a related query', async () => {
         const query = await SecondaryPurposeModel.query().innerJoinRelated('licenceVersionPurposes')
 
@@ -67,20 +89,6 @@ describe('Secondary Purpose model', () => {
     })
 
     describe('when linking to return requirement purposes', () => {
-      let testReturnRequirementPurposes
-
-      beforeEach(async () => {
-        testReturnRequirementPurposes = []
-        for (let i = 0; i < 2; i++) {
-          const returnRequirementPurpose = await ReturnRequirementPurposeHelper.add({
-            alias: `TEST return requirement purpose ${i}`,
-            secondaryPurposeId: testRecordId
-          })
-
-          testReturnRequirementPurposes.push(returnRequirementPurpose)
-        }
-      })
-
       it('can successfully run a related query', async () => {
         const query = await SecondaryPurposeModel.query().innerJoinRelated('returnRequirementPurposes')
 

--- a/test/models/source.model.test.js
+++ b/test/models/source.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -27,6 +27,12 @@ describe('Source model', () => {
       const point = await PointHelper.add({ sourceId: testRecord.id })
 
       testPoints.push(point)
+    }
+  })
+
+  after(async () => {
+    for (const point of testPoints) {
+      await point.$query().delete()
     }
   })
 

--- a/test/models/transaction.model.test.js
+++ b/test/models/transaction.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -30,6 +30,12 @@ describe('Transaction model', () => {
       billLicenceId: testBillLicence.id,
       chargeReferenceId: testChargeReference.id
     })
+  })
+
+  after(async () => {
+    await testBillLicence.$query().delete()
+    await testChargeReference.$query().delete()
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {

--- a/test/models/workflow.model.test.js
+++ b/test/models/workflow.model.test.js
@@ -4,7 +4,7 @@
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -23,6 +23,11 @@ describe('Workflow model', () => {
     testLicence = await LicenceHelper.add()
 
     testRecord = await WorkflowHelper.add({ licenceId: testLicence.id })
+  })
+
+  after(async () => {
+    await testLicence.$query().delete()
+    await testRecord.$query().delete()
   })
 
   describe('Basic query', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5710

When putting together this project, we selected [Hapi Lab](https://hapi.dev/module/lab/api/26.x.x) for the unit test framework. The main framework for all Defra Node-based projects is [Hapi](https://hapi.dev/). So, early Defra projects also selected **Lab** for unit testing. It was also the framework for [Charging Module API](https://github.com/DEFRA/sroc-charging-module-api), so the dev team were familiar with it.

But it has limitations. Other Node unit test frameworks include more functionality that we have to add to **Lab** ourselves. Documentation and online examples are limited. Plus, it prevents us from updating the codebase to use [ESM modules](https://nodejs.org/api/esm.html), the "official format" for JavaScript modules.

We've been keeping an eye on other Defra projects. Nowadays, [Vitest](https://vitest.dev/) is the approved framework of choice.

So, we intend to switch to Vitest for unit testing. This change requires some preparation beforehand. Ideally, model tests should

- Set up the database `before` running the tests
- cleanup `after` all the tests have run

Thanks to @Jozzey , the [setup before is covered](https://github.com/DEFRA/water-abstraction-system/pull/2478). But we were inconsistent with the cleanup.

Also, some tests were destructuring IDs for later use, while others referenced them directly. We now think the direct approach is clearer, so where we've spotted this behaviour, we've updated.