### PR TITLE
Update adhoc returns invitation templates and personalisation

### DIFF
--- a/app/lib/notify-templates.lib.js
+++ b/app/lib/notify-templates.lib.js
@@ -36,14 +36,14 @@ const NOTIFY_TEMPLATES = Object.freeze({
   invitations: {
     adhoc: {
       email: {
-        'primary user': '7bb89469-1dbc-458a-9526-fad8ab71285f',
-        'returns user': 'cbc4efe2-f3b5-4642-8f6d-3532df73ee94',
-        'single use': '7bb89469-1dbc-458a-9526-fad8ab71285f'
+        'primary user': '543e5de5-8056-4704-a552-bf4e9084c2ef',
+        'returns user': 'fcea4350-5ee0-4a93-a438-a46ff17844c4',
+        'single use': '543e5de5-8056-4704-a552-bf4e9084c2ef'
       },
       letter: {
-        'licence holder': '4b47cf1c-043c-4a0c-8659-5be06cb2b860',
-        'returns to': '73b4c395-4423-4976-8ab4-c82e2cb6beee',
-        'single use': '4b47cf1c-043c-4a0c-8659-5be06cb2b860'
+        'licence holder': 'c2c1de42-561f-4f1c-a65f-327f52e91266',
+        'returns to': '7af9dd97-863c-40bb-bd79-ff15f1580fc6',
+        'single use': 'c2c1de42-561f-4f1c-a65f-327f52e91266'
       }
     },
     standard: {

--- a/app/presenters/notices/setup/returns-notice-notifications.presenter.js
+++ b/app/presenters/notices/setup/returns-notice-notifications.presenter.js
@@ -68,7 +68,7 @@ function _email(recipient, noticeId, session) {
     messageType,
     messageRef: MESSAGE_REFS[noticeType][journey],
     personalisation: {
-      licencenumber: recipient.licence_refs[0],
+      licenceNumber: recipient.licence_refs[0],
       periodEndDate: formatLongDate(determinedReturnsPeriod?.endDate),
       periodStartDate: formatLongDate(determinedReturnsPeriod?.startDate),
       returnDueDate: formatLongDate(recipient.notificationDueDate)
@@ -95,7 +95,7 @@ function _letter(recipient, noticeId, session) {
     messageRef: MESSAGE_REFS[noticeType][journey],
     personalisation: {
       ...address,
-      licencenumber: recipient.licence_refs[0],
+      licenceNumber: recipient.licence_refs[0],
       periodEndDate: formatLongDate(determinedReturnsPeriod?.endDate),
       periodStartDate: formatLongDate(determinedReturnsPeriod?.startDate),
       returnDueDate: formatLongDate(recipient.notificationDueDate),

--- a/app/presenters/notices/setup/returns-notice-notifications.presenter.js
+++ b/app/presenters/notices/setup/returns-notice-notifications.presenter.js
@@ -68,6 +68,7 @@ function _email(recipient, noticeId, session) {
     messageType,
     messageRef: MESSAGE_REFS[noticeType][journey],
     personalisation: {
+      licencenumber: recipient.licence_refs[0],
       periodEndDate: formatLongDate(determinedReturnsPeriod?.endDate),
       periodStartDate: formatLongDate(determinedReturnsPeriod?.startDate),
       returnDueDate: formatLongDate(recipient.notificationDueDate)
@@ -94,6 +95,7 @@ function _letter(recipient, noticeId, session) {
     messageRef: MESSAGE_REFS[noticeType][journey],
     personalisation: {
       ...address,
+      licencenumber: recipient.licence_refs[0],
       periodEndDate: formatLongDate(determinedReturnsPeriod?.endDate),
       periodStartDate: formatLongDate(determinedReturnsPeriod?.startDate),
       returnDueDate: formatLongDate(recipient.notificationDueDate),

--- a/test/presenters/notices/setup/returns-notice-notifications.presenter.test.js
+++ b/test/presenters/notices/setup/returns-notice-notifications.presenter.test.js
@@ -2,16 +2,16 @@
 
 // Test helpers
 const RecipientsFixture = require('../../../support/fixtures/recipients.fixture.js')
-const { futureDueDate } = require('../../../../app/presenters/notices/base.presenter.js')
 const { NOTIFY_TEMPLATES } = require('../../../../app/lib/notify-templates.lib.js')
 const { formatLongDate } = require('../../../../app/presenters/base.presenter.js')
+const { futureDueDate } = require('../../../../app/presenters/notices/base.presenter.js')
+const { generateUUID } = require('../../../../app/lib/general.lib.js')
 
 // Thing under test
 const ReturnsNoticeNotificationsPresenter = require('../../../../app/presenters/notices/setup/returns-notice-notifications.presenter.js')
 
 describe('Notices - Setup - Returns Notice Notifications presenter', () => {
-  const noticeId = 'c1cae668-3dad-4806-94e2-eb3f27222ed9'
-
+  let noticeId
   let determinedReturnsPeriod
   let dynamicEmailDueDate
   let dynamicLetterDueDate
@@ -19,6 +19,8 @@ describe('Notices - Setup - Returns Notice Notifications presenter', () => {
   let session
 
   beforeEach(() => {
+    noticeId = generateUUID()
+
     dynamicEmailDueDate = futureDueDate()
     dynamicLetterDueDate = futureDueDate('letter')
 
@@ -58,6 +60,7 @@ describe('Notices - Setup - Returns Notice Notifications presenter', () => {
         messageRef: 'returns invitation',
         messageType: 'email',
         personalisation: {
+          licencenumber: recipients[0].licence_refs[0],
           periodEndDate: '31 March 2025',
           periodStartDate: '1 January 2025',
           returnDueDate: formatLongDate(dynamicEmailDueDate)
@@ -75,6 +78,7 @@ describe('Notices - Setup - Returns Notice Notifications presenter', () => {
         messageRef: 'returns invitation',
         messageType: 'email',
         personalisation: {
+          licencenumber: recipients[1].licence_refs[0],
           periodEndDate: '31 March 2025',
           periodStartDate: '1 January 2025',
           returnDueDate: formatLongDate(dynamicEmailDueDate)
@@ -98,6 +102,7 @@ describe('Notices - Setup - Returns Notice Notifications presenter', () => {
           address_line_4: 'Little Whinging',
           address_line_5: 'Surrey',
           address_line_6: 'WD25 7LR',
+          licencenumber: recipients[2].licence_refs[0],
           name: 'Returnsholder',
           periodEndDate: '31 March 2025',
           periodStartDate: '1 January 2025',
@@ -121,6 +126,7 @@ describe('Notices - Setup - Returns Notice Notifications presenter', () => {
           address_line_4: 'Little Whinging',
           address_line_5: 'Surrey',
           address_line_6: 'WD25 7LR',
+          licencenumber: recipients[3].licence_refs[0],
           name: 'Returnsto',
           periodEndDate: '31 March 2025',
           periodStartDate: '1 January 2025',
@@ -138,6 +144,7 @@ describe('Notices - Setup - Returns Notice Notifications presenter', () => {
         messageRef: 'returns invitation',
         messageType: 'email',
         personalisation: {
+          licencenumber: recipients[4].licence_refs[0],
           periodEndDate: '31 March 2025',
           periodStartDate: '1 January 2025',
           returnDueDate: formatLongDate(dynamicEmailDueDate)
@@ -161,6 +168,7 @@ describe('Notices - Setup - Returns Notice Notifications presenter', () => {
           address_line_4: 'Little Whinging',
           address_line_5: 'Surrey',
           address_line_6: 'WD25 7LR',
+          licencenumber: recipients[5].licence_refs[0],
           name: 'Additional',
           periodEndDate: '31 March 2025',
           periodStartDate: '1 January 2025',
@@ -293,6 +301,7 @@ describe('Notices - Setup - Returns Notice Notifications presenter', () => {
         const result = ReturnsNoticeNotificationsPresenter.go(session, recipients, noticeId)
 
         expect(result[0].personalisation).toEqual({
+          licencenumber: recipients[0].licence_refs[0],
           periodEndDate: '31 March 2025',
           periodStartDate: '1 January 2025',
           returnDueDate: formatLongDate(recipients[0].notificationDueDate)
@@ -311,6 +320,7 @@ describe('Notices - Setup - Returns Notice Notifications presenter', () => {
           address_line_4: 'Little Whinging',
           address_line_5: 'Surrey',
           address_line_6: 'WD25 7LR',
+          licencenumber: recipients[2].licence_refs[0],
           periodEndDate: '31 March 2025',
           periodStartDate: '1 January 2025',
           returnDueDate: formatLongDate(recipients[2].notificationDueDate),

--- a/test/presenters/notices/setup/returns-notice-notifications.presenter.test.js
+++ b/test/presenters/notices/setup/returns-notice-notifications.presenter.test.js
@@ -60,7 +60,7 @@ describe('Notices - Setup - Returns Notice Notifications presenter', () => {
         messageRef: 'returns invitation',
         messageType: 'email',
         personalisation: {
-          licencenumber: recipients[0].licence_refs[0],
+          licenceNumber: recipients[0].licence_refs[0],
           periodEndDate: '31 March 2025',
           periodStartDate: '1 January 2025',
           returnDueDate: formatLongDate(dynamicEmailDueDate)
@@ -78,7 +78,7 @@ describe('Notices - Setup - Returns Notice Notifications presenter', () => {
         messageRef: 'returns invitation',
         messageType: 'email',
         personalisation: {
-          licencenumber: recipients[1].licence_refs[0],
+          licenceNumber: recipients[1].licence_refs[0],
           periodEndDate: '31 March 2025',
           periodStartDate: '1 January 2025',
           returnDueDate: formatLongDate(dynamicEmailDueDate)
@@ -102,7 +102,7 @@ describe('Notices - Setup - Returns Notice Notifications presenter', () => {
           address_line_4: 'Little Whinging',
           address_line_5: 'Surrey',
           address_line_6: 'WD25 7LR',
-          licencenumber: recipients[2].licence_refs[0],
+          licenceNumber: recipients[2].licence_refs[0],
           name: 'Returnsholder',
           periodEndDate: '31 March 2025',
           periodStartDate: '1 January 2025',
@@ -126,7 +126,7 @@ describe('Notices - Setup - Returns Notice Notifications presenter', () => {
           address_line_4: 'Little Whinging',
           address_line_5: 'Surrey',
           address_line_6: 'WD25 7LR',
-          licencenumber: recipients[3].licence_refs[0],
+          licenceNumber: recipients[3].licence_refs[0],
           name: 'Returnsto',
           periodEndDate: '31 March 2025',
           periodStartDate: '1 January 2025',
@@ -144,7 +144,7 @@ describe('Notices - Setup - Returns Notice Notifications presenter', () => {
         messageRef: 'returns invitation',
         messageType: 'email',
         personalisation: {
-          licencenumber: recipients[4].licence_refs[0],
+          licenceNumber: recipients[4].licence_refs[0],
           periodEndDate: '31 March 2025',
           periodStartDate: '1 January 2025',
           returnDueDate: formatLongDate(dynamicEmailDueDate)
@@ -168,7 +168,7 @@ describe('Notices - Setup - Returns Notice Notifications presenter', () => {
           address_line_4: 'Little Whinging',
           address_line_5: 'Surrey',
           address_line_6: 'WD25 7LR',
-          licencenumber: recipients[5].licence_refs[0],
+          licenceNumber: recipients[5].licence_refs[0],
           name: 'Additional',
           periodEndDate: '31 March 2025',
           periodStartDate: '1 January 2025',
@@ -301,7 +301,7 @@ describe('Notices - Setup - Returns Notice Notifications presenter', () => {
         const result = ReturnsNoticeNotificationsPresenter.go(session, recipients, noticeId)
 
         expect(result[0].personalisation).toEqual({
-          licencenumber: recipients[0].licence_refs[0],
+          licenceNumber: recipients[0].licence_refs[0],
           periodEndDate: '31 March 2025',
           periodStartDate: '1 January 2025',
           returnDueDate: formatLongDate(recipients[0].notificationDueDate)
@@ -320,7 +320,7 @@ describe('Notices - Setup - Returns Notice Notifications presenter', () => {
           address_line_4: 'Little Whinging',
           address_line_5: 'Surrey',
           address_line_6: 'WD25 7LR',
-          licencenumber: recipients[2].licence_refs[0],
+          licenceNumber: recipients[2].licence_refs[0],
           periodEndDate: '31 March 2025',
           periodStartDate: '1 January 2025',
           returnDueDate: formatLongDate(recipients[2].notificationDueDate),

--- a/test/services/notices/setup/create-alternate-returns-notice.service.test.js
+++ b/test/services/notices/setup/create-alternate-returns-notice.service.test.js
@@ -88,6 +88,7 @@ describe('Notices - Setup - Create Alternate Returns Notice service', () => {
         address_line_4: 'Little Whinging',
         address_line_5: 'Surrey',
         address_line_6: 'WD25 7LR',
+        licencenumber: recipient.licence_refs[0],
         periodStartDate: '1 April 2024'
       },
       recipient: null,

--- a/test/services/notices/setup/create-alternate-returns-notice.service.test.js
+++ b/test/services/notices/setup/create-alternate-returns-notice.service.test.js
@@ -88,7 +88,7 @@ describe('Notices - Setup - Create Alternate Returns Notice service', () => {
         address_line_4: 'Little Whinging',
         address_line_5: 'Surrey',
         address_line_6: 'WD25 7LR',
-        licencenumber: recipient.licence_refs[0],
+        licenceNumber: recipient.licence_refs[0],
         periodStartDate: '1 April 2024'
       },
       recipient: null,

--- a/test/services/notices/setup/create-notifications.service.test.js
+++ b/test/services/notices/setup/create-notifications.service.test.js
@@ -348,6 +348,7 @@ describe('Notices - Setup - Create Notifications service', () => {
           address_line_4: 'Little Whinging',
           address_line_5: 'Surrey',
           address_line_6: 'WD25 7LR',
+          licencenumber: recipients[0].licence_refs[0],
           name: 'Returnsholder',
           periodEndDate: null,
           periodStartDate: null,
@@ -377,6 +378,7 @@ describe('Notices - Setup - Create Notifications service', () => {
           address_line_4: 'Little Whinging',
           address_line_5: 'Surrey',
           address_line_6: 'WD25 7LR',
+          licencenumber: recipients[1].licence_refs[0],
           periodStartDate: null,
           returnDueDate: formatLongDate(futureDueDate('letter'))
         },

--- a/test/services/notices/setup/create-notifications.service.test.js
+++ b/test/services/notices/setup/create-notifications.service.test.js
@@ -348,7 +348,7 @@ describe('Notices - Setup - Create Notifications service', () => {
           address_line_4: 'Little Whinging',
           address_line_5: 'Surrey',
           address_line_6: 'WD25 7LR',
-          licencenumber: recipients[0].licence_refs[0],
+          licenceNumber: recipients[0].licence_refs[0],
           name: 'Returnsholder',
           periodEndDate: null,
           periodStartDate: null,
@@ -378,7 +378,7 @@ describe('Notices - Setup - Create Notifications service', () => {
           address_line_4: 'Little Whinging',
           address_line_5: 'Surrey',
           address_line_6: 'WD25 7LR',
-          licencenumber: recipients[1].licence_refs[0],
+          licenceNumber: recipients[1].licence_refs[0],
           periodStartDate: null,
           returnDueDate: formatLongDate(futureDueDate('letter'))
         },


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5664

We have updated adhoc returns invitations templates which now include the licence ref.

This change adds the licence ref to the personalisation.