### PR TITLE
Stop Hapi server after each controller test

### DIFF
--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -51,6 +51,10 @@ const SubjectUnderTest = require('../../app/services/subject-under-test.service.
   })
   ```
 
+## Controller tests
+
+- Always call `await server.stop()` in `after`
+
 ## Sinon
 
 - Always call `Sinon.restore()` in `afterEach` whenever stubs are used

--- a/test/controllers/address.controller.test.js
+++ b/test/controllers/address.controller.test.js
@@ -7,7 +7,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 const { postRequestOptions } = require('../support/general.js')
@@ -46,6 +46,10 @@ describe('Address controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('/address/{id}/postcode', () => {

--- a/test/controllers/bill-licences.controller.test.js
+++ b/test/controllers/bill-licences.controller.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -41,6 +41,10 @@ describe('Bill Licences controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('/bill-licences', () => {

--- a/test/controllers/bill-runs-review.controller.test.js
+++ b/test/controllers/bill-runs-review.controller.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -54,6 +54,10 @@ describe('Bill Runs Review controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('/bill-runs/review/{billRunId}', () => {

--- a/test/controllers/bill-runs-setup.controller.test.js
+++ b/test/controllers/bill-runs-setup.controller.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -50,6 +50,10 @@ describe('Bill Runs Setup controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('/bill-runs/setup', () => {

--- a/test/controllers/bill-runs.controller.test.js
+++ b/test/controllers/bill-runs.controller.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -46,6 +46,10 @@ describe('Bill Runs controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('/bill-runs', () => {

--- a/test/controllers/billing-accounts-setup.controller.test.js
+++ b/test/controllers/billing-accounts-setup.controller.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -60,6 +60,10 @@ describe('Billing Accounts Setup controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('/billing-accounts/setup/{billingAccountId}', () => {

--- a/test/controllers/billing-accounts.controller.test.js
+++ b/test/controllers/billing-accounts.controller.test.js
@@ -8,7 +8,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Things we need to stub
@@ -48,6 +48,10 @@ describe('Billing Accounts controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('/billing-accounts/{billingAccountId}', () => {

--- a/test/controllers/bills.controller.test.js
+++ b/test/controllers/bills.controller.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -43,6 +43,10 @@ describe('Bills controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('/bills', () => {

--- a/test/controllers/check.controller.test.js
+++ b/test/controllers/check.controller.test.js
@@ -7,7 +7,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // For running our service
@@ -33,6 +33,10 @@ describe('Check controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('/check/placeholder', () => {

--- a/test/controllers/companies.controller.test.js
+++ b/test/controllers/companies.controller.test.js
@@ -7,7 +7,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 const { generateUUID } = require('../../app/lib/general.lib.js')
@@ -43,6 +43,10 @@ describe('Companies controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('/companies/{id}/{role}', () => {

--- a/test/controllers/company-contacts-setup.controller.test.js
+++ b/test/controllers/company-contacts-setup.controller.test.js
@@ -7,7 +7,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 const { generateUUID } = require('../../app/lib/general.lib.js')
@@ -57,6 +57,10 @@ describe('Company Contacts Setup controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('/company-contacts/setup/{companyId}', () => {

--- a/test/controllers/company-contacts.controller.test.js
+++ b/test/controllers/company-contacts.controller.test.js
@@ -7,7 +7,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -44,6 +44,10 @@ describe('Company Contacts controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('/company-contacts/{id}/communications', () => {

--- a/test/controllers/data.controller.test.js
+++ b/test/controllers/data.controller.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -38,6 +38,10 @@ describe('Data controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('/data/dates', () => {

--- a/test/controllers/health.controller.test.js
+++ b/test/controllers/health.controller.test.js
@@ -7,7 +7,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Things we need to stub
@@ -37,6 +37,10 @@ describe('Health controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('GET /health/airbrake', () => {

--- a/test/controllers/jobs.controller.test.js
+++ b/test/controllers/jobs.controller.test.js
@@ -7,7 +7,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Things we need to stub
@@ -43,6 +43,10 @@ describe('Jobs controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('/jobs/clean', () => {

--- a/test/controllers/licence-monitoring-station-setup.controller.test.js
+++ b/test/controllers/licence-monitoring-station-setup.controller.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -52,6 +52,10 @@ describe('Licence Monitoring Station - Setup - Controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('licence-monitoring-station/setup', () => {

--- a/test/controllers/licence-monitoring-station.controller.test.js
+++ b/test/controllers/licence-monitoring-station.controller.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -40,6 +40,10 @@ describe('Licence Monitoring Station - Controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('licence-monitoring-station/{licenceMonitoringStationId}/remove', () => {

--- a/test/controllers/licence-versions.controller.test.js
+++ b/test/controllers/licence-versions.controller.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -35,6 +35,10 @@ describe('Licence Versions controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('/licence-versions/{id}', () => {

--- a/test/controllers/licences-end-dates.controller.test.js
+++ b/test/controllers/licences-end-dates.controller.test.js
@@ -7,7 +7,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Things we need to stub
@@ -37,6 +37,10 @@ describe('Licences End Dates controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('/licences/end-dates/check', () => {

--- a/test/controllers/licences.controller.test.js
+++ b/test/controllers/licences.controller.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -54,6 +54,10 @@ describe('Licences controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('/licences/{id}/bills', () => {

--- a/test/controllers/manage.controller.test.js
+++ b/test/controllers/manage.controller.test.js
@@ -7,7 +7,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Things we need to stub
@@ -35,6 +35,10 @@ describe('Manage controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('/manage', () => {

--- a/test/controllers/monitoring-stations.controller.test.js
+++ b/test/controllers/monitoring-stations.controller.test.js
@@ -7,7 +7,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Things we need to stub
@@ -37,6 +37,10 @@ describe('Monitoring stations controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('/monitoring-station/{monitoringStationId}', () => {

--- a/test/controllers/notices-setup.controller.test.js
+++ b/test/controllers/notices-setup.controller.test.js
@@ -7,7 +7,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 const { postRequestOptions } = require('../support/general.js')
@@ -82,6 +82,10 @@ describe('Notices Setup controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('notices/setup', () => {

--- a/test/controllers/notices.controller.test.js
+++ b/test/controllers/notices.controller.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -43,6 +43,10 @@ describe('Notices controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('/notices', () => {

--- a/test/controllers/notifications.controller.test.js
+++ b/test/controllers/notifications.controller.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -45,6 +45,10 @@ describe('Notifications controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('Notifications controller', () => {

--- a/test/controllers/return-logs-setup.controller.test.js
+++ b/test/controllers/return-logs-setup.controller.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -74,6 +74,10 @@ describe('Return Logs - Setup - Controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('return-logs/setup', () => {

--- a/test/controllers/return-logs.controller.test.js
+++ b/test/controllers/return-logs.controller.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -43,6 +43,10 @@ describe('Return Logs controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('/system/return-logs/{id}/communications', () => {

--- a/test/controllers/return-submissions.controller.test.js
+++ b/test/controllers/return-submissions.controller.test.js
@@ -7,7 +7,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Things we need to stub
@@ -36,6 +36,10 @@ describe('Return Submissions controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('/system/return-submissions/{yearMonth}/{returnSubmissionId}', () => {

--- a/test/controllers/return-versions-setup.controller.test.js
+++ b/test/controllers/return-versions-setup.controller.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -73,6 +73,10 @@ describe('Return Versions controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('/return-versions/setup/{sessionId}/abstraction-period', () => {

--- a/test/controllers/return-versions.controller.test.js
+++ b/test/controllers/return-versions.controller.test.js
@@ -7,7 +7,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Things we need to stub
@@ -35,6 +35,10 @@ describe('Return Versions controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('/return-versions/{id}', () => {

--- a/test/controllers/root.controller.test.js
+++ b/test/controllers/root.controller.test.js
@@ -6,7 +6,7 @@ const { HTTP_STATUS_OK } = require('node:http2').constants
 const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 
-const { describe, it, before } = (exports.lab = Lab.script())
+const { describe, it, before, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // For running our service
@@ -18,6 +18,10 @@ describe('Root controller: GET /', () => {
   // Create server before running the tests
   before(async () => {
     server = await init()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   it('displays the correct message', async () => {

--- a/test/controllers/search.controller.test.js
+++ b/test/controllers/search.controller.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -38,6 +38,10 @@ describe('Search controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('/search', () => {

--- a/test/controllers/users-setup.controller.test.js
+++ b/test/controllers/users-setup.controller.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { afterEach, before, beforeEach, describe, it } = (exports.lab = Lab.script())
+const { after, afterEach, before, beforeEach, describe, it } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -62,6 +62,10 @@ describe('Users Setup controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('/users/external/{id}/setup', () => {

--- a/test/controllers/users.controller.test.js
+++ b/test/controllers/users.controller.test.js
@@ -5,7 +5,7 @@ const Lab = require('@hapi/lab')
 const Code = require('@hapi/code')
 const Sinon = require('sinon')
 
-const { describe, it, before, beforeEach, afterEach } = (exports.lab = Lab.script())
+const { describe, it, before, beforeEach, afterEach, after } = (exports.lab = Lab.script())
 const { expect } = Code
 
 // Test helpers
@@ -57,6 +57,10 @@ describe('Users controller', () => {
 
   afterEach(() => {
     Sinon.restore()
+  })
+
+  after(async () => {
+    await server.stop()
   })
 
   describe('/users', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5710

> Prep work ahead of switching from Hapi Lab to Vitest

When spiking the switch, it was observed that all ur controller tests initialise an instance of Hapi `server` and start it, but don't then stop it when the tests are complete.

During the switch, the tests would hang when run in CI, and stopping the server after all tests for a controller had run was a suggested fix.

It didn't work, but that doesn't mean we shouldn't be doing this.