### PR TITLE
Disable Vitest cache in CI and specify test dir

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -4,6 +4,7 @@ const ci = String(process.env.CI) === 'true' || false
 
 const vitestConfig = {
   test: {
+    cache: !ci,
     coverage: {
       // Only measure coverage for files changed since the last commit; in CI all files are always included
       changed: !ci,
@@ -27,6 +28,8 @@ const vitestConfig = {
       // Directory where lcov coverage reports are written
       reportsDirectory: 'coverage'
     },
+    // Base directory to scan for test files. Specified to speed up test discovery
+    dir: 'test',
     // Module(s) to run once before all test suites. We use it to clean and seed the database
     globalSetup: ['test/global-setup.js'],
     // Each entry is a separate Vitest project, allowing different runner settings per group of tests


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5710

We've switched our test framework from Hapi Lab to Vitest. However, we're still seeing intermittent hanging in GitHub actions.

We believe it is either a resource exhaustion or a query deadlocking issue.

To help with the resource issue, we are making a couple of changes to our config.

- `cache` - Vitest builds up a cache of data about your tests to speed up subsequent runs. In CI, this is irrelevant as the cache will be lost after each run. Disabling the cache should reduce memory usage and help speed up the tests in CI.
- `dir` - When not specified, Vitest will browse from the project root looking for test files. It is most likely a negligible performance impact, but we can speed up test discovery by specifying the test directory.