### PR TITLE
Fix CI hang from Airbrake Notifier process listener leak

### DIFF
--- a/app/plugins/airbrake.plugin.js
+++ b/app/plugins/airbrake.plugin.js
@@ -24,12 +24,23 @@ const airbrakeConfig = require('../../config/airbrake.config.js')
 const { gotWrapper } = require('../lib/got-wrapper.lib.js')
 const serverConfig = require('../../config/server.config.js')
 
+// The `Notifier` constructor unconditionally hooks `process.on('uncaughtException' | 'unhandledRejection' |
+// 'beforeExit', ...)` and never removes these listeners. In production this plugin is only ever registered once, so
+// it's a non-issue there, but our tests spin up many real Hapi servers (one per test file), and each would otherwise
+// create its own `Notifier`, permanently leaking 3 process-level listeners per server. We keep a single instance
+// here and reuse it across every registration to avoid that leak.
+let _notifier
+
 const AirbrakePlugin = {
   name: 'airbrake',
   register: async (server, _options) => {
     // We add an instance of the Airbrake Notifier so we can send notifications via Airbrake to Errbit manually if
     // needed. It's main use is when passed in as a param to RequestNotifierLib in the RequestNotifierPlugin
-    server.app.airbrake = new Notifier(await _notifierArgs())
+    if (!_notifier) {
+      _notifier = new Notifier(await _notifierArgs())
+    }
+
+    server.app.airbrake = _notifier
 
     // When Hapi emits a request event with an error we capture the details and use Airbrake to send a request to our
     // Errbit instance


### PR DESCRIPTION
## Summary

CI wasn't reliably finishing — the `Run unit tests` step (5 minute timeout) would occasionally exceed it, and the run showed repeated `MaxListenersExceededWarning` for `unhandledRejection`/`uncaughtException`/`beforeExit`, plus real network calls out to Airbrake failing with DNS/connection errors.

Root cause: `@airbrake/node`'s `Notifier` constructor unconditionally calls `process.on('uncaughtException' | 'unhandledRejection' | 'beforeExit', ...)` and never removes these listeners. `app/plugins/airbrake.plugin.js` constructed a **new** `Notifier` every time the plugin was registered. Dozens of controller/plugin test files each spin up a real Hapi server via `app/server.js`'s `init()`, registering the real Airbrake plugin every time. Since `vitest.config.js` runs these tests with `isolate: false` (test files in a project share one module/process scope per worker, for speed), every one of those servers piled another 3 permanent listeners onto the same shared process — eventually tripping Node's listener-leak warning, with pending real (and in CI, failing) network requests keeping the process from exiting cleanly.

## Fix

`app/plugins/airbrake.plugin.js` now keeps a single module-scoped `Notifier` instance and reuses it across every `register()` call, instead of constructing a new one each time. Production only ever registers the plugin once (server starts once), so this has no behavioural effect there — it only matters for tests, where many servers get built in the same process.

## Why not mock it in tests instead?

Mocking `@airbrake/node` for tests only was the first approach tried, but nothing proved reliable given this project's constraints:

- **`vi.mock`/`vi.doMock` via a global `setupFiles` entry** — looked like it worked in isolation, but failed once combined with the full suite. Traced it to `test/plugins/airbrake.plugin.test.js`, which uses **Proxyquire** to stub `@airbrake/node` in one of its `describe` blocks. Proxyquire calls through to the real package by default (to merge properties onto the stub), and that real `require()` call appears to knock out Vitest's own mock-resolution patching for the rest of that shared worker — every test file that ran afterwards in the same worker got the real, unmocked package again. This is inherently file-order-dependent (worse with `sequence.shuffle.files: true` also enabled), so it could pass locally and still fail in CI.
- **`resolve.alias` pointing `@airbrake/node` at a `__mocks__` file** — silently never took effect; Vitest externalises node_modules dependencies by default (loaded via plain `require()`, bypassing the alias) unless explicitly inlined via `deps.inline`, which didn't help either once combined with the same Proxyquire ordering issue above.
- **A `Module._resolveFilename` preload script wired through Vitest's `execArgv`** — this one actually worked reliably (verified against the full 7116-test suite, zero leaks), but it's a much heavier, harder-to-follow piece of test infrastructure than the problem warrants.

## Why not turn `isolate` on instead?

`isolate: false` is an existing, deliberate performance choice (see the comments already in `vitest.config.js`) — it lets test files in the `parallel`/`series` projects share one module registry and global scope per worker instead of each file getting a fresh isolated context. Flipping it to `true` would have fixed the leak too (each file would get its own fresh `Notifier`, capped at 3 listeners, and they'd disappear when that file's isolated context is torn down), but at the cost of re-transforming/re-executing the whole module graph per test file — undoing a chunk of the speed-up the Vitest migration was for, across every test in the project, to work around a leak in one plugin. Fixing the actual source (a plugin that shouldn't construct a new client on every registration) is a 12-line change with no test-side cost.

## Verification

- Ran the full suite locally with `CI=true` (matching the real workflow's `pool: forks`, `maxWorkers: 2`, cache disabled): 1052 files / 7116 tests passed, zero `MaxListenersExceededWarning`, completed in ~50s (well inside the 5 minute CI timeout).
- Confirmed `test/plugins/airbrake.plugin.test.js` and `test/lib/base-notifier.lib.test.js` (which asserts on the real `Notifier`'s constructor args) still pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)