### PR TITLE
Ensure idle DB connections closed when tests run

### DIFF
--- a/knexfile.js
+++ b/knexfile.js
@@ -38,7 +38,14 @@ const test = {
   connection: {
     ...defaultConnection,
     database: DatabaseConfig.testDatabase
-  }
+  },
+  // Knex/Tarn's default pool keeps a minimum of 2 connections open at all times, and those minimum connections are
+  // exempt from idle-timeout eviction - they only close when something explicitly destroys the pool. Nothing in our
+  // test suite does that (each Vitest worker creates its own pool via db/db.js and never tears it down), so those
+  // connections stay open for the life of the worker process, and could prevent it from exiting on its own once
+  // tests finish. Setting `min: 0` here means idle connections are free to close themselves after Tarn's default
+  // idle timeout instead
+  pool: { min: 0 }
 }
 
 const production = {

--- a/knexfile.js
+++ b/knexfile.js
@@ -39,13 +39,19 @@ const test = {
     ...defaultConnection,
     database: DatabaseConfig.testDatabase
   },
-  // Knex/Tarn's default pool keeps a minimum of 2 connections open at all times, and those minimum connections are
-  // exempt from idle-timeout eviction - they only close when something explicitly destroys the pool. Nothing in our
-  // test suite does that (each Vitest worker creates its own pool via db/db.js and never tears it down), so those
-  // connections stay open for the life of the worker process, and could prevent it from exiting on its own once
-  // tests finish. Setting `min: 0` here means idle connections are free to close themselves after Tarn's default
-  // idle timeout instead
-  pool: { min: 0 }
+  pool: {
+    // Knex/Tarn's default pool keeps a minimum of 2 connections open at all times, and those minimum connections are
+    // exempt from idle-timeout eviction - they only close when something explicitly destroys the pool. Nothing in our
+    // test suite does that (each Vitest worker creates its own pool via db/db.js and never tears it down), so those
+    // connections stay open for the life of the worker process, and could prevent it from exiting on its own once
+    // tests finish. Setting `min: 0` here means idle connections are free to close themselves after Tarn's default
+    // idle timeout instead
+    min: 0,
+    // Aggressively tear down idle connections quickly. The default is 30 seconds
+    idleTimeoutMillis: 500,
+    // Frequently scan and clear out those idle connections. The default is 1 second
+    reapIntervalMillis: 250
+  }
 }
 
 const production = {

--- a/test/global-teardown.js
+++ b/test/global-teardown.js
@@ -1,0 +1,22 @@
+'use strict'
+
+/**
+ * Vitest global teardown — runs once in the main process after the full test suite
+ * @module GlobalTeardown
+ */
+
+const Database = require('./support/database.js')
+
+/**
+ * Vitest global teardown — runs once in the main process after the full test suite
+ *
+ * When loaded by Vitest via ESM interop, module.exports becomes m.default. Vitest requires the default export to be a
+ * function, so we export teardown directly rather than wrapping it in an object.
+ *
+ * @returns {Promise} resolves when the database connection has been closed
+ */
+async function teardown() {
+  await Database.closeConnection()
+}
+
+module.exports = teardown

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -32,6 +32,8 @@ const vitestConfig = {
     dir: 'test',
     // Module(s) to run once before all test suites. We use it to clean and seed the database
     globalSetup: ['test/global-setup.js'],
+    // Module(s) to run once after all test suites. We use it to ensure the database connection is closed
+    globalTeardown: ['test/global-teardown.js'],
     // Each entry is a separate Vitest project, allowing different runner settings per group of tests
     projects: [
       {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5710

We've switched our test framework from Hapi Lab to Vitest. However, we're still seeing intermittent hanging in GitHub actions.

The AI suggested the following possible cause (note - it isn't!)

-----

`knexfile.js` set no `pool` option, so Knex/Tarn use their defaults: `min: 2, max: 10`. Tarn's `min` connections are specifically exempt from idle-timeout eviction - they're kept open forever, and only close when something explicitly calls `.destroy()` on the pool.

Nothing in the test suite ever does that for the connections actually used to run tests:

- `test/global-setup.js` calls `Database.closeConnection()`, but only for the one-off connection it uses to clean/seed the database once before any workers spawn, in the main process.
- Each Vitest worker (`pool: forks`, so a separate OS process) requires `db/db.js` fresh and gets its own knex pool, used for every test file that worker runs. That pool is never destroyed anywhere.

With `min: 2`, that means every worker holds at least 2 permanently-open Postgres connections for its entire life, which is exactly the kind of open handle that stops a Node process from exiting on its own once its work is done.

-----

It even explained why Hapi Lab never hung.

-----

`@hapi/lab`'s CLI (`bin/lab`) does this at the end of every run, unconditionally:

```js
const main = async () => {
  const { code } = await require('../lib/cli').run()
  process.exit(code)
}
```

It doesn't wait for anything to close - the instant the reporter finishes printing, the process is killed, regardless of any open sockets, timers, or leaked pool connections. Vitest is more well-behaved: it waits for a worker to actually exit before considering it done. So a leak that lab was silently papering over for who knows how long is now something Vitest actually blocks on.

-----

We've confirmed the tests can still hang in GitHub actions even when setting `pool: { min: 0, max: 10 }` in `knexfile.js`. So it's not a fix, but it's prudent to do when testing. So, this change updates the Knex config used for tests to include a `pool`. We've expanded the pool config to ensure idle connections are aggressively cleaned up to keep overhead down when using multiple workers.

We've also added a `globalTeardown` module to the Vitest config that runs once after all tests have completed. This module calls `Database.closeConnection()` to ensure the pool is destroyed and all connections are closed before the process exits.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>