### PR TITLE
Fix Sinon fake timers

### DIFF
--- a/test/dal/company-contacts/setup/create-company-contact.dal.test.js
+++ b/test/dal/company-contacts/setup/create-company-contact.dal.test.js
@@ -28,7 +28,7 @@ describe('Company Contacts - Create Company Contact dal', () => {
 
     company = await CompanyHelper.add()
 
-    clock = Sinon.useFakeTimers(new Date('2021-01-01'))
+    clock = Sinon.useFakeTimers({ now: new Date('2021-01-01'), toFake: ['Date'] })
   })
 
   afterAll(async () => {

--- a/test/dal/company-contacts/setup/update-company-contact.dal.test.js
+++ b/test/dal/company-contacts/setup/update-company-contact.dal.test.js
@@ -27,7 +27,7 @@ describe('Company Contacts - Update Company Contact dal', () => {
     seedDate = new Date('2021-01-01')
     today = new Date('2025-06-02')
 
-    clock = Sinon.useFakeTimers(today)
+    clock = Sinon.useFakeTimers({ now: today, toFake: ['Date'] })
 
     licenceRole = LicenceRoleHelper.select('additionalContact')
 

--- a/test/services/bill-runs/create-bill-run-event.service.test.js
+++ b/test/services/bill-runs/create-bill-run-event.service.test.js
@@ -18,7 +18,7 @@ describe('Create Bill Run Event service', () => {
 
   beforeEach(async () => {
     testDate = new Date(2015, 9, 21, 20, 31, 57)
-    clock = Sinon.useFakeTimers(testDate)
+    clock = Sinon.useFakeTimers({ now: testDate, toFake: ['Date'] })
   })
 
   afterEach(() => {

--- a/test/services/billing-accounts/change-address.service.test.js
+++ b/test/services/billing-accounts/change-address.service.test.js
@@ -318,7 +318,7 @@ describe('Change address service', () => {
 
         const testDate = new Date(2023, 8, 4, 10, 31, 57, 2)
 
-        clock = Sinon.useFakeTimers(testDate)
+        clock = Sinon.useFakeTimers({ now: testDate, toFake: ['Date'] })
       })
 
       afterEach(() => {

--- a/test/services/company-contacts/delete-company-contact.service.test.js
+++ b/test/services/company-contacts/delete-company-contact.service.test.js
@@ -21,7 +21,7 @@ describe('Company contact - Delete company contact service', () => {
 
     today = new Date('2020-06-06')
 
-    clock = Sinon.useFakeTimers(today)
+    clock = Sinon.useFakeTimers({ now: today, toFake: ['Date'] })
   })
 
   afterEach(async () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5710

### Problem
Five test files were intermittently timing out when Vitest switched from lab to Vitest. The tests would hang and eventually abort at the timeout limit, but only on some runs.

### Root Cause
These tests used `Sinon.useFakeTimers(date)` to control the test date. By default, Sinon fakes **all** global timer functions: `setTimeout`, `setInterval`, `setImmediate`, `queueMicrotask`, `process.nextTick`, and `Date`. The fake clock is frozen — timers never fire unless manually advanced via `clock.tick()`.

The database stack (Knex's `tarn` pool and the `pg` driver) relies on these timer functions for critical operations:
- `tarn` uses `setTimeout`/`setInterval` for connection acquisition timeouts, retry scheduling, and idle-connection reaping
- `pg`/`pg-pool` use `setTimeout`, `setImmediate`, and `process.nextTick`

When a real DB query ran while all timers were frozen, the pool stalled waiting for a timer that would never fire. The test's promise never settled, and Vitest aborted at `testTimeout`.

The flakiness was due to file-order shuffling (`shuffle.files: true`). Depending on pool state from the previous test, some runs completed without needing a timer, while others got blocked.

### Solution
Restrict Sinon to fake only the `Date` object:
```javascript
// Before: freezes all timers
Sinon.useFakeTimers(new Date('2021-01-01'))

// After: freezes only Date, leaves real timers for Knex/pg
Sinon.useFakeTimers({ now: new Date('2021-01-01'), toFake: ['Date'] })