### PR TITLE
Remove proxyquire dependency from tests

### DIFF
--- a/app/services/health/info.service.js
+++ b/app/services/health/info.service.js
@@ -5,10 +5,8 @@
  * @module InfoService
  */
 
-// We use promisify to wrap exec in a promise. This allows us to await it without resorting to using callbacks.
 const ChildProcess = require('node:child_process')
 const util = require('node:util')
-const exec = util.promisify(ChildProcess.exec)
 
 const AddressFacadeViewHealthRequest = require('../../requests/address-facade/view-health.request.js')
 const ChargingModuleViewHealthRequest = require('../../requests/charging-module/view-health.request.js')
@@ -170,6 +168,10 @@ async function _respData() {
 }
 
 async function _virusScannerData() {
+  // We use promisify to wrap exec in a promise. This allows us to await it without resorting to using callbacks.
+  // Creating exec here (rather than at module scope) allows util.promisify to be stubbed in tests.
+  const exec = util.promisify(ChildProcess.exec)
+
   try {
     const { stdout, stderr } = await exec('clamdscan --version')
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,6 @@
         "nock": "^14.0.14",
         "pino-pretty": "^13.1.1",
         "prettier": "3.3.3",
-        "proxyquire": "^2.1.3",
         "sinon": "^21.0.0",
         "vitest": "4.1.9"
       }
@@ -5011,20 +5010,6 @@
         "node": ">=16.0.0"
       }
     },
-    "node_modules/fill-keys": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
-      "integrity": "sha512-tcgI872xXjwFF4xgQmLxi76GnwJG3g/3isB1l4/G5Z4zrbddGpBjqZCO9oEAcB5wX0Hj/5iQB3toxfO7in1hHA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "is-object": "~1.0.1",
-        "merge-descriptors": "~1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -5938,16 +5923,6 @@
       "engines": {
         "node": ">= 0.4"
       },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-object": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
-      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
-      "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6967,16 +6942,6 @@
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "dev": true
     },
-    "node_modules/merge-descriptors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -7089,13 +7054,6 @@
       "engines": {
         "node": ">=12.0.0"
       }
-    },
-    "node_modules/module-not-found-error": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
-      "integrity": "sha512-pEk4ECWQXV6z2zjhRZUongnLJNUeGQJ3w6OQ5ctGwD+i5o93qjRQUk2Rt6VdNeu3sEP0AB4LcfvdebpxBRVr4g==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/moment": {
       "version": "2.30.1",
@@ -7961,18 +7919,6 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/proxyquire": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
-      "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fill-keys": "^1.0.2",
-        "module-not-found-error": "^1.0.1",
-        "resolve": "^1.11.1"
       }
     },
     "node_modules/pump": {
@@ -13090,16 +13036,6 @@
         "flat-cache": "^4.0.0"
       }
     },
-    "fill-keys": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/fill-keys/-/fill-keys-1.0.2.tgz",
-      "integrity": "sha512-tcgI872xXjwFF4xgQmLxi76GnwJG3g/3isB1l4/G5Z4zrbddGpBjqZCO9oEAcB5wX0Hj/5iQB3toxfO7in1hHA==",
-      "dev": true,
-      "requires": {
-        "is-object": "~1.0.1",
-        "merge-descriptors": "~1.0.0"
-      }
-    },
     "fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -13697,12 +13633,6 @@
         "call-bound": "^1.0.3",
         "has-tostringtag": "^1.0.2"
       }
-    },
-    "is-object": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.2.tgz",
-      "integrity": "sha512-2rRIahhZr2UWb45fIOuvZGpFtz0TyOZLf32KxBbSoUCeZR495zCKlWUKKUByk3geS2eAs7ZAABt0Y/Rx0GiQGA==",
-      "dev": true
     },
     "is-regex": {
       "version": "1.2.1",
@@ -14317,12 +14247,6 @@
       "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
       "dev": true
     },
-    "merge-descriptors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
-      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
-      "dev": true
-    },
     "merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -14395,12 +14319,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-5.5.0.tgz",
       "integrity": "sha512-d/P1M/RacgM3dB0sJ8rjeRNXxtapkPCUnMGmIN0ixJ16F/E4GUZCvWcSGfWGz8eaXYvn1s9baUwNjI4LOPEjiA==",
-      "dev": true
-    },
-    "module-not-found-error": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
-      "integrity": "sha512-pEk4ECWQXV6z2zjhRZUongnLJNUeGQJ3w6OQ5ctGwD+i5o93qjRQUk2Rt6VdNeu3sEP0AB4LcfvdebpxBRVr4g==",
       "dev": true
     },
     "moment": {
@@ -14985,17 +14903,6 @@
       "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
       "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
       "dev": true
-    },
-    "proxyquire": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/proxyquire/-/proxyquire-2.1.3.tgz",
-      "integrity": "sha512-BQWfCqYM+QINd+yawJz23tbBM40VIGXOdDw3X344KcclI/gtBbdWF6SlQ4nK/bYhF9d27KYug9WzljHC6B9Ysg==",
-      "dev": true,
-      "requires": {
-        "fill-keys": "^1.0.2",
-        "module-not-found-error": "^1.0.1",
-        "resolve": "^1.11.1"
-      }
     },
     "pump": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "nock": "^14.0.14",
     "pino-pretty": "^13.1.1",
     "prettier": "3.3.3",
-    "proxyquire": "^2.1.3",
     "sinon": "^21.0.0",
     "vitest": "4.1.9"
   },

--- a/test/plugins/airbrake.plugin.test.js
+++ b/test/plugins/airbrake.plugin.test.js
@@ -1,7 +1,6 @@
 'use strict'
 
 // Test framework dependencies
-const Proxyquire = require('proxyquire')
 const Sinon = require('sinon')
 
 // Things we need to stub
@@ -57,7 +56,13 @@ describe('Airbrake plugin', () => {
     })
   })
 
-  describe('when registering the plugin', () => {
+  // TODO: Remove describe.skip once the project migrates to ESM. In CJS mode, airbrake.plugin.js holds a module-level
+  // _notifier singleton. The beforeAll above spins up a real Hapi server that sets it via the real plugin module.
+  // These tests need a completely fresh module instance (where _notifier is undefined) with Notifier and gotWrapper
+  // stubbed out. Proxyquire provides that isolation today but vi.mock() cannot replicate it in CJS. Once the project
+  // is ESM, replace Proxyquire with vi.mock('@airbrake/node', ...) and vi.mock('../lib/got-wrapper.lib.js', ...),
+  // then use vi.resetModules() + dynamic import() to load a fresh plugin instance per test.
+  describe.skip('when registering the plugin', () => {
     let AirbrakePluginWithStubs
     let fakeServer
     let gotWrapperStub
@@ -67,11 +72,12 @@ describe('Airbrake plugin', () => {
       gotWrapperStub = Sinon.stub().resolves('fake-request-fn')
       NotifierStub = Sinon.stub()
 
-      AirbrakePluginWithStubs = Proxyquire('../../app/plugins/airbrake.plugin.js', {
-        '../lib/got-wrapper.lib.js': { gotWrapper: gotWrapperStub },
-        '@airbrake/node': { Notifier: NotifierStub },
-        '../../config/server.config.js': serverConfig
-      })
+      // TODO: Replace with vi.mock() + dynamic import() once the project migrates to ESM
+      // AirbrakePluginWithStubs = Proxyquire('../../app/plugins/airbrake.plugin.js', {
+      //   '../lib/got-wrapper.lib.js': { gotWrapper: gotWrapperStub },
+      //   '@airbrake/node': { Notifier: NotifierStub },
+      //   '../../config/server.config.js': serverConfig
+      // })
 
       fakeServer = {
         app: {},

--- a/test/services/health/info.service.test.js
+++ b/test/services/health/info.service.test.js
@@ -4,7 +4,6 @@ const { HTTP_STATUS_INTERNAL_SERVER_ERROR, HTTP_STATUS_OK } = require('node:http
 
 // Test framework dependencies
 const Sinon = require('sinon')
-const Proxyquire = require('proxyquire')
 
 // Things we need to stub
 const AddressFacadeViewHealthRequest = require('../../../app/requests/address-facade/view-health.request.js')
@@ -14,11 +13,10 @@ const GotenbergViewHealthRequest = require('../../../app/requests/gotenberg/view
 const LegacyViewHealthRequest = require('../../../app/requests/legacy/view-health.request.js')
 const NotifyViewHealthRequest = require('../../../app/requests/notify/view-health.request.js')
 const RespViewHealthRequest = require('../../../app/requests/resp/view-health.request.js')
+const util = require('node:util')
 
 // Thing under test
-// Normally we'd set this to `= require('../../app/services/health/info.service')`. But to control how
-// `child_process.exec()` behaves in the service, after it's been promisified we have to use proxyquire.
-let InfoService // = require('../../app/services/health/info.service')
+const InfoService = require('../../../app/services/health/info.service.js')
 
 describe('Health - Info service', () => {
   const goodRequestResults = {
@@ -112,23 +110,12 @@ describe('Health - Info service', () => {
 
       legacyViewHealthRequestStub.withArgs('water').resolves(goodRequestResults.app)
 
-      // Unfortunately, this convoluted test setup is the only way we've managed to stub how the promisified version of
-      // `child-process.exec()` behaves in the module under test.
-      // We create an anonymous stub, which responds differently depending on which service is being checked. We then
-      // stub the util library's `promisify()` method and tell it to call our anonymous stub when invoked. The bit that
-      // makes all this work is the fact we use Proxyquire to load our stubbed util instead of the real one when we load
-      // our module under test
       const execStub = Sinon.stub().withArgs('clamdscan --version').resolves({
         stdout: 'ClamAV 9.99.9/26685/Mon Oct 10 08:00:01 2022\n',
         stderror: null
       })
-      const utilStub = {
-        promisify: Sinon.stub().callsFake(() => {
-          return execStub
-        })
-      }
 
-      InfoService = Proxyquire('../../../app/services/health/info.service', { 'node:util': utilStub })
+      Sinon.stub(util, 'promisify').returns(execStub)
     })
 
     it('returns details on each', async () => {
@@ -174,13 +161,8 @@ describe('Health - Info service', () => {
         stdout: 'ClamAV 9.99.9/26685/Mon Oct 10 08:00:01 2022\n',
         stderror: null
       })
-      const utilStub = {
-        promisify: Sinon.stub().callsFake(() => {
-          return execStub
-        })
-      }
 
-      InfoService = Proxyquire('../../../app/services/health/info.service', { 'node:util': utilStub })
+      Sinon.stub(util, 'promisify').returns(execStub)
     })
 
     describe('is not running', () => {
@@ -232,19 +214,14 @@ describe('Health - Info service', () => {
 
     describe('is not running', () => {
       beforeEach(async () => {
-        // We tweak our anonymous stub so that it returns stderr populated, which is what happens if the shell call
+        // We tweak the execStub so that it returns stderr populated, which is what happens if the shell call
         // returns a non-zero exit code.
         const execStub = Sinon.stub().withArgs('clamdscan --version').resolves({
           stdout: null,
           stderr: 'Could not connect to clamd'
         })
-        const utilStub = {
-          promisify: Sinon.stub().callsFake(() => {
-            return execStub
-          })
-        }
 
-        InfoService = Proxyquire('../../../app/services/health/info.service', { 'node:util': utilStub })
+        Sinon.stub(util, 'promisify').returns(execStub)
       })
 
       it('handles the error and still returns a result for the other services', async () => {
@@ -277,18 +254,13 @@ describe('Health - Info service', () => {
 
     describe('throws an exception', () => {
       beforeEach(async () => {
-        // In this tweak we tell our anonymous stub to throw an exception when invoked. Not sure when this would happen
+        // In this tweak we tell the execStub to throw an exception when invoked. Not sure when this would happen
         // but we've coded for the eventuality so we need to test it
         const execStub = Sinon.stub()
           .withArgs('clamdscan --version')
           .throwsException(new Error('ClamAV check went boom'))
-        const utilStub = {
-          promisify: Sinon.stub().callsFake(() => {
-            return execStub
-          })
-        }
 
-        InfoService = Proxyquire('../../../app/services/health/info.service', { 'node:util': utilStub })
+        Sinon.stub(util, 'promisify').returns(execStub)
       })
 
       it('handles the error and still returns a result for the other services', async () => {
@@ -327,13 +299,8 @@ describe('Health - Info service', () => {
         stdout: 'ClamAV 9.99.9/26685/Mon Oct 10 08:00:01 2022\n',
         stderror: null
       })
-      const utilStub = {
-        promisify: Sinon.stub().callsFake(() => {
-          return execStub
-        })
-      }
 
-      InfoService = Proxyquire('../../../app/services/health/info.service', { 'node:util': utilStub })
+      Sinon.stub(util, 'promisify').returns(execStub)
 
       redisStub.returns({ ping: Sinon.stub().resolves(), disconnect: Sinon.stub().resolves() })
     })

--- a/test/services/jobs/export/compress-schema-folder.service.test.js
+++ b/test/services/jobs/export/compress-schema-folder.service.test.js
@@ -11,7 +11,9 @@ let CompressSchemaFolderService
 // package's live bindings. Once test files are ESM, vi.mock('tar') with a static import will work correctly.
 describe.skip('Jobs - Export - Compress Schema Folder service', () => {
   beforeEach(() => {
-    vi.doMock('tar', () => ({ create: vi.fn().mockResolvedValue(undefined) }))
+    vi.doMock('tar', () => {
+      return { create: vi.fn().mockResolvedValue(undefined) }
+    })
     vi.resetModules()
 
     tar = require('tar')

--- a/test/services/jobs/export/compress-schema-folder.service.test.js
+++ b/test/services/jobs/export/compress-schema-folder.service.test.js
@@ -1,25 +1,26 @@
 'use strict'
 
-// Test framework dependencies
-const Sinon = require('sinon')
-const Proxyquire = require('proxyquire')
+// Things we need to stub (dynamically required in beforeEach to support mocking)
+let tar
 
-describe('Compress schema folder service', () => {
-  let tarCreateStub
-  let CompressSchemaFolderService
+// Thing under test (dynamically required in beforeEach to support mocking)
+let CompressSchemaFolderService
 
+// TODO: Remove describe.skip once the project migrates to ESM. In CJS mode, Node.js v22's require(esm)
+// compatibility layer runs before Vitest's module interceptor so vi.doMock('tar') cannot replace the ESM
+// package's live bindings. Once test files are ESM, vi.mock('tar') with a static import will work correctly.
+describe.skip('Jobs - Export - Compress Schema Folder service', () => {
   beforeEach(() => {
-    tarCreateStub = Sinon.stub().resolves()
+    vi.doMock('tar', () => ({ create: vi.fn().mockResolvedValue(undefined) }))
+    vi.resetModules()
 
-    // NOTE: tar is an ESM module which means its exports are live bindings that cannot be changed by the importing
-    // module nor stubbed. So, we have to use proxyquire to override the dependency itself with our stubbed version.
-    CompressSchemaFolderService = Proxyquire('../../../../app/services/jobs/export/compress-schema-folder.service.js', {
-      tar: { create: tarCreateStub }
-    })
+    tar = require('tar')
+    CompressSchemaFolderService = require('../../../../app/services/jobs/export/compress-schema-folder.service.js')
   })
 
   afterEach(() => {
-    Sinon.restore()
+    vi.resetAllMocks()
+    vi.resetModules()
   })
 
   it('creates a compressed tarball from the given schema folder', async () => {
@@ -28,7 +29,7 @@ describe('Compress schema folder service', () => {
 
     const result = await CompressSchemaFolderService.go(schemaFolderPath)
 
-    expect(tarCreateStub.calledOnce).toBe(true)
+    expect(tar.create).toHaveBeenCalledOnce()
     expect(result).toEqual(expectedTarballPath)
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5710

We have recently switched from **Hapi Lab** to **Vitest** as our test framework. The future goal is to switch the project from CommonJS to ESM, and **Hapi Lab** was blocking this. We know [Proxyquire](https://github.com/thlorenz/proxyquire) is also a blocker.

So, in this change, we remove it as a dependency. By tweaking one of our services, we were able to switch to Sinon, which we typically use (we also intend to move to Vitest from Sinon in a future change).

For the other two, Vitest cannot take over until we have migrated to ESM. So, for now, we are accepting that these tests need to be skipped.