### PR TITLE
Add quarterly periods to /data/dates endpoint

### DIFF
--- a/app/services/data/dates/dates.service.js
+++ b/app/services/data/dates/dates.service.js
@@ -12,7 +12,7 @@ const {
   determineCycleEndDate,
   determineCycleStartDate
 } = require('../../../lib/return-cycle-dates.lib.js')
-const { determineUpcomingReturnPeriods } = require('../../../lib/return-periods.lib.js')
+const { determineReturnsPeriods, determineUpcomingReturnPeriods } = require('../../../lib/return-periods.lib.js')
 
 /**
  * Returns dynamic dates used by the service, for example, current financial year and returns periods
@@ -43,6 +43,7 @@ function go() {
     endDate: determineCycleEndDate(false),
     dueDate: determineCycleDueDate(false)
   }
+  const quarterlyPeriods = determineReturnsPeriods(currentWinterReturnCycle)
   const currentFinancialYear = determineCurrentFinancialYear()
   const billingPeriods = {
     annual: DetermineBillingPeriodsService.go('annual', currentFinancialYear.endDate.getFullYear()),
@@ -59,6 +60,7 @@ function go() {
     currentFinancialYear,
     currentSummerReturnCycle,
     currentWinterReturnCycle,
+    quarterlyPeriods,
     firstReturnPeriod,
     secondReturnPeriod
   }

--- a/test/services/data/dates/dates.service.test.js
+++ b/test/services/data/dates/dates.service.test.js
@@ -34,6 +34,15 @@ describe('Data - Dates service', () => {
     expect(result.billingPeriods.twoPartSupplementary[0].endDate).toBeInstanceOf(Date)
   })
 
+  it('returns the current quarterly periods', () => {
+    const result = DatesService.go()
+
+    expect(result.quarterlyPeriods).toBeDefined()
+    expect(result.quarterlyPeriods.length).toBeGreaterThanOrEqual(4)
+    expect(result.quarterlyPeriods[0].startDate).toBeInstanceOf(Date)
+    expect(result.quarterlyPeriods[0].endDate).toBeInstanceOf(Date)
+  })
+
   it('returns the current financial year', () => {
     const result = DatesService.go()
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5722

We use the `/data/dates` endpoint in our [water-abstraction-acceptance-tests](https://github.com/DEFRA/water-abstraction-acceptance-tests). There are a number of 'dates' the service has to calculate, all dependent on the 'current date'.

Rather than duplicating all that logic in our acceptance tests, we added this endpoint so the tests can make a call to retrieve the 'current' dates for the service.

We now need the quarterly return periods for the current cycle for our tests (quarterly only follows the winter and all-year cycle). So, this change adds them to the output.