### PR TITLE
Ensure view licence returns has deterministic order

### DIFF
--- a/app/services/licences/fetch-returns.service.js
+++ b/app/services/licences/fetch-returns.service.js
@@ -39,7 +39,7 @@ async function _fetch(licenceId, page) {
     ])
     .innerJoinRelated('licence')
     .where('licence.id', licenceId)
-    .orderByRaw('return_logs.start_date desc, return_logs.return_reference::integer desc')
+    .orderByRaw('return_logs.start_date desc, return_logs.return_reference::integer desc, return_logs.end_date desc')
     .page(Number(page) - 1, DatabaseConfig.defaultPageSize)
 }
 

--- a/test/services/licences/fetch-returns.service.test.js
+++ b/test/services/licences/fetch-returns.service.test.js
@@ -18,6 +18,17 @@ describe('Licences - Fetch Returns service', () => {
 
     let returnLog = await ReturnLogHelper.add({
       dueDate: new Date('2020-06-28'),
+      endDate: new Date('2020-07-01'),
+      licenceRef: licence.licenceRef,
+      metadata: { nald: { formatId: 9999990 } },
+      returnReference: '9999990',
+      startDate: new Date('2020-02-01'),
+      status: 'due'
+    })
+    returnLogs.push(returnLog)
+
+    returnLog = await ReturnLogHelper.add({
+      dueDate: new Date('2020-06-28'),
       endDate: new Date('2020-06-01'),
       licenceRef: licence.licenceRef,
       metadata: { nald: { formatId: 9999990 } },
@@ -63,13 +74,24 @@ describe('Licences - Fetch Returns service', () => {
       const result = await FetchReturnsService.go(licence.id)
 
       expect(result).toEqual({
-        //  This should be ordered first by start date, then by return reference
+        //  This should be ordered first by start date, then by return reference, then by end date
         //
-        // - 2020-05-01 - 123
-        // - 2020-02-01 - 10334004
-        // - 2020-02-01 - 9999990
+        // - 2020-05-01 - 123      - 2020-06-01
+        // - 2020-02-01 - 10334004 - 2020-06-01
+        // - 2020-02-01 - 9999990  - 2020-06-01
+        // - 2020-02-01 - 9999990  - 2020-07-01
         //
         returns: [
+          {
+            dueDate: returnLogs[3].dueDate,
+            endDate: returnLogs[3].endDate,
+            id: returnLogs[3].id,
+            metadata: returnLogs[3].metadata,
+            returnId: returnLogs[3].returnId,
+            returnReference: returnLogs[3].returnReference,
+            startDate: returnLogs[3].startDate,
+            status: returnLogs[3].status
+          },
           {
             dueDate: returnLogs[2].dueDate,
             endDate: returnLogs[2].endDate,
@@ -81,16 +103,6 @@ describe('Licences - Fetch Returns service', () => {
             status: returnLogs[2].status
           },
           {
-            dueDate: returnLogs[1].dueDate,
-            endDate: returnLogs[1].endDate,
-            id: returnLogs[1].id,
-            metadata: returnLogs[1].metadata,
-            returnId: returnLogs[1].returnId,
-            returnReference: returnLogs[1].returnReference,
-            startDate: returnLogs[1].startDate,
-            status: returnLogs[1].status
-          },
-          {
             dueDate: returnLogs[0].dueDate,
             endDate: returnLogs[0].endDate,
             id: returnLogs[0].id,
@@ -99,9 +111,19 @@ describe('Licences - Fetch Returns service', () => {
             returnReference: returnLogs[0].returnReference,
             startDate: returnLogs[0].startDate,
             status: returnLogs[0].status
+          },
+          {
+            dueDate: returnLogs[1].dueDate,
+            endDate: returnLogs[1].endDate,
+            id: returnLogs[1].id,
+            metadata: returnLogs[1].metadata,
+            returnId: returnLogs[1].returnId,
+            returnReference: returnLogs[1].returnReference,
+            startDate: returnLogs[1].startDate,
+            status: returnLogs[1].status
           }
         ],
-        totalNumber: 3
+        totalNumber: 4
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5735

Whilst working on converting our acceptance tests from Cypress to Playwright, we encountered one that was intermittently failing.

We realised it was because, although the results were always the same, their order could change on each test run.

The updated test adds a return version partway through the previous return version. This results in the existing winter return log being marked as void and a new split log for the previous return version being created.

We end up with two return logs, both with the same reference and start date. After checking, we confirmed that these are the only things the page sorts results by, which means they can switch places each time the page loads.

This change adds `endDate` to the ordering to ensure deterministic ordering.

> You cannot have more than one return log with the same reference, start, and end dates, so we don't need to add any additional properties.