### PR TITLE
Export route arrays anonymously to satisfy Sonar default-export rule

### DIFF
--- a/app/routes/address.routes.js
+++ b/app/routes/address.routes.js
@@ -9,7 +9,7 @@ import {
   viewSelect
 } from '../controllers/address.controller.js'
 
-const routes = [
+export default [
   {
     method: 'GET',
     path: '/address/{sessionId}/postcode',
@@ -67,5 +67,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/assets.routes.js
+++ b/app/routes/assets.routes.js
@@ -1,4 +1,4 @@
-const routes = [
+export default [
   {
     method: 'GET',
     path: '/assets/all.js',
@@ -33,5 +33,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/bill-licences.routes.js
+++ b/app/routes/bill-licences.routes.js
@@ -1,6 +1,6 @@
 import { remove, submitRemove, view } from '../controllers/bill-licences.controller.js'
 
-const routes = [
+export default [
   {
     method: 'GET',
     path: '/bill-licences/{id}',
@@ -38,5 +38,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/bill-runs-review.routes.js
+++ b/app/routes/bill-runs-review.routes.js
@@ -16,7 +16,7 @@ import {
   viewReviewLicence
 } from '../controllers/bill-runs-review.controller.js'
 
-const routes = [
+export default [
   {
     method: 'GET',
     path: '/bill-runs/review/{billRunId}',
@@ -198,5 +198,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/bill-runs-setup.routes.js
+++ b/app/routes/bill-runs-setup.routes.js
@@ -13,7 +13,7 @@ import {
   year
 } from '../controllers/bill-runs-setup.controller.js'
 
-const routes = [
+export default [
   {
     method: 'GET',
     path: '/bill-runs/setup/{sessionId}/check',
@@ -159,5 +159,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/bill-runs.routes.js
+++ b/app/routes/bill-runs.routes.js
@@ -9,7 +9,7 @@ import {
   view
 } from '../controllers/bill-runs.controller.js'
 
-const routes = [
+export default [
   {
     method: 'GET',
     path: '/bill-runs',
@@ -107,5 +107,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/billing-accounts-setup.routes.js
+++ b/app/routes/billing-accounts-setup.routes.js
@@ -22,7 +22,7 @@ import {
   viewSelectCompany
 } from '../controllers/billing-accounts-setup.controller.js'
 
-const routes = [
+export default [
   {
     method: 'POST',
     path: '/billing-accounts/setup/{billingAccountId}',
@@ -276,5 +276,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/billing-accounts.routes.js
+++ b/app/routes/billing-accounts.routes.js
@@ -1,6 +1,6 @@
 import { changeAddress, view } from '../controllers/billing-accounts.controller.js'
 
-const routes = [
+export default [
   {
     method: 'GET',
     path: '/billing-accounts/{id}',
@@ -32,5 +32,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/bills.routes.js
+++ b/app/routes/bills.routes.js
@@ -1,6 +1,6 @@
 import { remove, submitRemove, view } from '../controllers/bills.controller.js'
 
-const routes = [
+export default [
   {
     method: 'GET',
     path: '/bills/{id}',
@@ -38,5 +38,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/check.routes.js
+++ b/app/routes/check.routes.js
@@ -1,6 +1,6 @@
 import { placeholder } from '../controllers/check.controller.js'
 
-const routes = [
+export default [
   {
     method: 'POST',
     path: '/check/placeholder',
@@ -17,5 +17,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/companies.routes.js
+++ b/app/routes/companies.routes.js
@@ -7,7 +7,7 @@ import {
   viewLicences
 } from '../controllers/companies.controller.js'
 
-const routes = [
+export default [
   {
     method: 'GET',
     path: '/companies/{id}/{role}',
@@ -56,5 +56,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/company-contacts-setup.routes.js
+++ b/app/routes/company-contacts-setup.routes.js
@@ -17,7 +17,7 @@ import {
   viewRestore
 } from '../controllers/company-contacts-setup.controller.js'
 
-const routes = [
+export default [
   {
     method: 'GET',
     path: '/company-contacts/setup/{companyId}',
@@ -211,5 +211,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/company-contacts.routes.js
+++ b/app/routes/company-contacts.routes.js
@@ -5,7 +5,7 @@ import {
   viewRemoveCompanyContact
 } from '../controllers/company-contacts.controller.js'
 
-const routes = [
+export default [
   {
     method: 'GET',
     path: '/company-contacts/{id}/communications',
@@ -45,5 +45,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/data.routes.js
+++ b/app/routes/data.routes.js
@@ -1,6 +1,6 @@
 import { dates, load, seed, tearDown } from '../controllers/data.controller.js'
 
-const routes = [
+export default [
   {
     method: 'GET',
     path: '/data/dates',
@@ -59,5 +59,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/health.routes.js
+++ b/app/routes/health.routes.js
@@ -1,6 +1,6 @@
 import { airbrake, database, info } from '../controllers/health.controller.js'
 
-const routes = [
+export default [
   {
     method: 'GET',
     path: '/health/airbrake',
@@ -39,5 +39,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/jobs.routes.js
+++ b/app/routes/jobs.routes.js
@@ -9,7 +9,7 @@ import {
   timeLimited
 } from '../controllers/jobs.controller.js'
 
-const routes = [
+export default [
   {
     method: 'POST',
     path: '/jobs/clean',
@@ -137,5 +137,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/licence-monitoring-station-setup.routes.js
+++ b/app/routes/licence-monitoring-station-setup.routes.js
@@ -14,7 +14,7 @@ import {
   thresholdAndUnit
 } from '../controllers/licence-monitoring-station-setup.controller.js'
 
-const routes = [
+export default [
   {
     method: 'POST',
     path: '/licence-monitoring-station/setup',
@@ -172,5 +172,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/licence-monitoring-station.routes.js
+++ b/app/routes/licence-monitoring-station.routes.js
@@ -1,6 +1,6 @@
 import { remove, submitRemove } from '../controllers/licence-monitoring-station.controller.js'
 
-const routes = [
+export default [
   {
     method: 'GET',
     path: '/licence-monitoring-station/{licenceMonitoringStationId}/remove',
@@ -26,5 +26,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/licence-versions.routes.js
+++ b/app/routes/licence-versions.routes.js
@@ -1,6 +1,6 @@
 import { view } from '../controllers/licence-versions.controller.js'
 
-const routes = [
+export default [
   {
     method: 'GET',
     path: '/licence-versions/{id}',
@@ -9,5 +9,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/licence.routes.js
+++ b/app/routes/licence.routes.js
@@ -17,7 +17,7 @@ import {
   viewSummary
 } from '../controllers/licences.controller.js'
 
-const routes = [
+export default [
   {
     method: 'GET',
     path: '/licences/{id}/bills',
@@ -165,5 +165,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/licences-end-dates.routes.js
+++ b/app/routes/licences-end-dates.routes.js
@@ -1,6 +1,6 @@
 import { check, process } from '../controllers/licences-end-dates.controller.js'
 
-const routes = [
+export default [
   {
     method: 'POST',
     path: '/licences/end-dates/check',
@@ -30,5 +30,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/manage.routes.js
+++ b/app/routes/manage.routes.js
@@ -1,6 +1,6 @@
 import { view } from '../controllers/manage.controller.js'
 
-const routes = [
+export default [
   {
     method: 'GET',
     path: '/manage',
@@ -24,5 +24,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/monitoring-station.routes.js
+++ b/app/routes/monitoring-station.routes.js
@@ -1,6 +1,6 @@
 import { licence, view } from '../controllers/monitoring-stations.controller.js'
 
-const routes = [
+export default [
   {
     method: 'GET',
     path: '/monitoring-stations/{monitoringStationId}',
@@ -16,5 +16,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/notices-setup.routes.js
+++ b/app/routes/notices-setup.routes.js
@@ -42,7 +42,7 @@ import {
   viewSelectRecipients
 } from '../controllers/notices-setup.controller.js'
 
-const routes = [
+export default [
   {
     method: 'GET',
     path: '/notices/setup/{journey}',
@@ -548,5 +548,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/notices.routes.js
+++ b/app/routes/notices.routes.js
@@ -1,6 +1,6 @@
 import { index, submitIndex, submitView, view } from '../controllers/notices.controller.js'
 
-const routes = [
+export default [
   {
     method: 'GET',
     path: '/notices',
@@ -50,5 +50,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/notifications.routes.js
+++ b/app/routes/notifications.routes.js
@@ -1,6 +1,6 @@
 import { download, returnedLetter, view } from '../controllers/notifications.controller.js'
 
-const routes = [
+export default [
   {
     method: 'GET',
     path: '/notifications/{id}/download',
@@ -30,5 +30,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/reports.routes.js
+++ b/app/routes/reports.routes.js
@@ -1,6 +1,6 @@
 import { invalidAddresses } from '../controllers/reports.controller.js'
 
-const routes = [
+export default [
   {
     method: 'GET',
     path: '/reports/invalid-addresses',
@@ -22,5 +22,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/return-logs-setup.routes.js
+++ b/app/routes/return-logs-setup.routes.js
@@ -36,7 +36,7 @@ import {
   volumes
 } from '../controllers/return-logs-setup.controller.js'
 
-const routes = [
+export default [
   {
     method: 'POST',
     path: '/return-logs/setup',
@@ -458,5 +458,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/return-logs.routes.js
+++ b/app/routes/return-logs.routes.js
@@ -1,6 +1,6 @@
 import { download, submitDetails, viewCommunications, viewDetails } from '../controllers/return-logs.controller.js'
 
-const routes = [
+export default [
   {
     method: 'GET',
     path: '/return-logs/{id}/communications',
@@ -30,5 +30,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/return-submissions.routes.js
+++ b/app/routes/return-submissions.routes.js
@@ -1,6 +1,6 @@
 import { view } from '../controllers/return-submissions.controller.js'
 
-const routes = [
+export default [
   {
     method: 'GET',
     path: '/return-submissions/{returnSubmissionId}/{yearMonth}',
@@ -9,5 +9,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/return-versions-setup.routes.js
+++ b/app/routes/return-versions-setup.routes.js
@@ -40,7 +40,7 @@ import {
   submitStartDate
 } from '../controllers/return-versions-setup.controller.js'
 
-const routes = [
+export default [
   {
     method: 'GET',
     path: '/return-versions/setup/{sessionId}/abstraction-period/{requirementIndex}',
@@ -510,5 +510,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/return-versions.routes.js
+++ b/app/routes/return-versions.routes.js
@@ -1,6 +1,6 @@
 import { view } from '../controllers/return-versions.controller.js'
 
-const routes = [
+export default [
   {
     method: 'GET',
     path: '/return-versions/{id}',
@@ -14,5 +14,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/root.routes.js
+++ b/app/routes/root.routes.js
@@ -1,6 +1,6 @@
 import { index } from '../controllers/root.controller.js'
 
-const routes = [
+export default [
   {
     method: 'GET',
     path: '/',
@@ -34,5 +34,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/search.routes.js
+++ b/app/routes/search.routes.js
@@ -1,6 +1,6 @@
 import { submitSearch, viewSearch } from '../controllers/search.controller.js'
 
-const routes = [
+export default [
   {
     method: 'GET',
     path: '/search',
@@ -16,5 +16,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/users-setup.routes.js
+++ b/app/routes/users-setup.routes.js
@@ -20,7 +20,7 @@ import {
   viewInternalPermissions
 } from '../controllers/users-setup.controller.js'
 
-const routes = [
+export default [
   {
     method: 'POST',
     path: '/users/external/{id}/setup',
@@ -250,5 +250,3 @@ const routes = [
     }
   }
 ]
-
-export default routes

--- a/app/routes/users.routes.js
+++ b/app/routes/users.routes.js
@@ -13,7 +13,7 @@ import {
   viewProfileDetails
 } from '../controllers/users.controller.js'
 
-const routes = [
+export default [
   {
     method: 'GET',
     path: '/users',
@@ -134,5 +134,3 @@ const routes = [
     }
   }
 ]
-
-export default routes


### PR DESCRIPTION
## Summary
- SonarCloud's S3317 rule ("Default export names and file names should match") flags every `*.routes.js` file because they all export a variable named `routes`, which doesn't match the filename
- Removed the intermediate named variable in all 36 route files so the array is exported directly (`export default [...]`), matching the existing pattern already used in `app/plugins/*.plugin.js`
- No changes needed elsewhere since `app/plugins/router.plugin.js` already imports each route file with its own local alias