### PR TITLE
Remove orphaned Test framework dependencies comment from test files

### DIFF
--- a/test/controllers/address.controller.test.js
+++ b/test/controllers/address.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import { postRequestOptions } from '../support/general.js'

--- a/test/controllers/bill-licences.controller.test.js
+++ b/test/controllers/bill-licences.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import { postRequestOptions } from '../support/general.js'

--- a/test/controllers/bill-runs-review.controller.test.js
+++ b/test/controllers/bill-runs-review.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import { postRequestOptions } from '../support/general.js'

--- a/test/controllers/bill-runs-setup.controller.test.js
+++ b/test/controllers/bill-runs-setup.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import { postRequestOptions } from '../support/general.js'

--- a/test/controllers/bill-runs.controller.test.js
+++ b/test/controllers/bill-runs.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import { postRequestOptions } from '../support/general.js'

--- a/test/controllers/billing-accounts-setup.controller.test.js
+++ b/test/controllers/billing-accounts-setup.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import { generateUUID } from '../../app/lib/general.lib.js'

--- a/test/controllers/billing-accounts.controller.test.js
+++ b/test/controllers/billing-accounts.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 

--- a/test/controllers/bills.controller.test.js
+++ b/test/controllers/bills.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import { postRequestOptions } from '../support/general.js'

--- a/test/controllers/check.controller.test.js
+++ b/test/controllers/check.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 

--- a/test/controllers/companies.controller.test.js
+++ b/test/controllers/companies.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import { generateUUID } from '../../app/lib/general.lib.js'

--- a/test/controllers/company-contacts-setup.controller.test.js
+++ b/test/controllers/company-contacts-setup.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import { generateUUID } from '../../app/lib/general.lib.js'

--- a/test/controllers/company-contacts.controller.test.js
+++ b/test/controllers/company-contacts.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import { generateUUID } from '../../app/lib/general.lib.js'

--- a/test/controllers/data.controller.test.js
+++ b/test/controllers/data.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 

--- a/test/controllers/health.controller.test.js
+++ b/test/controllers/health.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 

--- a/test/controllers/jobs.controller.test.js
+++ b/test/controllers/jobs.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 

--- a/test/controllers/licence-monitoring-station-setup.controller.test.js
+++ b/test/controllers/licence-monitoring-station-setup.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import { postRequestOptions } from '../support/general.js'

--- a/test/controllers/licence-monitoring-station.controller.test.js
+++ b/test/controllers/licence-monitoring-station.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import { postRequestOptions } from '../support/general.js'

--- a/test/controllers/licence-versions.controller.test.js
+++ b/test/controllers/licence-versions.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 

--- a/test/controllers/licences-end-dates.controller.test.js
+++ b/test/controllers/licences-end-dates.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 

--- a/test/controllers/licences.controller.test.js
+++ b/test/controllers/licences.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import Boom from '@hapi/boom'
 import http2 from 'node:http2'

--- a/test/controllers/manage.controller.test.js
+++ b/test/controllers/manage.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 

--- a/test/controllers/monitoring-stations.controller.test.js
+++ b/test/controllers/monitoring-stations.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 

--- a/test/controllers/notices-setup.controller.test.js
+++ b/test/controllers/notices-setup.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import { postRequestOptions } from '../support/general.js'

--- a/test/controllers/notices.controller.test.js
+++ b/test/controllers/notices.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import { generateNoticeReferenceCode } from '../../app/lib/general.lib.js'

--- a/test/controllers/notifications.controller.test.js
+++ b/test/controllers/notifications.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import * as NoticesFixture from '../support/fixtures/notices.fixture.js'

--- a/test/controllers/return-logs-setup.controller.test.js
+++ b/test/controllers/return-logs-setup.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import { postRequestOptions } from '../support/general.js'

--- a/test/controllers/return-logs.controller.test.js
+++ b/test/controllers/return-logs.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import { postRequestOptions } from '../support/general.js'

--- a/test/controllers/return-submissions.controller.test.js
+++ b/test/controllers/return-submissions.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 

--- a/test/controllers/return-versions-setup.controller.test.js
+++ b/test/controllers/return-versions-setup.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import { postRequestOptions } from '../support/general.js'

--- a/test/controllers/return-versions.controller.test.js
+++ b/test/controllers/return-versions.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 

--- a/test/controllers/search.controller.test.js
+++ b/test/controllers/search.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import { postRequestOptions } from '../support/general.js'

--- a/test/controllers/users-setup.controller.test.js
+++ b/test/controllers/users-setup.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import { generateUUID } from '../../app/lib/general.lib.js'

--- a/test/controllers/users.controller.test.js
+++ b/test/controllers/users.controller.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import FeatureFlagsConfig from '../../config/feature-flags.config.js'
 import http2 from 'node:http2'

--- a/test/dal/companies/fetch-company-crm-data.dal.test.js
+++ b/test/dal/companies/fetch-company-crm-data.dal.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CRMSeeder from '../../support/seeders/crm.seeder.js'
 

--- a/test/dal/companies/fetch-history.dal.test.js
+++ b/test/dal/companies/fetch-history.dal.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CRMContactsSeeder from '../../support/seeders/crm-contacts.seeder.js'
 import * as LicenceHelper from '../../support/helpers/licence.helper.js'

--- a/test/dal/companies/fetch-licences.dal.test.js
+++ b/test/dal/companies/fetch-licences.dal.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CRMContactsSeeder from '../../support/seeders/crm-contacts.seeder.js'
 import * as LicenceHelper from '../../support/helpers/licence.helper.js'

--- a/test/dal/company-contacts/setup/create-company-contact.dal.test.js
+++ b/test/dal/company-contacts/setup/create-company-contact.dal.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import CompanyContactModel from '../../../../app/models/company-contact.model.js'
 import * as CompanyHelper from '../../../support/helpers/company.helper.js'

--- a/test/dal/company-contacts/setup/update-company-contact.dal.test.js
+++ b/test/dal/company-contacts/setup/update-company-contact.dal.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CompanyContactHelper from '../../../support/helpers/company-contact.helper.js'
 import CompanyContactModel from '../../../../app/models/company-contact.model.js'

--- a/test/dal/users/fetch-users.dal.test.js
+++ b/test/dal/users/fetch-users.dal.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import DatabaseConfig from '../../../config/database.config.js'
 

--- a/test/dal/users/internal/create-user.dal.test.js
+++ b/test/dal/users/internal/create-user.dal.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import EventModel from '../../../../app/models/event.model.js'
 import UserGroupModel from '../../../../app/models/user-group.model.js'

--- a/test/dal/users/internal/update-user.dal.test.js
+++ b/test/dal/users/internal/update-user.dal.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import EventModel from '../../../../app/models/event.model.js'
 import * as GroupHelper from '../../../support/helpers/group.helper.js'

--- a/test/lib/base-notifier.lib.test.js
+++ b/test/lib/base-notifier.lib.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { NOTIFY_TEMPLATES } from '../../app/lib/notify-templates.lib.js'
 

--- a/test/lib/boom-notifier.lib.test.js
+++ b/test/lib/boom-notifier.lib.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Thing under test
 import BoomNotifierLib from '../../app/lib/boom-notifier.lib.js'
 

--- a/test/lib/check-page.lib.test.js
+++ b/test/lib/check-page.lib.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Thing under test
 import * as CheckPageLib from '../../app/lib/check-page.lib.js'
 

--- a/test/lib/dates.lib.test.js
+++ b/test/lib/dates.lib.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Thing under test
 import * as DateLib from '../../app/lib/dates.lib.js'
 

--- a/test/lib/general.lib.test.js
+++ b/test/lib/general.lib.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as TransactionHelper from '../support/helpers/transaction.helper.js'
 import YarStub from '../support/stubs/yar.stub.js'

--- a/test/lib/global-notifier.lib.test.js
+++ b/test/lib/global-notifier.lib.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import BaseNotifierLib from '../../app/lib/base-notifier.lib.js'
 

--- a/test/lib/request-notifier.lib.test.js
+++ b/test/lib/request-notifier.lib.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Thing under test
 import RequestNotifierLib from '../../app/lib/request-notifier.lib.js'
 

--- a/test/lib/return-cycle-dates.lib.test.js
+++ b/test/lib/return-cycle-dates.lib.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { today } from '../../app/lib/general.lib.js'
 import { returnCycleDates } from '../../app/lib/static-lookups.lib.js'

--- a/test/lib/return-periods.lib.test.js
+++ b/test/lib/return-periods.lib.test.js
@@ -1,5 +1,4 @@
 // Test framework dependencies
-
 import { returnPeriodDates } from '../../app/lib/static-lookups.lib.js'
 import * as ReturnCycleHelper from '../support/helpers/return-cycle.helper.js'
 

--- a/test/lib/submit-page.lib.test.js
+++ b/test/lib/submit-page.lib.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import YarStub from '../support/stubs/yar.stub.js'
 

--- a/test/plugins/airbrake.plugin.test.js
+++ b/test/plugins/airbrake.plugin.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import serverConfig from '../../config/server.config.js'
 

--- a/test/plugins/charging-module-token-cache.plugin.test.js
+++ b/test/plugins/charging-module-token-cache.plugin.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import * as ChargingModuleTokenRequest from '../../app/requests/charging-module/token.request.js'
 

--- a/test/plugins/error-pages.plugin.test.js
+++ b/test/plugins/error-pages.plugin.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import Boom from '@hapi/boom'

--- a/test/plugins/keep-yar-alive.plugin.test.js
+++ b/test/plugins/keep-yar-alive.plugin.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import Hapi from '@hapi/hapi'

--- a/test/plugins/notify-token-cache.plugin.test.js
+++ b/test/plugins/notify-token-cache.plugin.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import jwt from 'jsonwebtoken'
 import notifyConfig from '../../config/notify.config.js'

--- a/test/plugins/resp-token-cache.plugin.test.js
+++ b/test/plugins/resp-token-cache.plugin.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import * as RespTokenRequest from '../../app/requests/resp/token.request.js'
 

--- a/test/presenters/bill-licences/remove-bill-licence.presenter.test.js
+++ b/test/presenters/bill-licences/remove-bill-licence.presenter.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Thing under test
 import RemoveBillLicencePresenter from '../../../app/presenters/bill-licences/remove-bill-licence.presenter.js'
 

--- a/test/presenters/bill-licences/view-bill-licence.presenter.test.js
+++ b/test/presenters/bill-licences/view-bill-licence.presenter.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import * as ViewCompensationChargeTransactionPresenter from '../../../app/presenters/bill-licences/view-compensation-charge-transaction.presenter.js'
 import * as ViewMinimumChargeTransactionPresenter from '../../../app/presenters/bill-licences/view-minimum-charge-transaction.presenter.js'

--- a/test/presenters/bills/remove-bill.presenter.test.js
+++ b/test/presenters/bills/remove-bill.presenter.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import BillingAccountModel from '../../../app/models/billing-account.model.js'
 

--- a/test/presenters/licence-versions/view.presenter.test.js
+++ b/test/presenters/licence-versions/view.presenter.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'
 import { generateUUID } from '../../../app/lib/general.lib.js'

--- a/test/presenters/licences/supplementary/mark-for-supplementary-billing.presenter.test.js
+++ b/test/presenters/licences/supplementary/mark-for-supplementary-billing.presenter.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { generateUUID } from '../../../../app/lib/general.lib.js'
 import { generateLicenceRef } from '../../../support/helpers/licence.helper.js'

--- a/test/presenters/manage/manage.presenter.test.js
+++ b/test/presenters/manage/manage.presenter.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import AuthService from '../../../app/services/plugins/auth.service.js'
 import { data as users } from '../../../db/seeds/data/users.js'

--- a/test/presenters/notices/base.presenter.test.js
+++ b/test/presenters/notices/base.presenter.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as RecipientsFixture from '../../support/fixtures/recipients.fixture.js'
 

--- a/test/presenters/notices/setup/check.presenter.test.js
+++ b/test/presenters/notices/setup/check.presenter.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 import { generateNoticeReferenceCode, generateUUID } from '../../../../app/lib/general.lib.js'

--- a/test/presenters/notices/setup/prepare-paper-return.presenter.test.js
+++ b/test/presenters/notices/setup/prepare-paper-return.presenter.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as ReturnLogFixture from '../../../support/fixtures/return-logs.fixture.js'
 

--- a/test/presenters/notices/setup/preview/preview.presenter.test.js
+++ b/test/presenters/notices/setup/preview/preview.presenter.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import { generateNoticeReferenceCode } from '../../../../../app/lib/general.lib.js'

--- a/test/presenters/notices/setup/returns-period.presenter.test.js
+++ b/test/presenters/notices/setup/returns-period.presenter.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { generateNoticeReferenceCode, generateUUID } from '../../../../app/lib/general.lib.js'
 

--- a/test/presenters/paginator.presenter.test.js
+++ b/test/presenters/paginator.presenter.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import DatabaseConfig from '../../config/database.config.js'
 

--- a/test/presenters/return-submissions/view-return-submission.presenter.test.js
+++ b/test/presenters/return-submissions/view-return-submission.presenter.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Thing under test
 import ViewReturnSubmissionPresenter from '../../../app/presenters/return-submissions/view-return-submission.presenter.js'
 

--- a/test/presenters/users/index-users.presenter.test.js
+++ b/test/presenters/users/index-users.presenter.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as UsersFixture from '../../support/fixtures/users.fixture.js'
 

--- a/test/requests/address-facade.request.test.js
+++ b/test/requests/address-facade.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as BaseRequest from '../../app/requests/base.request.js'
 

--- a/test/requests/address-facade/lookup-postcode.request.test.js
+++ b/test/requests/address-facade/lookup-postcode.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as AddressFacadeRequest from '../../../app/requests/address-facade.request.js'
 

--- a/test/requests/address-facade/lookup-uprn.request.test.js
+++ b/test/requests/address-facade/lookup-uprn.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as AddressFacadeRequest from '../../../app/requests/address-facade.request.js'
 

--- a/test/requests/address-facade/view-health.request.test.js
+++ b/test/requests/address-facade/view-health.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import addressFacadeConfig from '../../../config/address-facade.config.js'
 import * as BaseRequest from '../../../app/requests/base.request.js'

--- a/test/requests/base.request.test.js
+++ b/test/requests/base.request.test.js
@@ -1,5 +1,4 @@
 // Test framework dependencies
-
 import Nock from 'nock'
 
 // Test helpers

--- a/test/requests/charging-module.request.test.js
+++ b/test/requests/charging-module.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as BaseRequest from '../../app/requests/base.request.js'
 import chargingModuleConfig from '../../config/charging-module.config.js'

--- a/test/requests/charging-module/calculate-charge.request.test.js
+++ b/test/requests/charging-module/calculate-charge.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as ChargingModuleRequest from '../../../app/requests/charging-module.request.js'
 

--- a/test/requests/charging-module/create-bill-run.request.test.js
+++ b/test/requests/charging-module/create-bill-run.request.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import * as RegionHelper from '../../support/helpers/region.helper.js'

--- a/test/requests/charging-module/create-customer-change.request.test.js
+++ b/test/requests/charging-module/create-customer-change.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as ChargingModuleRequest from '../../../app/requests/charging-module.request.js'
 

--- a/test/requests/charging-module/create-transaction.request.test.js
+++ b/test/requests/charging-module/create-transaction.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as ChargingModuleRequest from '../../../app/requests/charging-module.request.js'
 

--- a/test/requests/charging-module/delete-bill-run.request.test.js
+++ b/test/requests/charging-module/delete-bill-run.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as ChargingModuleRequest from '../../../app/requests/charging-module.request.js'
 

--- a/test/requests/charging-module/generate-bill-run.request.test.js
+++ b/test/requests/charging-module/generate-bill-run.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as ChargingModuleRequest from '../../../app/requests/charging-module.request.js'
 

--- a/test/requests/charging-module/reissue-bill.request.test.js
+++ b/test/requests/charging-module/reissue-bill.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as ChargingModuleRequest from '../../../app/requests/charging-module.request.js'
 

--- a/test/requests/charging-module/send-bill-run.request.test.js
+++ b/test/requests/charging-module/send-bill-run.request.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import ExpandedError from '../../../app/errors/expanded.error.js'

--- a/test/requests/charging-module/token.request.test.js
+++ b/test/requests/charging-module/token.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as BaseRequest from '../../../app/requests/base.request.js'
 

--- a/test/requests/charging-module/view-bill-run-status.request.test.js
+++ b/test/requests/charging-module/view-bill-run-status.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as ChargingModuleRequest from '../../../app/requests/charging-module.request.js'
 

--- a/test/requests/charging-module/view-bill-run.request.test.js
+++ b/test/requests/charging-module/view-bill-run.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as ChargingModuleRequest from '../../../app/requests/charging-module.request.js'
 

--- a/test/requests/charging-module/view-bill.request.test.js
+++ b/test/requests/charging-module/view-bill.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as ChargingModuleRequest from '../../../app/requests/charging-module.request.js'
 

--- a/test/requests/charging-module/view-customer-files.request.test.js
+++ b/test/requests/charging-module/view-customer-files.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as ChargingModuleRequest from '../../../app/requests/charging-module.request.js'
 

--- a/test/requests/charging-module/view-health.request.test.js
+++ b/test/requests/charging-module/view-health.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as ChargingModuleRequest from '../../../app/requests/charging-module.request.js'
 

--- a/test/requests/charging-module/wait-for-status.request.test.js
+++ b/test/requests/charging-module/wait-for-status.request.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import billingConfig from '../../../config/billing.config.js'

--- a/test/requests/companies-house.request.test.js
+++ b/test/requests/companies-house.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as BaseRequest from '../../app/requests/base.request.js'
 import companiesHouseConfig from '../../config/companies-house.config.js'

--- a/test/requests/companies-house/lookup-companies-house-number.request.test.js
+++ b/test/requests/companies-house/lookup-companies-house-number.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as CompaniesHouseRequest from '../../../app/requests/companies-house.request.js'
 

--- a/test/requests/companies-house/search-companies.request.test.js
+++ b/test/requests/companies-house/search-companies.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as CompaniesHouseRequest from '../../../app/requests/companies-house.request.js'
 

--- a/test/requests/gotenberg.request.test.js
+++ b/test/requests/gotenberg.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as BaseRequest from '../../app/requests/base.request.js'
 import gotenbergConfig from '../../config/gotenberg.config.js'

--- a/test/requests/gotenberg/generate-paper-return.request.test.js
+++ b/test/requests/gotenberg/generate-paper-return.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as GotenbergRequest from '../../../app/requests/gotenberg.request.js'
 

--- a/test/requests/gotenberg/view-health.request.test.js
+++ b/test/requests/gotenberg/view-health.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as BaseRequest from '../../../app/requests/base.request.js'
 import gotenbergConfig from '../../../config/gotenberg.config.js'

--- a/test/requests/legacy.request.test.js
+++ b/test/requests/legacy.request.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import legacyConfig from '../../config/legacy.config.js'

--- a/test/requests/legacy/create-bill-run.request.test.js
+++ b/test/requests/legacy/create-bill-run.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as LegacyRequest from '../../../app/requests/legacy.request.js'
 

--- a/test/requests/legacy/delete-bill-licence.request.test.js
+++ b/test/requests/legacy/delete-bill-licence.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as LegacyRequest from '../../../app/requests/legacy.request.js'
 

--- a/test/requests/legacy/delete-bill.request.test.js
+++ b/test/requests/legacy/delete-bill.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as LegacyRequest from '../../../app/requests/legacy.request.js'
 

--- a/test/requests/legacy/refresh-bill-run.request.test.js
+++ b/test/requests/legacy/refresh-bill-run.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as LegacyRequest from '../../../app/requests/legacy.request.js'
 

--- a/test/requests/legacy/view-health.request.test.js
+++ b/test/requests/legacy/view-health.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as LegacyRequest from '../../../app/requests/legacy.request.js'
 

--- a/test/requests/notify.request.test.js
+++ b/test/requests/notify.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as BaseRequest from '../../app/requests/base.request.js'
 import notifyConfig from '../../config/notify.config.js'

--- a/test/requests/notify/create-email.request.test.js
+++ b/test/requests/notify/create-email.request.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import { NOTIFY_TEMPLATES } from '../../../app/lib/notify-templates.lib.js'

--- a/test/requests/notify/create-letter.request.test.js
+++ b/test/requests/notify/create-letter.request.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import { NOTIFY_TEMPLATES } from '../../../app/lib/notify-templates.lib.js'

--- a/test/requests/notify/create-precompiled-file.request.test.js
+++ b/test/requests/notify/create-precompiled-file.request.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import { generateNoticeReferenceCode } from '../../../app/lib/general.lib.js'

--- a/test/requests/notify/generate-preview.request.test.js
+++ b/test/requests/notify/generate-preview.request.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import { NOTIFY_TEMPLATES } from '../../../app/lib/notify-templates.lib.js'

--- a/test/requests/notify/view-health.request.test.js
+++ b/test/requests/notify/view-health.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as NotifyRequest from '../../../app/requests/notify.request.js'
 

--- a/test/requests/notify/view-message-data.request.test.js
+++ b/test/requests/notify/view-message-data.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as NotifyRequest from '../../../app/requests/notify.request.js'
 

--- a/test/requests/resp.request.test.js
+++ b/test/requests/resp.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as BaseRequest from '../../app/requests/base.request.js'
 

--- a/test/requests/resp/token.request.test.js
+++ b/test/requests/resp/token.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as BaseRequest from '../../../app/requests/base.request.js'
 

--- a/test/requests/resp/view-health.request.test.js
+++ b/test/requests/resp/view-health.request.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as RespRequest from '../../../app/requests/resp.request.js'
 

--- a/test/services/address/international.service.test.js
+++ b/test/services/address/international.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { countryLookup } from '../../../app/presenters/address/base-address.presenter.js'
 import SessionModelStub from '../../support/stubs/session.stub.js'

--- a/test/services/address/manual.service.test.js
+++ b/test/services/address/manual.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../support/stubs/session.stub.js'
 

--- a/test/services/address/postcode.service.test.js
+++ b/test/services/address/postcode.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../support/stubs/session.stub.js'
 

--- a/test/services/address/select.service.test.js
+++ b/test/services/address/select.service.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../support/stubs/session.stub.js'
 

--- a/test/services/address/submit-international.service.test.js
+++ b/test/services/address/submit-international.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../support/stubs/session.stub.js'
 import { countryLookup } from '../../../app/presenters/address/base-address.presenter.js'

--- a/test/services/address/submit-manual.service.test.js
+++ b/test/services/address/submit-manual.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../support/stubs/session.stub.js'
 import { generateUUID } from '../../../app/lib/general.lib.js'

--- a/test/services/address/submit-postcode.service.test.js
+++ b/test/services/address/submit-postcode.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../support/stubs/session.stub.js'
 import { generateUUID } from '../../../app/lib/general.lib.js'

--- a/test/services/address/submit-select.service.test.js
+++ b/test/services/address/submit-select.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../support/stubs/session.stub.js'
 import http2 from 'node:http2'

--- a/test/services/bill-licences/remove-bill-licence.service.test.js
+++ b/test/services/bill-licences/remove-bill-licence.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import * as FetchBillLicenceSummaryService from '../../../app/services/bill-licences/fetch-bill-licence-summary.service.js'
 

--- a/test/services/bill-licences/submit-remove-bill-licence.service.test.js
+++ b/test/services/bill-licences/submit-remove-bill-licence.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import BillLicenceModel from '../../../app/models/bill-licence.model.js'
 import * as LegacyDeleteBillLicenceRequest from '../../../app/requests/legacy/delete-bill-licence.request.js'

--- a/test/services/bill-licences/view-bill-licence.service.test.js
+++ b/test/services/bill-licences/view-bill-licence.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import * as FetchBillLicenceService from '../../../app/services/bill-licences/fetch-bill-licence.service.js'
 import * as ViewBillLicencePresenter from '../../../app/presenters/bill-licences/view-bill-licence.presenter.js'

--- a/test/services/bill-runs/annual/process-bill-run.service.test.js
+++ b/test/services/bill-runs/annual/process-bill-run.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import BillRunError from '../../../../app/errors/bill-run.error.js'
 import * as BillRunHelper from '../../../support/helpers/bill-run.helper.js'

--- a/test/services/bill-runs/annual/process-billing-period.service.test.js
+++ b/test/services/bill-runs/annual/process-billing-period.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { determineCurrentFinancialYear, generateUUID } from '../../../../app/lib/general.lib.js'
 

--- a/test/services/bill-runs/cancel/cancel-bill-run.service.test.js
+++ b/test/services/bill-runs/cancel/cancel-bill-run.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import BillRunModel from '../../../../app/models/bill-run.model.js'
 

--- a/test/services/bill-runs/cancel/delete-bill-run.service.test.js
+++ b/test/services/bill-runs/cancel/delete-bill-run.service.test.js
@@ -1,5 +1,4 @@
 // Test framework dependencies
-
 import * as BillHelper from '../../../support/helpers/bill.helper.js'
 import * as BillLicenceHelper from '../../../support/helpers/bill-licence.helper.js'
 import * as BillRunHelper from '../../../support/helpers/bill-run.helper.js'

--- a/test/services/bill-runs/cancel/submit-cancel-bill-run.service.test.js
+++ b/test/services/bill-runs/cancel/submit-cancel-bill-run.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { pause } from '../../../../app/lib/general.lib.js'
 

--- a/test/services/bill-runs/cancel/view-cancel-bill-run.service.test.js
+++ b/test/services/bill-runs/cancel/view-cancel-bill-run.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import BillRunModel from '../../../../app/models/bill-run.model.js'
 

--- a/test/services/bill-runs/check-busy-bill-runs.service.test.js
+++ b/test/services/bill-runs/check-busy-bill-runs.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import { db } from '../../../db/db.js'
 

--- a/test/services/bill-runs/create-bill-run-event.service.test.js
+++ b/test/services/bill-runs/create-bill-run-event.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillRunHelper from '../../support/helpers/bill-run.helper.js'
 import BillRunModel from '../../../app/models/bill-run.model.js'

--- a/test/services/bill-runs/fetch-bill-runs.service.test.js
+++ b/test/services/bill-runs/fetch-bill-runs.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillRunHelper from '../../support/helpers/bill-run.helper.js'
 import DatabaseConfig from '../../../config/database.config.js'

--- a/test/services/bill-runs/generate-transactions.service.test.js
+++ b/test/services/bill-runs/generate-transactions.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as ChargeCategoryHelper from '../../support/helpers/charge-category.helper.js'
 import * as ChargeElementHelper from '../../support/helpers/charge-element.helper.js'

--- a/test/services/bill-runs/generate-two-part-tariff-bill-run.service.test.js
+++ b/test/services/bill-runs/generate-two-part-tariff-bill-run.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import ExpandedErrorError from '../../../app/errors/expanded.error.js'
 

--- a/test/services/bill-runs/handle-errored-bill-run.service.test.js
+++ b/test/services/bill-runs/handle-errored-bill-run.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillRunHelper from '../../support/helpers/bill-run.helper.js'
 

--- a/test/services/bill-runs/index-bill-runs.service.test.js
+++ b/test/services/bill-runs/index-bill-runs.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import YarStub from '../../support/stubs/yar.stub.js'
 

--- a/test/services/bill-runs/initiate-bill-run.service.test.js
+++ b/test/services/bill-runs/initiate-bill-run.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import BillRunModel from '../../../app/models/bill-run.model.js'

--- a/test/services/bill-runs/match/fetch-licences.service.test.js
+++ b/test/services/bill-runs/match/fetch-licences.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import * as FetchChargeVersionsService from '../../../../app/services/bill-runs/match/fetch-charge-versions.service.js'
 

--- a/test/services/bill-runs/match/fetch-return-logs-for-licence.service.test.js
+++ b/test/services/bill-runs/match/fetch-return-logs-for-licence.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as ReturnLogHelper from '../../../support/helpers/return-log.helper.js'
 import * as ReturnSubmissionHelper from '../../../support/helpers/return-submission.helper.js'

--- a/test/services/bill-runs/match/match-and-allocate.service.test.js
+++ b/test/services/bill-runs/match/match-and-allocate.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import * as AllocateReturnsToChargeElementService from '../../../../app/services/bill-runs/match/allocate-returns-to-charge-element.service.js'
 import * as DetermineLicenceIssuesService from '../../../../app/services/bill-runs/match/determine-licence-issues.service.js'

--- a/test/services/bill-runs/match/prepare-return-logs.service.test.js
+++ b/test/services/bill-runs/match/prepare-return-logs.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import * as FetchReturnLogsForLicenceService from '../../../../app/services/bill-runs/match/fetch-return-logs-for-licence.service.js'
 

--- a/test/services/bill-runs/reissue/fetch-bills-to-be-reissued.service.test.js
+++ b/test/services/bill-runs/reissue/fetch-bills-to-be-reissued.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillHelper from '../../../support/helpers/bill.helper.js'
 import BillModel from '../../../../app/models/bill.model.js'

--- a/test/services/bill-runs/reissue/reissue-bill.service.test.js
+++ b/test/services/bill-runs/reissue/reissue-bill.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import * as BillHelper from '../../../support/helpers/bill.helper.js'

--- a/test/services/bill-runs/reissue/reissue-bills.service.test.js
+++ b/test/services/bill-runs/reissue/reissue-bills.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillHelper from '../../../support/helpers/bill.helper.js'
 import BillModel from '../../../../app/models/bill.model.js'

--- a/test/services/bill-runs/review/fetch-bill-run-licences.service.test.js
+++ b/test/services/bill-runs/review/fetch-bill-run-licences.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillRunHelper from '../../../support/helpers/bill-run.helper.js'
 import DatabaseConfig from '../../../../config/database.config.js'

--- a/test/services/bill-runs/review/preview.service.test.js
+++ b/test/services/bill-runs/review/preview.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'

--- a/test/services/bill-runs/review/process-bill-run-post-remove.service.test.js
+++ b/test/services/bill-runs/review/process-bill-run-post-remove.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import BillRunModel from '../../../../app/models/bill-run.model.js'
 import * as GenerateTwoPartTariffBillRunService from '../../../../app/services/bill-runs/generate-two-part-tariff-bill-run.service.js'

--- a/test/services/bill-runs/review/submit-authorised.service.test.js
+++ b/test/services/bill-runs/review/submit-authorised.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/bill-runs/review/submit-edit.service.test.js
+++ b/test/services/bill-runs/review/submit-edit.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/bill-runs/review/submit-factors.service.test.js
+++ b/test/services/bill-runs/review/submit-factors.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/bill-runs/review/submit-remove.service.test.js
+++ b/test/services/bill-runs/review/submit-remove.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/bill-runs/review/submit-review-licence.service.test.js
+++ b/test/services/bill-runs/review/submit-review-licence.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 import ReviewLicenceModel from '../../../../app/models/review-licence.model.js'

--- a/test/services/bill-runs/review/submit-review.service.test.js
+++ b/test/services/bill-runs/review/submit-review.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { generateUUID } from '../../../../app/lib/general.lib.js'
 

--- a/test/services/bill-runs/review/view-authorised.service.test.js
+++ b/test/services/bill-runs/review/view-authorised.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 

--- a/test/services/bill-runs/review/view-edit.service.test.js
+++ b/test/services/bill-runs/review/view-edit.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 

--- a/test/services/bill-runs/review/view-factors.service.test.js
+++ b/test/services/bill-runs/review/view-factors.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 

--- a/test/services/bill-runs/review/view-remove.service.test.js
+++ b/test/services/bill-runs/review/view-remove.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 

--- a/test/services/bill-runs/review/view-review-charge-element.service.test.js
+++ b/test/services/bill-runs/review/view-review-charge-element.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/bill-runs/review/view-review-charge-reference.service.test.js
+++ b/test/services/bill-runs/review/view-review-charge-reference.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/bill-runs/review/view-review-licence.service.test.js
+++ b/test/services/bill-runs/review/view-review-licence.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/bill-runs/review/view-review.service.test.js
+++ b/test/services/bill-runs/review/view-review.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as RegionHelper from '../../../support/helpers/region.helper.js'
 import { generateUUID } from '../../../../app/lib/general.lib.js'

--- a/test/services/bill-runs/send-transactions.service.test.js
+++ b/test/services/bill-runs/send-transactions.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import BillRunError from '../../../app/errors/bill-run.error.js'
 import BillRunModel from '../../../app/models/bill-run.model.js'

--- a/test/services/bill-runs/send/send-bill-run.service.test.js
+++ b/test/services/bill-runs/send/send-bill-run.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import BillRunModel from '../../../../app/models/bill-run.model.js'
 

--- a/test/services/bill-runs/send/submit-send-bill-run.service.test.js
+++ b/test/services/bill-runs/send/submit-send-bill-run.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { pause } from '../../../../app/lib/general.lib.js'
 

--- a/test/services/bill-runs/send/update-invoice-numbers.service.test.js
+++ b/test/services/bill-runs/send/update-invoice-numbers.service.test.js
@@ -1,5 +1,4 @@
 // Test framework dependencies
-
 import BillModel from '../../../../app/models/bill.model.js'
 import BillRunModel from '../../../../app/models/bill-run.model.js'
 import ExpandedError from '../../../../app/errors/expanded.error.js'

--- a/test/services/bill-runs/send/view-send-bill-run.service.test.js
+++ b/test/services/bill-runs/send/view-send-bill-run.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import BillRunModel from '../../../../app/models/bill-run.model.js'
 

--- a/test/services/bill-runs/setup/check.service.test.js
+++ b/test/services/bill-runs/setup/check.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { engineTriggers } from '../../../../app/lib/static-lookups.lib.js'
 

--- a/test/services/bill-runs/setup/create.service.test.js
+++ b/test/services/bill-runs/setup/create.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import { engineTriggers } from '../../../../app/lib/static-lookups.lib.js'

--- a/test/services/bill-runs/setup/determine-blocking-annual.service.test.js
+++ b/test/services/bill-runs/setup/determine-blocking-annual.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { determineCurrentFinancialYear } from '../../../../app/lib/general.lib.js'
 import { engineTriggers } from '../../../../app/lib/static-lookups.lib.js'

--- a/test/services/bill-runs/setup/determine-blocking-bill-run.service.test.js
+++ b/test/services/bill-runs/setup/determine-blocking-bill-run.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { engineTriggers } from '../../../../app/lib/static-lookups.lib.js'
 

--- a/test/services/bill-runs/setup/determine-blocking-supplementary.service.test.js
+++ b/test/services/bill-runs/setup/determine-blocking-supplementary.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { determineCurrentFinancialYear } from '../../../../app/lib/general.lib.js'
 import { engineTriggers } from '../../../../app/lib/static-lookups.lib.js'

--- a/test/services/bill-runs/setup/determine-blocking-two-part-annual.service.test.js
+++ b/test/services/bill-runs/setup/determine-blocking-two-part-annual.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { engineTriggers } from '../../../../app/lib/static-lookups.lib.js'
 

--- a/test/services/bill-runs/setup/determine-blocking-two-part-supplementary.service.test.js
+++ b/test/services/bill-runs/setup/determine-blocking-two-part-supplementary.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { engineTriggers } from '../../../../app/lib/static-lookups.lib.js'
 

--- a/test/services/bill-runs/setup/no-licences.service.test.js
+++ b/test/services/bill-runs/setup/no-licences.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as RegionHelper from '../../../support/helpers/region.helper.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/bill-runs/setup/region.service.test.js
+++ b/test/services/bill-runs/setup/region.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as RegionHelper from '../../../support/helpers/region.helper.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/bill-runs/setup/season.service.test.js
+++ b/test/services/bill-runs/setup/season.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/bill-runs/setup/submit-check.service.test.js
+++ b/test/services/bill-runs/setup/submit-check.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { engineTriggers } from '../../../../app/lib/static-lookups.lib.js'
 

--- a/test/services/bill-runs/setup/submit-region.service.test.js
+++ b/test/services/bill-runs/setup/submit-region.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as RegionHelper from '../../../support/helpers/region.helper.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/bill-runs/setup/submit-season.service.test.js
+++ b/test/services/bill-runs/setup/submit-season.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/bill-runs/setup/submit-type.service.test.js
+++ b/test/services/bill-runs/setup/submit-type.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/bill-runs/setup/submit-year.service.test.js
+++ b/test/services/bill-runs/setup/submit-year.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/bill-runs/setup/type.service.test.js
+++ b/test/services/bill-runs/setup/type.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/bill-runs/setup/year.service.test.js
+++ b/test/services/bill-runs/setup/year.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/bill-runs/start-bill-run-process.service.test.js
+++ b/test/services/bill-runs/start-bill-run-process.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import NoBillingPeriodsError from '../../../app/errors/no-billing-periods.error.js'
 

--- a/test/services/bill-runs/submit-index-bill-runs.service.test.js
+++ b/test/services/bill-runs/submit-index-bill-runs.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things to stub
 import * as CheckBusyBillRunsService from '../../../app/services/bill-runs/check-busy-bill-runs.service.js'
 import * as FetchBillRunsService from '../../../app/services/bill-runs/fetch-bill-runs.service.js'

--- a/test/services/bill-runs/supplementary/pre-generate-billing-data.service.test.js
+++ b/test/services/bill-runs/supplementary/pre-generate-billing-data.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { generateUUID } from '../../../../app/lib/general.lib.js'
 import { generateAccountNumber } from '../../../support/helpers/billing-account.helper.js'

--- a/test/services/bill-runs/supplementary/process-bill-run.service.test.js
+++ b/test/services/bill-runs/supplementary/process-bill-run.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import BillRunError from '../../../../app/errors/bill-run.error.js'
 

--- a/test/services/bill-runs/supplementary/process-billing-period.service.test.js
+++ b/test/services/bill-runs/supplementary/process-billing-period.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillingAccountHelper from '../../../support/helpers/billing-account.helper.js'
 import BillRunError from '../../../../app/errors/bill-run.error.js'

--- a/test/services/bill-runs/tpt-supplementary/generate-bill-run.service.test.js
+++ b/test/services/bill-runs/tpt-supplementary/generate-bill-run.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import BillRunError from '../../../../app/errors/bill-run.error.js'
 

--- a/test/services/bill-runs/tpt-supplementary/process-bill-run.service.test.js
+++ b/test/services/bill-runs/tpt-supplementary/process-bill-run.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import * as AssignBillRunToLicencesService from '../../../../app/services/bill-runs/assign-bill-run-to-licences.service.js'
 import BillRunModel from '../../../../app/models/bill-run.model.js'

--- a/test/services/bill-runs/tpt-supplementary/process-billing-period.service.test.js
+++ b/test/services/bill-runs/tpt-supplementary/process-billing-period.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as RegionHelper from '../../../support/helpers/region.helper.js'
 import * as TwoPartTariffFixture from '../../../support/fixtures/two-part-tariff.fixture.js'

--- a/test/services/bill-runs/two-part-tariff/generate-bill-run.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/generate-bill-run.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import BillRunError from '../../../../app/errors/bill-run.error.js'
 

--- a/test/services/bill-runs/two-part-tariff/process-bill-run.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/process-bill-run.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import BillRunModel from '../../../../app/models/bill-run.model.js'
 import GlobalNotifierStub from '../../../support/stubs/global-notifier.stub.js'

--- a/test/services/bill-runs/two-part-tariff/process-billing-period.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/process-billing-period.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as RegionHelper from '../../../support/helpers/region.helper.js'
 import * as TwoPartTariffFixture from '../../../support/fixtures/two-part-tariff.fixture.js'

--- a/test/services/bill-runs/unassign-bill-run-to-licences.service.test.js
+++ b/test/services/bill-runs/unassign-bill-run-to-licences.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import LicenceSupplementaryYearModel from '../../../app/models/licence-supplementary-year.model.js'
 

--- a/test/services/bill-runs/unassign-licences-to-bill-run.service.test.js
+++ b/test/services/bill-runs/unassign-licences-to-bill-run.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import LicenceSupplementaryYearModel from '../../../app/models/licence-supplementary-year.model.js'
 

--- a/test/services/bill-runs/view-bill-run.service.test.js
+++ b/test/services/bill-runs/view-bill-run.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import * as FetchBillRunService from '../../../app/services/bill-runs/fetch-bill-run.service.js'
 

--- a/test/services/billing-accounts/change-address.service.test.js
+++ b/test/services/billing-accounts/change-address.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as AddressHelper from '../../support/helpers/address.helper.js'
 import AddressModel from '../../../app/models/address.model.js'

--- a/test/services/billing-accounts/send-customer-change.service.test.js
+++ b/test/services/billing-accounts/send-customer-change.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import ExpandedError from '../../../app/errors/expanded.error.js'
 

--- a/test/services/billing-accounts/setup/fetch-companies.service.test.js
+++ b/test/services/billing-accounts/setup/fetch-companies.service.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as SearchCompaniesRequest from '../../../../app/requests/companies-house/search-companies.request.js'
 

--- a/test/services/billing-accounts/setup/fetch-company.service.test.js
+++ b/test/services/billing-accounts/setup/fetch-company.service.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as LookupCompanysHouseNumberRequest from '../../../../app/requests/companies-house/lookup-companies-house-number.request.js'
 

--- a/test/services/billing-accounts/setup/initiate-session.service.test.js
+++ b/test/services/billing-accounts/setup/initiate-session.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 

--- a/test/services/billing-accounts/setup/submit-account-type.service.test.js
+++ b/test/services/billing-accounts/setup/submit-account-type.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/billing-accounts/setup/submit-account.service.test.js
+++ b/test/services/billing-accounts/setup/submit-account.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/billing-accounts/setup/submit-check.service.test.js
+++ b/test/services/billing-accounts/setup/submit-check.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as AddressHelper from '../../../support/helpers/address.helper.js'
 import * as BillingAccountAddressHelper from '../../../support/helpers/billing-account-address.helper.js'

--- a/test/services/billing-accounts/setup/submit-company-search.service.test.js
+++ b/test/services/billing-accounts/setup/submit-company-search.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/billing-accounts/setup/submit-contact-name.service.test.js
+++ b/test/services/billing-accounts/setup/submit-contact-name.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/billing-accounts/setup/submit-contact.service.test.js
+++ b/test/services/billing-accounts/setup/submit-contact.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import * as CustomersFixture from '../../../support/fixtures/customers.fixture.js'

--- a/test/services/billing-accounts/setup/submit-existing-account.service.test.js
+++ b/test/services/billing-accounts/setup/submit-existing-account.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/billing-accounts/setup/submit-existing-address.service.test.js
+++ b/test/services/billing-accounts/setup/submit-existing-address.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/billing-accounts/setup/submit-fao.service.test.js
+++ b/test/services/billing-accounts/setup/submit-fao.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/billing-accounts/setup/submit-select-company.service.test.js
+++ b/test/services/billing-accounts/setup/submit-select-company.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as FetchCompaniesService from '../../../../app/services/billing-accounts/setup/fetch-companies.service.js'
 import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'

--- a/test/services/billing-accounts/setup/view-account-type.service.test.js
+++ b/test/services/billing-accounts/setup/view-account-type.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/billing-accounts/setup/view-account.service.test.js
+++ b/test/services/billing-accounts/setup/view-account.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/billing-accounts/setup/view-check.service.test.js
+++ b/test/services/billing-accounts/setup/view-check.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/billing-accounts/setup/view-company-search.service.test.js
+++ b/test/services/billing-accounts/setup/view-company-search.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/billing-accounts/setup/view-contact-name.service.test.js
+++ b/test/services/billing-accounts/setup/view-contact-name.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/billing-accounts/setup/view-contact.service.test.js
+++ b/test/services/billing-accounts/setup/view-contact.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import * as CustomersFixture from '../../../support/fixtures/customers.fixture.js'

--- a/test/services/billing-accounts/setup/view-existing-account.service.test.js
+++ b/test/services/billing-accounts/setup/view-existing-account.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/billing-accounts/setup/view-existing-address.service.test.js
+++ b/test/services/billing-accounts/setup/view-existing-address.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/billing-accounts/setup/view-fao.service.test.js
+++ b/test/services/billing-accounts/setup/view-fao.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/billing-accounts/setup/view-select-company.service.test.js
+++ b/test/services/billing-accounts/setup/view-select-company.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/billing-accounts/view-billing-account.service.test.js
+++ b/test/services/billing-accounts/view-billing-account.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillingAccountsFixture from '../../support/fixtures/billing-accounts.fixture.js'
 import { generateUUID } from '../../../app/lib/general.lib.js'

--- a/test/services/bills/remove-bill.service.test.js
+++ b/test/services/bills/remove-bill.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import BillingAccountModel from '../../../app/models/billing-account.model.js'
 

--- a/test/services/bills/submit-remove-bill.service.test.js
+++ b/test/services/bills/submit-remove-bill.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import BillModel from '../../../app/models/bill.model.js'
 import * as LegacyDeleteBillRequest from '../../../app/requests/legacy/delete-bill.request.js'

--- a/test/services/bills/view-bill.service.test.js
+++ b/test/services/bills/view-bill.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import BillingAccountModel from '../../../app/models/billing-account.model.js'
 import FetchBillService from '../../../app/services/bills/fetch-bill-service.js'

--- a/test/services/companies/view-billing-accounts.service.test.js
+++ b/test/services/companies/view-billing-accounts.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CustomersFixtures from '../../support/fixtures/customers.fixture.js'
 

--- a/test/services/companies/view-company-with-address.service.test.js
+++ b/test/services/companies/view-company-with-address.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CustomersFixtures from '../../support/fixtures/customers.fixture.js'
 

--- a/test/services/companies/view-company.service.test.js
+++ b/test/services/companies/view-company.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CustomersFixtures from '../../support/fixtures/customers.fixture.js'
 

--- a/test/services/companies/view-contacts.service.test.js
+++ b/test/services/companies/view-contacts.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CustomersFixtures from '../../support/fixtures/customers.fixture.js'
 import { generateUUID } from '../../../app/lib/general.lib.js'

--- a/test/services/companies/view-history.service.test.js
+++ b/test/services/companies/view-history.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CustomersFixtures from '../../support/fixtures/customers.fixture.js'
 

--- a/test/services/companies/view-licences.service.test.js
+++ b/test/services/companies/view-licences.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CustomersFixtures from '../../support/fixtures/customers.fixture.js'
 import LicenceModel from '../../../app/models/licence.model.js'

--- a/test/services/company-contacts/delete-company-contact.service.test.js
+++ b/test/services/company-contacts/delete-company-contact.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CompanyContactHelper from '../../support/helpers/company-contact.helper.js'
 import CompanyContactModel from '../../../app/models/company-contact.model.js'

--- a/test/services/company-contacts/setup/initiate-edit-session.service.test.js
+++ b/test/services/company-contacts/setup/initiate-edit-session.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import CompanyContactModel from '../../../../app/models/company-contact.model.js'
 import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'

--- a/test/services/company-contacts/setup/initiate-session.service.test.js
+++ b/test/services/company-contacts/setup/initiate-session.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import SessionModel from '../../../../app/models/session.model.js'

--- a/test/services/company-contacts/setup/submit-abstraction-alerts.service.test.js
+++ b/test/services/company-contacts/setup/submit-abstraction-alerts.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/company-contacts/setup/submit-cancel.service.test.js
+++ b/test/services/company-contacts/setup/submit-cancel.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/company-contacts/setup/submit-check.service.test.js
+++ b/test/services/company-contacts/setup/submit-check.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import SessionModel from '../../../../app/models/session.model.js'

--- a/test/services/company-contacts/setup/submit-contact-email.service.test.js
+++ b/test/services/company-contacts/setup/submit-contact-email.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/company-contacts/setup/submit-contact-name.service.test.js
+++ b/test/services/company-contacts/setup/submit-contact-name.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/company-contacts/setup/submit-licences.service.test.js
+++ b/test/services/company-contacts/setup/submit-licences.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/company-contacts/setup/submit-restore.service.test.js
+++ b/test/services/company-contacts/setup/submit-restore.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/company-contacts/setup/view-abstraction-alerts.service.test.js
+++ b/test/services/company-contacts/setup/view-abstraction-alerts.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/company-contacts/setup/view-cancel.service.test.js
+++ b/test/services/company-contacts/setup/view-cancel.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/company-contacts/setup/view-check.service.test.js
+++ b/test/services/company-contacts/setup/view-check.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/company-contacts/setup/view-contact-email.service.test.js
+++ b/test/services/company-contacts/setup/view-contact-email.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/company-contacts/setup/view-contact-name.service.test.js
+++ b/test/services/company-contacts/setup/view-contact-name.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/company-contacts/setup/view-licences.service.test.js
+++ b/test/services/company-contacts/setup/view-licences.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/company-contacts/setup/view-restore.service.test.js
+++ b/test/services/company-contacts/setup/view-restore.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/company-contacts/submit-remove-company-contact.service.test.js
+++ b/test/services/company-contacts/submit-remove-company-contact.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CustomersFixtures from '../../support/fixtures/customers.fixture.js'
 import YarStub from '../../support/stubs/yar.stub.js'

--- a/test/services/company-contacts/view-communications.service.test.js
+++ b/test/services/company-contacts/view-communications.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CustomersFixtures from '../../support/fixtures/customers.fixture.js'
 import { generateUUID } from '../../../app/lib/general.lib.js'

--- a/test/services/company-contacts/view-contact-details.service.test.js
+++ b/test/services/company-contacts/view-contact-details.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CustomersFixtures from '../../support/fixtures/customers.fixture.js'
 import YarStub from '../../support/stubs/yar.stub.js'

--- a/test/services/company-contacts/view-remove-company-contact.service.test.js
+++ b/test/services/company-contacts/view-remove-company-contact.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as CustomersFixtures from '../../support/fixtures/customers.fixture.js'
 

--- a/test/services/data/seed/seed.service.test.js
+++ b/test/services/data/seed/seed.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import { db } from '../../../../db/db.js'
 

--- a/test/services/data/tear-down/tear-down.service.test.js
+++ b/test/services/data/tear-down/tear-down.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import * as CrmSchemaService from '../../../../app/services/data/tear-down/crm-schema.service.js'
 import GlobalNotifierStub from '../../../support/stubs/global-notifier.stub.js'

--- a/test/services/health/info.service.test.js
+++ b/test/services/health/info.service.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Things we need to stub
 import * as AddressFacadeViewHealthRequest from '../../../app/requests/address-facade/view-health.request.js'
 import * as ChargingModuleViewHealthRequest from '../../../app/requests/charging-module/view-health.request.js'

--- a/test/services/jobs/clean/clean-empty-bill-runs.service.test.js
+++ b/test/services/jobs/clean/clean-empty-bill-runs.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import BillRunModel from '../../../../app/models/bill-run.model.js'
 

--- a/test/services/jobs/clean/clean-empty-void-return-logs.service.test.js
+++ b/test/services/jobs/clean/clean-empty-void-return-logs.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as ReturnLogHelper from '../../../support/helpers/return-log.helper.js'
 import ReturnLogModel from '../../../../app/models/return-log.model.js'

--- a/test/services/jobs/clean/clean-expired-sessions.service.test.js
+++ b/test/services/jobs/clean/clean-expired-sessions.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as SessionHelper from '../../../support/helpers/session.helper.js'
 import SessionModel from '../../../../app/models/session.model.js'

--- a/test/services/jobs/clean/clean-incomplete-company-contacts.service.test.js
+++ b/test/services/jobs/clean/clean-incomplete-company-contacts.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as LicenceEntityHelper from '../../../support/helpers/licence-entity.helper.js'
 import * as LicenceRoleHelper from '../../../support/helpers/licence-role.helper.js'

--- a/test/services/jobs/clean/clean-orphaned-contacts.service.test.js
+++ b/test/services/jobs/clean/clean-orphaned-contacts.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillingAccountAddressHelper from '../../../support/helpers/billing-account-address.helper.js'
 import * as CompanyContactHelper from '../../../support/helpers/company-contact.helper.js'

--- a/test/services/jobs/clean/process-clean.service.test.js
+++ b/test/services/jobs/clean/process-clean.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import * as CleanEmptyBillRunsService from '../../../../app/services/jobs/clean/clean-empty-bill-runs.service.js'
 import * as CleanEmptyVoidReturnLogsService from '../../../../app/services/jobs/clean/clean-empty-void-return-logs.service.js'

--- a/test/services/jobs/customer-files/process-customer-files.service.test.js
+++ b/test/services/jobs/customer-files/process-customer-files.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import * as BillingAccountHelper from '../../../support/helpers/billing-account.helper.js'

--- a/test/services/jobs/export/delete-files.service.test.js
+++ b/test/services/jobs/export/delete-files.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import fs from 'fs'
 import path from 'path'

--- a/test/services/jobs/export/export-table.service.test.js
+++ b/test/services/jobs/export/export-table.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import * as FetchTableService from '../../../../app/services/jobs/export/fetch-table.service.js'
 import * as WriteTableToFileService from '../../../../app/services/jobs/export/write-table-to-file.service.js'

--- a/test/services/jobs/export/export.service.test.js
+++ b/test/services/jobs/export/export.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import GlobalNotifierStub from '../../../support/stubs/global-notifier.stub.js'
 import * as SchemaExportService from '../../../../app/services/jobs/export/schema-export.service.js'

--- a/test/services/jobs/export/schema-export.service.test.js
+++ b/test/services/jobs/export/schema-export.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import * as CompressSchemaFolderService from '../../../../app/services/jobs/export/compress-schema-folder.service.js'
 import * as DeleteFilesService from '../../../../app/services/jobs/export/delete-files.service.js'

--- a/test/services/jobs/export/send-to-s3-bucket.service.test.js
+++ b/test/services/jobs/export/send-to-s3-bucket.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import { S3Client, PutObjectCommand } from '@aws-sdk/client-s3'
 

--- a/test/services/jobs/export/write-table-to-file.service.test.js
+++ b/test/services/jobs/export/write-table-to-file.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { data as chargeCategories } from '../../../../db/seeds/data/charge-categories.js'
 import { db } from '../../../../db/db.js'

--- a/test/services/jobs/licence-updates/process-licence-updates.service.test.js
+++ b/test/services/jobs/licence-updates/process-licence-updates.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { generateUUID } from '../../../../app/lib/general.lib.js'
 import WorkflowModel from '../../../../app/models/workflow.model.js'

--- a/test/services/jobs/notification-status/fetch-notifications.service.test.js
+++ b/test/services/jobs/notification-status/fetch-notifications.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as NoticesFixture from '../../../support/fixtures/notices.fixture.js'
 import * as NotificationHelper from '../../../support/helpers/notification.helper.js'

--- a/test/services/jobs/notification-status/process-notification-status.service.test.js
+++ b/test/services/jobs/notification-status/process-notification-status.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as NoticesFixture from '../../../support/fixtures/notices.fixture.js'
 import * as NotificationsFixture from '../../../support/fixtures/notifications.fixture.js'

--- a/test/services/jobs/notification-status/send-alternate-notices.service.test.js
+++ b/test/services/jobs/notification-status/send-alternate-notices.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { generateUUID } from '../../../../app/lib/general.lib.js'
 

--- a/test/services/jobs/renewal-invitations/process-renewal-invitations.service.test.js
+++ b/test/services/jobs/renewal-invitations/process-renewal-invitations.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import GlobalNotifierStub from '../../../support/stubs/global-notifier.stub.js'
 import * as SendRenewalInvitations from '../../../../app/services/jobs/renewal-invitations/send-renewal-invitations.service.js'

--- a/test/services/jobs/renewal-invitations/send-renewal-invitations.service.test.js
+++ b/test/services/jobs/renewal-invitations/send-renewal-invitations.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { generateLicenceRef } from '../../../support/helpers/licence.helper.js'
 import { generateUUID } from '../../../../app/lib/general.lib.js'

--- a/test/services/jobs/return-logs/check-return-cycle.service.test.js
+++ b/test/services/jobs/return-logs/check-return-cycle.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things to stub
 import ReturnCycleModel from '../../../../app/models/return-cycle.model.js'
 

--- a/test/services/jobs/return-logs/process-return-logs.service.test.js
+++ b/test/services/jobs/return-logs/process-return-logs.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as ReturnCyclesFixture from '../../../support/fixtures/return-cycles.fixture.js'
 import * as ReturnRequirementsFixture from '../../../support/fixtures/return-requirements.fixture.js'

--- a/test/services/jobs/time-limited/process-time-limited-licences.service.test.js
+++ b/test/services/jobs/time-limited/process-time-limited-licences.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import WorkflowModel from '../../../../app/models/workflow.model.js'
 import { generateUUID } from '../../../../app/lib/general.lib.js'

--- a/test/services/licence-monitoring-station/remove.service.test.js
+++ b/test/services/licence-monitoring-station/remove.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import * as FetchLicenceMonitoringStationService from '../../../app/services/licence-monitoring-station/fetch-licence-monitoring-station.service.js'
 

--- a/test/services/licence-monitoring-station/setup/abstraction-period.service.test.js
+++ b/test/services/licence-monitoring-station/setup/abstraction-period.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/licence-monitoring-station/setup/check.service.test.js
+++ b/test/services/licence-monitoring-station/setup/check.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/licence-monitoring-station/setup/full-condition.service.test.js
+++ b/test/services/licence-monitoring-station/setup/full-condition.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/licence-monitoring-station/setup/initate-session.service.test.js
+++ b/test/services/licence-monitoring-station/setup/initate-session.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as MonitoringStationHelper from '../../../support/helpers/monitoring-station.helper.js'
 import SessionModel from '../../../../app/models/session.model.js'

--- a/test/services/licence-monitoring-station/setup/licence-number.service.test.js
+++ b/test/services/licence-monitoring-station/setup/licence-number.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/licence-monitoring-station/setup/stop-or-reduce.service.test.js
+++ b/test/services/licence-monitoring-station/setup/stop-or-reduce.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/licence-monitoring-station/setup/submit-abstraction-period.service.test.js
+++ b/test/services/licence-monitoring-station/setup/submit-abstraction-period.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/licence-monitoring-station/setup/submit-check.service.test.js
+++ b/test/services/licence-monitoring-station/setup/submit-check.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import LicenceMonitoringStationModel from '../../../../app/models/licence-monitoring-station.model.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/licence-monitoring-station/setup/submit-full-condition.service.test.js
+++ b/test/services/licence-monitoring-station/setup/submit-full-condition.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as LicenceVersionPurposeConditionHelper from '../../../support/helpers/licence-version-purpose-condition.helper.js'
 import * as LicenceVersionPurposeHelper from '../../../support/helpers/licence-version-purpose.helper.js'

--- a/test/services/licence-monitoring-station/setup/submit-licence-number.service.test.js
+++ b/test/services/licence-monitoring-station/setup/submit-licence-number.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import LicenceModel from '../../../../app/models/licence.model.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/licence-monitoring-station/setup/submit-stop-or-reduce.service.test.js
+++ b/test/services/licence-monitoring-station/setup/submit-stop-or-reduce.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/licence-monitoring-station/setup/submit-threshold-and-unit.service.test.js
+++ b/test/services/licence-monitoring-station/setup/submit-threshold-and-unit.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/licence-monitoring-station/setup/threshold-and-unit.service.test.js
+++ b/test/services/licence-monitoring-station/setup/threshold-and-unit.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/licence-monitoring-station/submit-remove.service.test.js
+++ b/test/services/licence-monitoring-station/submit-remove.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as LicenceMonitoringStationHelper from '../../support/helpers/licence-monitoring-station.helper.js'
 import YarStub from '../../support/stubs/yar.stub.js'

--- a/test/services/licence-versions/view.service.test.js
+++ b/test/services/licence-versions/view.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'
 

--- a/test/services/licences/end-dates/check-all-licence-end-dates.service.test.js
+++ b/test/services/licences/end-dates/check-all-licence-end-dates.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import * as FetchLicencesService from '../../../../app/services/licences/end-dates/fetch-licences.service.js'
 import GlobalNotifierStub from '../../../support/stubs/global-notifier.stub.js'

--- a/test/services/licences/end-dates/check-licence-end-dates.service.test.js
+++ b/test/services/licences/end-dates/check-licence-end-dates.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { generateUUID } from '../../../../app/lib/general.lib.js'
 import LicenceEndDateChangeModel from '../../../../app/models/licence-end-date-change.model.js'

--- a/test/services/licences/end-dates/process-licence-end-date-changes.service.test.js
+++ b/test/services/licences/end-dates/process-licence-end-date-changes.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as LicenceEndDateChangeHelper from '../../../support/helpers/licence-end-date-change.helper.js'
 

--- a/test/services/licences/fetch-licence-crm-data.service.test.js
+++ b/test/services/licences/fetch-licence-crm-data.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import DatabaseConfig from '../../../config/database.config.js'
 import * as CRMSeeder from '../../support/seeders/crm.seeder.js'

--- a/test/services/licences/supplementary/determine-billing-years.service.test.js
+++ b/test/services/licences/supplementary/determine-billing-years.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Thing under test
 import DetermineBillingYearsService from '../../../../app/services/licences/supplementary/determine-billing-years.service.js'
 

--- a/test/services/licences/supplementary/determine-charge-version-flags.service.test.js
+++ b/test/services/licences/supplementary/determine-charge-version-flags.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import * as GeneralLib from '../../../../app/lib/general.lib.js'
 import * as FetchChargeVersionBillingDataService from '../../../../app/services/licences/supplementary/fetch-charge-version-billing-data.service.js'

--- a/test/services/licences/supplementary/determine-imported-licence-flags.service.test.js
+++ b/test/services/licences/supplementary/determine-imported-licence-flags.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as FetchExistingLicenceDetailsService from '../../../../app/services/licences/supplementary/fetch-existing-licence-details.service.js'
 

--- a/test/services/licences/supplementary/determine-workflow-flags.service.test.js
+++ b/test/services/licences/supplementary/determine-workflow-flags.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillRunHelper from '../../../support/helpers/bill-run.helper.js'
 import { determineCurrentFinancialYear } from '../../../../app/lib/general.lib.js'

--- a/test/services/licences/supplementary/persist-supplementary-billing-flags.service.test.js
+++ b/test/services/licences/supplementary/persist-supplementary-billing-flags.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as LicenceHelper from '../../../support/helpers/licence.helper.js'
 import LicenceModel from '../../../../app/models/licence.model.js'

--- a/test/services/licences/supplementary/process-billing-flag.service.test.js
+++ b/test/services/licences/supplementary/process-billing-flag.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import * as DetermineBillLicenceFlagsService from '../../../../app/services/licences/supplementary/determine-bill-licence-flags.service.js'
 import * as DetermineChargeVersionFlagsService from '../../../../app/services/licences/supplementary/determine-charge-version-flags.service.js'

--- a/test/services/licences/supplementary/submit-mark-for-supplementary-billing.service.test.js
+++ b/test/services/licences/supplementary/submit-mark-for-supplementary-billing.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as LicenceHelper from '../../../support/helpers/licence.helper.js'
 import LicenceModel from '../../../../app/models/licence.model.js'

--- a/test/services/licences/supplementary/view-mark-for-supplementary-billing.service.test.js
+++ b/test/services/licences/supplementary/view-mark-for-supplementary-billing.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as LicenceHelper from '../../../support/helpers/licence.helper.js'
 

--- a/test/services/licences/view-bills.service.test.js
+++ b/test/services/licences/view-bills.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { generateUUID } from '../../../app/lib/general.lib.js'
 import { generateLicenceRef } from '../../support/helpers/licence.helper.js'

--- a/test/services/licences/view-communications.service.test.js
+++ b/test/services/licences/view-communications.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test Helpers
 import * as NoticesFixture from '../../support/fixtures/notices.fixture.js'
 import * as NotificationsFixture from '../../support/fixtures/notifications.fixture.js'

--- a/test/services/licences/view-conditions.service.test.js
+++ b/test/services/licences/view-conditions.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'
 

--- a/test/services/licences/view-contact-details.service.test.js
+++ b/test/services/licences/view-contact-details.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { generateLicenceRef } from '../../support/helpers/licence.helper.js'
 import { generateUUID } from '../../../app/lib/general.lib.js'

--- a/test/services/licences/view-history.service.test.js
+++ b/test/services/licences/view-history.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import LicenceVersionModel from '../../../app/models/licence-version.model.js'
 import { generateLicenceRef } from '../../support/helpers/licence.helper.js'

--- a/test/services/licences/view-points.service.test.js
+++ b/test/services/licences/view-points.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'
 

--- a/test/services/licences/view-purposes.service.test.js
+++ b/test/services/licences/view-purposes.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'
 

--- a/test/services/licences/view-returns.service.test.js
+++ b/test/services/licences/view-returns.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { generateLicenceRef } from '../../support/helpers/licence.helper.js'
 

--- a/test/services/licences/view-set-up.service.test.js
+++ b/test/services/licences/view-set-up.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import ReturnVersionModel from '../../../app/models/return-version.model.js'
 import * as ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'

--- a/test/services/licences/view-summary.service.test.js
+++ b/test/services/licences/view-summary.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import LicenceModel from '../../../app/models/licence.model.js'
 import { generateLicenceRef } from '../../support/helpers/licence.helper.js'

--- a/test/services/monitoring-stations/view-licence.service.test.js
+++ b/test/services/monitoring-stations/view-licence.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { generateUUID } from '../../../app/lib/general.lib.js'
 import { licenceEnds } from '../../support/fixtures/licence.fixture.js'

--- a/test/services/monitoring-stations/view.service.test.js
+++ b/test/services/monitoring-stations/view.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import YarStub from '../../support/stubs/yar.stub.js'
 

--- a/test/services/notices/fetch-notices.service.test.js
+++ b/test/services/notices/fetch-notices.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import DatabaseConfig from '../../../config/database.config.js'
 

--- a/test/services/notices/index-notices.service.test.js
+++ b/test/services/notices/index-notices.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as NoticesFixture from '../../support/fixtures/notices.fixture.js'
 import YarStub from '../../support/stubs/yar.stub.js'

--- a/test/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { generateUUID } from '../../../../../app/lib/general.lib.js'
 import { licenceEnds } from '../../../../support/fixtures/licence.fixture.js'

--- a/test/services/notices/setup/abstraction-alerts/process-remove-threshold.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/process-remove-threshold.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'

--- a/test/services/notices/setup/abstraction-alerts/submit-alert-email-address.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/submit-alert-email-address.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'

--- a/test/services/notices/setup/abstraction-alerts/submit-alert-thresholds.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/submit-alert-thresholds.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'

--- a/test/services/notices/setup/abstraction-alerts/submit-alert-type.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/submit-alert-type.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'

--- a/test/services/notices/setup/abstraction-alerts/submit-cancel-alerts.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/submit-cancel-alerts.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 

--- a/test/services/notices/setup/abstraction-alerts/submit-check-licence-matches.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/submit-check-licence-matches.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'

--- a/test/services/notices/setup/abstraction-alerts/view-alert-email-address.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/view-alert-email-address.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'

--- a/test/services/notices/setup/abstraction-alerts/view-alert-thresholds.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/view-alert-thresholds.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'

--- a/test/services/notices/setup/abstraction-alerts/view-alert-type.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/view-alert-type.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'

--- a/test/services/notices/setup/abstraction-alerts/view-cancel-alerts.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/view-cancel-alerts.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'

--- a/test/services/notices/setup/abstraction-alerts/view-check-licence-matches.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/view-check-licence-matches.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'

--- a/test/services/notices/setup/create-alternate-renewal-notice.service.test.js
+++ b/test/services/notices/setup/create-alternate-renewal-notice.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import EventModel from '../../../../app/models/event.model.js'
 import * as NoticesFixture from '../../../support/fixtures/notices.fixture.js'

--- a/test/services/notices/setup/create-alternate-returns-notice.service.test.js
+++ b/test/services/notices/setup/create-alternate-returns-notice.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import EventModel from '../../../../app/models/event.model.js'
 import * as NoticesFixture from '../../../support/fixtures/notices.fixture.js'

--- a/test/services/notices/setup/determine-returns-period.service.test.js
+++ b/test/services/notices/setup/determine-returns-period.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Thing under test
 import DetermineReturnsPeriodService from '../../../../app/services/notices/setup/determine-returns-period.service.js'
 

--- a/test/services/notices/setup/fetch-recipients.service.test.js
+++ b/test/services/notices/setup/fetch-recipients.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 import { NoticeJourney, NoticeType } from '../../../../app/lib/static-lookups.lib.js'

--- a/test/services/notices/setup/initiate-session.service.test.js
+++ b/test/services/notices/setup/initiate-session.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as AbstractionAlertSessionData from '../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 import SessionModel from '../../../../app/models/session.model.js'

--- a/test/services/notices/setup/prepare-paper-return.service.test.js
+++ b/test/services/notices/setup/prepare-paper-return.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as ReturnLogFixture from '../../../support/fixtures/return-logs.fixture.js'
 import { formatLongDate } from '../../../../app/presenters/base.presenter.js'

--- a/test/services/notices/setup/preview/view-preview-check-alert.service.test.js
+++ b/test/services/notices/setup/preview/view-preview-check-alert.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as AbstractionAlertSessionDataFixture from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 import * as RecipientsFixture from '../../../../support/fixtures/recipients.fixture.js'

--- a/test/services/notices/setup/preview/view-preview-check-paper-return.service.test.js
+++ b/test/services/notices/setup/preview/view-preview-check-paper-return.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 import { generateNoticeReferenceCode, generateUUID } from '../../../../../app/lib/general.lib.js'

--- a/test/services/notices/setup/preview/view-preview.service.test.js
+++ b/test/services/notices/setup/preview/view-preview.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 

--- a/test/services/notices/setup/process-add-recipient.service.test.js
+++ b/test/services/notices/setup/process-add-recipient.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as AddressHelper from '../../../support/helpers/address.helper.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/notices/setup/process-download-recipients.service.test.js
+++ b/test/services/notices/setup/process-download-recipients.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as NoticeSessionFixture from '../../../support/fixtures/notice-session.fixture.js'
 import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'

--- a/test/services/notices/setup/process-preview-paper-return.service.test.js
+++ b/test/services/notices/setup/process-preview-paper-return.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 import * as ReturnLogFixture from '../../../support/fixtures/return-logs.fixture.js'

--- a/test/services/notices/setup/renewal-notice/process-licence-submission.service.test.js
+++ b/test/services/notices/setup/renewal-notice/process-licence-submission.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Helpers
 import LicenceModel from '../../../../../app/models/licence.model.js'
 import { generateUUID } from '../../../../../app/lib/general.lib.js'

--- a/test/services/notices/setup/returns-notice/process-licence-submission.service.test.js
+++ b/test/services/notices/setup/returns-notice/process-licence-submission.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import * as CheckLicenceExistsDal from '../../../../../app/dal/notices/setup/check-licence-exists.dal.js'
 import * as FetchDueReturnsForLicenceService from '../../../../../app/services/notices/setup/returns-notice/fetch-due-returns-for-licence.service.js'

--- a/test/services/notices/setup/send/renewal-invitation-alternate-notice.service.test.js
+++ b/test/services/notices/setup/send/renewal-invitation-alternate-notice.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as NoticesFixture from '../../../../support/fixtures/notices.fixture.js'
 import * as NotificationsFixture from '../../../../support/fixtures/notifications.fixture.js'

--- a/test/services/notices/setup/send/returns-invitation-alternate-notice.service.test.js
+++ b/test/services/notices/setup/send/returns-invitation-alternate-notice.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as NoticesFixture from '../../../../support/fixtures/notices.fixture.js'
 import * as NotificationsFixture from '../../../../support/fixtures/notifications.fixture.js'

--- a/test/services/notices/setup/send/send-alternate-notice.service.test.js
+++ b/test/services/notices/setup/send/send-alternate-notice.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as NoticesFixture from '../../../../support/fixtures/notices.fixture.js'
 import * as NotificationsFixture from '../../../../support/fixtures/notifications.fixture.js'

--- a/test/services/notices/setup/send/send-email-notification.service.test.js
+++ b/test/services/notices/setup/send/send-email-notification.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as NotificationsFixture from '../../../../support/fixtures/notifications.fixture.js'
 import * as NotifyResponseFixture from '../../../../support/fixtures/notify-response.fixture.js'

--- a/test/services/notices/setup/send/send-letter-notification.service.test.js
+++ b/test/services/notices/setup/send/send-letter-notification.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as NotificationsFixture from '../../../../support/fixtures/notifications.fixture.js'
 import * as NotifyResponseFixture from '../../../../support/fixtures/notify-response.fixture.js'

--- a/test/services/notices/setup/send/send-main-notice.service.test.js
+++ b/test/services/notices/setup/send/send-main-notice.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as NoticesFixture from '../../../../support/fixtures/notices.fixture.js'
 import * as NotificationsFixture from '../../../../support/fixtures/notifications.fixture.js'

--- a/test/services/notices/setup/send/send-notice.service.test.js
+++ b/test/services/notices/setup/send/send-notice.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as NoticesFixture from '../../../../support/fixtures/notices.fixture.js'
 import * as NotificationsFixture from '../../../../support/fixtures/notifications.fixture.js'

--- a/test/services/notices/setup/send/send-paper-return-notification.service.test.js
+++ b/test/services/notices/setup/send/send-paper-return-notification.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as NotificationsFixture from '../../../../support/fixtures/notifications.fixture.js'
 import * as NotifyResponseFixture from '../../../../support/fixtures/notify-response.fixture.js'

--- a/test/services/notices/setup/submit-cancel.service.test.js
+++ b/test/services/notices/setup/submit-cancel.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/notices/setup/submit-check-notice-type.service.test.js
+++ b/test/services/notices/setup/submit-check-notice-type.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import { generateUUID } from '../../../../app/lib/general.lib.js'

--- a/test/services/notices/setup/submit-check.service.test.js
+++ b/test/services/notices/setup/submit-check.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as NoticesFixture from '../../../support/fixtures/notices.fixture.js'
 import * as NotificationsFixture from '../../../support/fixtures/notifications.fixture.js'

--- a/test/services/notices/setup/submit-contact-type.service.test.js
+++ b/test/services/notices/setup/submit-contact-type.service.test.js
@@ -1,5 +1,4 @@
 // Test framework dependencies
-
 import crypto from 'crypto'
 
 // Test helpers

--- a/test/services/notices/setup/submit-licence.service.test.js
+++ b/test/services/notices/setup/submit-licence.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import { generateLicenceRef } from '../../../support/helpers/licence.helper.js'

--- a/test/services/notices/setup/submit-notice-type.service.test.js
+++ b/test/services/notices/setup/submit-notice-type.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/notices/setup/submit-paper-return.service.test.js
+++ b/test/services/notices/setup/submit-paper-return.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import { generateLicenceRef } from '../../../support/helpers/licence.helper.js'

--- a/test/services/notices/setup/submit-recipient-name.service.test.js
+++ b/test/services/notices/setup/submit-recipient-name.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/notices/setup/submit-remove-licences.services.test.js
+++ b/test/services/notices/setup/submit-remove-licences.services.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import { generateLicenceRef } from '../../../support/helpers/licence.helper.js'

--- a/test/services/notices/setup/submit-returns-period.services.test.js
+++ b/test/services/notices/setup/submit-returns-period.services.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import { generateNoticeReferenceCode } from '../../../../app/lib/general.lib.js'

--- a/test/services/notices/setup/submit-select-recipients.service.test.js
+++ b/test/services/notices/setup/submit-select-recipients.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/notices/setup/view-cancel.service.test.js
+++ b/test/services/notices/setup/view-cancel.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import { generateNoticeReferenceCode } from '../../../../app/lib/general.lib.js'

--- a/test/services/notices/setup/view-check-notice-type.service.test.js
+++ b/test/services/notices/setup/view-check-notice-type.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import { generateLicenceRef } from '../../../support/helpers/licence.helper.js'

--- a/test/services/notices/setup/view-check.service.test.js
+++ b/test/services/notices/setup/view-check.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 import * as NoticeSessionFixture from '../../../support/fixtures/notice-session.fixture.js'

--- a/test/services/notices/setup/view-contact-type.service.test.js
+++ b/test/services/notices/setup/view-contact-type.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/notices/setup/view-licence.service.test.js
+++ b/test/services/notices/setup/view-licence.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import { generateLicenceRef } from '../../../support/helpers/licence.helper.js'

--- a/test/services/notices/setup/view-notice-type.service.test.js
+++ b/test/services/notices/setup/view-notice-type.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/notices/setup/view-paper-return.service.test.js
+++ b/test/services/notices/setup/view-paper-return.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import { generateLicenceRef } from '../../../support/helpers/licence.helper.js'

--- a/test/services/notices/setup/view-recipient-name.service.test.js
+++ b/test/services/notices/setup/view-recipient-name.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import { generateNoticeReferenceCode } from '../../../../app/lib/general.lib.js'

--- a/test/services/notices/setup/view-remove-licences.service.test.js
+++ b/test/services/notices/setup/view-remove-licences.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import { generateNoticeReferenceCode } from '../../../../app/lib/general.lib.js'

--- a/test/services/notices/setup/view-returns-period.service.test.js
+++ b/test/services/notices/setup/view-returns-period.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import { generateNoticeReferenceCode } from '../../../../app/lib/general.lib.js'

--- a/test/services/notices/setup/view-select-recipients.service.test.js
+++ b/test/services/notices/setup/view-select-recipients.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/notices/submit-index-notices.service.test.js
+++ b/test/services/notices/submit-index-notices.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as NoticesFixture from '../../support/fixtures/notices.fixture.js'
 

--- a/test/services/notices/submit-view-notice.service.test.js
+++ b/test/services/notices/submit-view-notice.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { generateNoticeReferenceCode } from '../../../app/lib/general.lib.js'
 

--- a/test/services/notices/view-notice.service.test.js
+++ b/test/services/notices/view-notice.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { generateNoticeReferenceCode } from '../../../app/lib/general.lib.js'
 

--- a/test/services/notifications/check-notification-status.service.test.js
+++ b/test/services/notifications/check-notification-status.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as NoticesFixture from '../../support/fixtures/notices.fixture.js'
 import * as NotificationsFixture from '../../support/fixtures/notifications.fixture.js'

--- a/test/services/notifications/download-notification.service.test.js
+++ b/test/services/notifications/download-notification.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import * as FetchDownloadNotificationService from '../../../app/services/notifications/fetch-notification-download.service.js'
 

--- a/test/services/notifications/process-returned-letter.service.test.js
+++ b/test/services/notifications/process-returned-letter.service.test.js
@@ -1,5 +1,4 @@
 // Test framework dependencies
-
 import { generateUUID, today, generateNoticeReferenceCode } from '../../../app/lib/general.lib.js'
 
 // Test helpers

--- a/test/services/notifications/view-notification.service.test.js
+++ b/test/services/notifications/view-notification.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as NoticesFixture from '../../support/fixtures/notices.fixture.js'
 import * as NotificationsFixture from '../../support/fixtures/notifications.fixture.js'

--- a/test/services/plugins/auth.service.test.js
+++ b/test/services/plugins/auth.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things to stub
 import FeatureFlagsConfig from '../../../config/feature-flags.config.js'
 import * as FetchUserRolesAndGroupsService from '../../../app/services/idm/fetch-user-roles-and-groups.service.js'

--- a/test/services/plugins/error-pages.service.test.js
+++ b/test/services/plugins/error-pages.service.test.js
@@ -1,7 +1,5 @@
 import http2 from 'node:http2'
 
-// Test framework dependencies
-
 // Test helpers
 import SessionNotFoundError from '../../../app/errors/session-not-found.error.js'
 

--- a/test/services/plugins/filter-routes.service.test.js
+++ b/test/services/plugins/filter-routes.service.test.js
@@ -1,5 +1,4 @@
 // Test framework dependencies
-
 import * as Hoek from '@hapi/hoek'
 
 // Thing under test

--- a/test/services/plugins/hapi-pino-log-in-test.service.test.js
+++ b/test/services/plugins/hapi-pino-log-in-test.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Thing under test
 import HapiPinoLogInTestService from '../../../app/services/plugins//hapi-pino-log-in-test.service.js'
 

--- a/test/services/reports/view-invalid-addresses.service.test.js
+++ b/test/services/reports/view-invalid-addresses.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we want to stub
 import * as FetchInvalidAddressesService from '../../../app/services/reports/fetch-invalid-addresses.service.js'
 

--- a/test/services/return-logs/download-return-log.service.test.js
+++ b/test/services/return-logs/download-return-log.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { formatDateObjectToISO } from '../../../app/lib/dates.lib.js'
 import * as ReturnLogsFixture from '../../support/fixtures/return-logs.fixture.js'

--- a/test/services/return-logs/fetch-return-log-details.service.test.js
+++ b/test/services/return-logs/fetch-return-log-details.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as LicenceHelper from '../../support/helpers/licence.helper.js'
 import * as ReturnLogHelper from '../../support/helpers/return-log.helper.js'

--- a/test/services/return-logs/process-licence-return-logs.service.test.js
+++ b/test/services/return-logs/process-licence-return-logs.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as ReturnCyclesFixture from '../../support/fixtures/return-cycles.fixture.js'
 import * as ReturnRequirementsFixture from '../../support/fixtures/return-requirements.fixture.js'

--- a/test/services/return-logs/setup/cancel.service.test.js
+++ b/test/services/return-logs/setup/cancel.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-logs/setup/check.service.test.js
+++ b/test/services/return-logs/setup/check.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/return-logs/setup/confirmed.service.test.js
+++ b/test/services/return-logs/setup/confirmed.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import * as FetchReturnLogService from '../../../../app/services/return-logs/setup/fetch-return-log.service.js'
 

--- a/test/services/return-logs/setup/delete-note.service.test.js
+++ b/test/services/return-logs/setup/delete-note.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/return-logs/setup/meter-details.service.test.js
+++ b/test/services/return-logs/setup/meter-details.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-logs/setup/meter-provided.service.test.js
+++ b/test/services/return-logs/setup/meter-provided.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-logs/setup/multiple-entries.service.test.js
+++ b/test/services/return-logs/setup/multiple-entries.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-logs/setup/note.service.test.js
+++ b/test/services/return-logs/setup/note.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-logs/setup/period-used.service.test.js
+++ b/test/services/return-logs/setup/period-used.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-logs/setup/readings.service.test.js
+++ b/test/services/return-logs/setup/readings.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-logs/setup/received.service.test.js
+++ b/test/services/return-logs/setup/received.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-logs/setup/reported.service.test.js
+++ b/test/services/return-logs/setup/reported.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-logs/setup/single-volume.service.test.js
+++ b/test/services/return-logs/setup/single-volume.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-logs/setup/start-reading.service.test.js
+++ b/test/services/return-logs/setup/start-reading.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-logs/setup/submission.service.test.js
+++ b/test/services/return-logs/setup/submission.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-logs/setup/submit-cancel.service.test.js
+++ b/test/services/return-logs/setup/submit-cancel.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-logs/setup/submit-check.service.test.js
+++ b/test/services/return-logs/setup/submit-check.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as LicenceHelper from '../../../support/helpers/licence.helper.js'
 import * as ReturnLogHelper from '../../../support/helpers/return-log.helper.js'

--- a/test/services/return-logs/setup/submit-confirmed.service.test.js
+++ b/test/services/return-logs/setup/submit-confirmed.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as LicenceHelper from '../../../support/helpers/licence.helper.js'
 import * as ReturnLogHelper from '../../../support/helpers/return-log.helper.js'

--- a/test/services/return-logs/setup/submit-meter-details.service.test.js
+++ b/test/services/return-logs/setup/submit-meter-details.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/return-logs/setup/submit-meter-provided.service.test.js
+++ b/test/services/return-logs/setup/submit-meter-provided.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/return-logs/setup/submit-multiple-entries.service.test.js
+++ b/test/services/return-logs/setup/submit-multiple-entries.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/return-logs/setup/submit-note.service.test.js
+++ b/test/services/return-logs/setup/submit-note.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/return-logs/setup/submit-period-used.service.test.js
+++ b/test/services/return-logs/setup/submit-period-used.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-logs/setup/submit-readings.service.test.js
+++ b/test/services/return-logs/setup/submit-readings.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/return-logs/setup/submit-received.service.test.js
+++ b/test/services/return-logs/setup/submit-received.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import { today } from '../../../../app/lib/general.lib.js'

--- a/test/services/return-logs/setup/submit-reported.service.test.js
+++ b/test/services/return-logs/setup/submit-reported.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/return-logs/setup/submit-single-volume.service.test.js
+++ b/test/services/return-logs/setup/submit-single-volume.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-logs/setup/submit-start-reading.service.test.js
+++ b/test/services/return-logs/setup/submit-start-reading.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/return-logs/setup/submit-submission.service.test.js
+++ b/test/services/return-logs/setup/submit-submission.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as ReturnLogHelper from '../../../support/helpers/return-log.helper.js'
 import * as ReturnRequirementHelper from '../../../support/helpers/return-requirement.helper.js'

--- a/test/services/return-logs/setup/submit-units.service.test.js
+++ b/test/services/return-logs/setup/submit-units.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/return-logs/setup/submit-volumes.service.test.js
+++ b/test/services/return-logs/setup/submit-volumes.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/return-logs/setup/units.service.test.js
+++ b/test/services/return-logs/setup/units.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-logs/setup/volumes.service.test.js
+++ b/test/services/return-logs/setup/volumes.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-logs/submit-details.service.test.js
+++ b/test/services/return-logs/submit-details.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as ReturnLogHelper from '../../support/helpers/return-log.helper.js'
 import ReturnLogModel from '../../../app/models/return-log.model.js'

--- a/test/services/return-logs/view-communications.service.test.js
+++ b/test/services/return-logs/view-communications.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import { generateUUID } from '../../../app/lib/general.lib.js'
 import { generateLicenceRef } from '../../support/helpers/licence.helper.js'

--- a/test/services/return-logs/view-details.service.test.js
+++ b/test/services/return-logs/view-details.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as ReturnLogsFixture from '../../support/fixtures/return-logs.fixture.js'
 import * as ReturnLogHelper from '../../support/helpers/return-log.helper.js'

--- a/test/services/return-submissions/fetch-return-submission.service.test.js
+++ b/test/services/return-submissions/fetch-return-submission.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as ReturnLogHelper from '../../support/helpers/return-log.helper.js'
 import ReturnLogModel from '../../../app/models/return-log.model.js'

--- a/test/services/return-submissions/view-return-submission.service.test.js
+++ b/test/services/return-submissions/view-return-submission.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import * as FetchReturnSubmissionService from '../../../app/services/return-submissions/fetch-return-submission.service.js'
 

--- a/test/services/return-versions/setup/abstraction-period.service.test.js
+++ b/test/services/return-versions/setup/abstraction-period.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-versions/setup/add.service.test.js
+++ b/test/services/return-versions/setup/add.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-versions/setup/additional-submission-options.service.test.js
+++ b/test/services/return-versions/setup/additional-submission-options.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-versions/setup/agreements-exceptions.service.test.js
+++ b/test/services/return-versions/setup/agreements-exceptions.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-versions/setup/cancel.service.test.js
+++ b/test/services/return-versions/setup/cancel.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-versions/setup/check/check.service.test.js
+++ b/test/services/return-versions/setup/check/check.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as FetchPointsService from '../../../../../app/services/return-versions/setup/fetch-points.service.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'

--- a/test/services/return-versions/setup/check/generate-return-version-requirements.service.test.js
+++ b/test/services/return-versions/setup/check/generate-return-version-requirements.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import * as FetchOtherPurposeIdsDal from '../../../../../app/dal/return-versions/fetch-other-purpose-ids.dal.js'
 

--- a/test/services/return-versions/setup/check/generate-return-version.service.test.js
+++ b/test/services/return-versions/setup/check/generate-return-version.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 

--- a/test/services/return-versions/setup/check/process-existing-return-versions.service.test.js
+++ b/test/services/return-versions/setup/check/process-existing-return-versions.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import * as FetchCurrentReturnVersionsDal from '../../../../../app/dal/return-versions/fetch-current-return-versions.dal.js'
 import * as UpdateReturnVersionEndDateDal from '../../../../../app/dal/return-versions/update-return-version-end-date.dal.js'

--- a/test/services/return-versions/setup/check/submit-check.service.test.js
+++ b/test/services/return-versions/setup/check/submit-check.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 

--- a/test/services/return-versions/setup/delete-note.service.test.js
+++ b/test/services/return-versions/setup/delete-note.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/return-versions/setup/determine-relevant-licence-version.service.test.js
+++ b/test/services/return-versions/setup/determine-relevant-licence-version.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 
 // Things we need to stub

--- a/test/services/return-versions/setup/existing/existing.service.test.js
+++ b/test/services/return-versions/setup/existing/existing.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 

--- a/test/services/return-versions/setup/existing/generate-from-existing-requirements.service.test.js
+++ b/test/services/return-versions/setup/existing/generate-from-existing-requirements.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import * as FetchExistingRequirementsService from '../../../../../app/services/return-versions/setup/existing/fetch-existing-requirements.service.js'
 

--- a/test/services/return-versions/setup/existing/submit-existing.service.test.js
+++ b/test/services/return-versions/setup/existing/submit-existing.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 

--- a/test/services/return-versions/setup/frequency-collected.service.test.js
+++ b/test/services/return-versions/setup/frequency-collected.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-versions/setup/frequency-reported.service.test.js
+++ b/test/services/return-versions/setup/frequency-reported.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-versions/setup/initiate-session.service.test.js
+++ b/test/services/return-versions/setup/initiate-session.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import http2 from 'node:http2'
 import LicenceModel from '../../../../app/models/licence.model.js'

--- a/test/services/return-versions/setup/method/generate-from-abstraction-data.service.test.js
+++ b/test/services/return-versions/setup/method/generate-from-abstraction-data.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import LicenceModel from '../../../../../app/models/licence.model.js'
 import LicenceVersionPurposeModel from '../../../../../app/models/licence-version-purpose.model.js'

--- a/test/services/return-versions/setup/method/method.service.test.js
+++ b/test/services/return-versions/setup/method/method.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 

--- a/test/services/return-versions/setup/method/submit-method.service.test.js
+++ b/test/services/return-versions/setup/method/submit-method.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 

--- a/test/services/return-versions/setup/no-returns-required.service.test.js
+++ b/test/services/return-versions/setup/no-returns-required.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-versions/setup/note.service.test.js
+++ b/test/services/return-versions/setup/note.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-versions/setup/points.service.test.js
+++ b/test/services/return-versions/setup/points.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import PointModel from '../../../../app/models/point.model.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/return-versions/setup/purpose.service.test.js
+++ b/test/services/return-versions/setup/purpose.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-versions/setup/reason.service.test.js
+++ b/test/services/return-versions/setup/reason.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-versions/setup/remove.service.test.js
+++ b/test/services/return-versions/setup/remove.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-versions/setup/returns-cycle.service.test.js
+++ b/test/services/return-versions/setup/returns-cycle.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-versions/setup/site-description.service.test.js
+++ b/test/services/return-versions/setup/site-description.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-versions/setup/start-date.service.test.js
+++ b/test/services/return-versions/setup/start-date.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-versions/setup/submit-abstraction-period.service.test.js
+++ b/test/services/return-versions/setup/submit-abstraction-period.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/return-versions/setup/submit-additional-submission-options.service.test.js
+++ b/test/services/return-versions/setup/submit-additional-submission-options.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/return-versions/setup/submit-agreements-exceptions.service.test.js
+++ b/test/services/return-versions/setup/submit-agreements-exceptions.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/return-versions/setup/submit-cancel.service.test.js
+++ b/test/services/return-versions/setup/submit-cancel.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-versions/setup/submit-frequency-collected.service.test.js
+++ b/test/services/return-versions/setup/submit-frequency-collected.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/return-versions/setup/submit-frequency-reported.service.test.js
+++ b/test/services/return-versions/setup/submit-frequency-reported.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/return-versions/setup/submit-no-returns-required.service.test.js
+++ b/test/services/return-versions/setup/submit-no-returns-required.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/return-versions/setup/submit-note.service.test.js
+++ b/test/services/return-versions/setup/submit-note.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 

--- a/test/services/return-versions/setup/submit-points.service.test.js
+++ b/test/services/return-versions/setup/submit-points.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import PointModel from '../../../../app/models/point.model.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'

--- a/test/services/return-versions/setup/submit-purpose.service.test.js
+++ b/test/services/return-versions/setup/submit-purpose.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/return-versions/setup/submit-reason.service.test.js
+++ b/test/services/return-versions/setup/submit-reason.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/return-versions/setup/submit-remove.service.test.js
+++ b/test/services/return-versions/setup/submit-remove.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/return-versions/setup/submit-returns-cycle.service.test.js
+++ b/test/services/return-versions/setup/submit-returns-cycle.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/return-versions/setup/submit-site-description.service.test.js
+++ b/test/services/return-versions/setup/submit-site-description.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/return-versions/setup/submit-start-date.service.test.js
+++ b/test/services/return-versions/setup/submit-start-date.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/return-versions/view.service.test.js
+++ b/test/services/return-versions/view.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import ContactModel from '../../../app/models/contact.model.js'
 import LicenceModel from '../../../app/models/licence.model.js'

--- a/test/services/search/fetch-search-results-details.service.test.js
+++ b/test/services/search/fetch-search-results-details.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things to stub
 import BillingAccountModel from '../../../app/models/billing-account.model.js'
 import CompanyModel from '../../../app/models/company.model.js'

--- a/test/services/search/fetch-search-results.service.test.js
+++ b/test/services/search/fetch-search-results.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as BillingAccountHelper from '../../support/helpers/billing-account.helper.js'
 import * as CRMContactsSeeder from '../../support/seeders/crm-contacts.seeder.js'

--- a/test/services/search/find-all-search-matches.service.test.js
+++ b/test/services/search/find-all-search-matches.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things to stub
 import * as DetermineSearchItemsService from '../../../app/services/search/determine-search-items.service.js'
 import * as FetchSearchResultsDetailsService from '../../../app/services/search/fetch-search-results-details.service.js'

--- a/test/services/search/submit-search.service.test.js
+++ b/test/services/search/submit-search.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Thing under test
 import SubmitSearchService from '../../../app/services/search/submit-search.service.js'
 

--- a/test/services/search/view-search.service.test.js
+++ b/test/services/search/view-search.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things to stub
 import * as FindAllSearchMatchesService from '../../../app/services/search/find-all-search-matches.service.js'
 

--- a/test/services/users/external/setup/initiate-session.service.test.js
+++ b/test/services/users/external/setup/initiate-session.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModel from '../../../../../app/models/session.model.js'
 import * as UsersFixture from '../../../../support/fixtures/users.fixture.js'

--- a/test/services/users/external/setup/submit-cancel.service.test.js
+++ b/test/services/users/external/setup/submit-cancel.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as UserSessionsFixture from '../../../../support/fixtures/user-sessions.fixture.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'

--- a/test/services/users/external/setup/submit-check.service.test.js
+++ b/test/services/users/external/setup/submit-check.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 import * as UserSessionsFixture from '../../../../support/fixtures/user-sessions.fixture.js'

--- a/test/services/users/external/setup/submit-licences.service.test.js
+++ b/test/services/users/external/setup/submit-licences.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 import * as UserSessionsFixture from '../../../../support/fixtures/user-sessions.fixture.js'

--- a/test/services/users/external/setup/view-cancel.service.test.js
+++ b/test/services/users/external/setup/view-cancel.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 import * as UserSessionsFixture from '../../../../support/fixtures/user-sessions.fixture.js'

--- a/test/services/users/external/setup/view-check.service.test.js
+++ b/test/services/users/external/setup/view-check.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 import * as UserSessionsFixture from '../../../../support/fixtures/user-sessions.fixture.js'

--- a/test/services/users/external/setup/view-licences.service.test.js
+++ b/test/services/users/external/setup/view-licences.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 import * as UserSessionsFixture from '../../../../support/fixtures/user-sessions.fixture.js'

--- a/test/services/users/external/view-communications.service.test.js
+++ b/test/services/users/external/view-communications.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as UsersFixture from '../../../support/fixtures/users.fixture.js'
 

--- a/test/services/users/external/view-details.service.test.js
+++ b/test/services/users/external/view-details.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as UsersFixture from '../../../support/fixtures/users.fixture.js'
 

--- a/test/services/users/external/view-licences.service.test.js
+++ b/test/services/users/external/view-licences.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as UsersFixture from '../../../support/fixtures/users.fixture.js'
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/users/external/view-verifications.service.test.js
+++ b/test/services/users/external/view-verifications.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as UsersFixture from '../../../support/fixtures/users.fixture.js'
 

--- a/test/services/users/index-users.service.test.js
+++ b/test/services/users/index-users.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as UsersFixture from '../../support/fixtures/users.fixture.js'
 import YarStub from '../../support/stubs/yar.stub.js'

--- a/test/services/users/internal/setup/initiate-edit-session.service.test.js
+++ b/test/services/users/internal/setup/initiate-edit-session.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModel from '../../../../../app/models/session.model.js'
 

--- a/test/services/users/internal/setup/send-verification-email.service.test.js
+++ b/test/services/users/internal/setup/send-verification-email.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Things we need to stub
 import * as CheckNotificationStatusService from '../../../../../app/services/notifications/check-notification-status.service.js'
 import * as CreateEmailRequest from '../../../../../app/requests/notify/create-email.request.js'

--- a/test/services/users/internal/setup/submit-access.service.test.js
+++ b/test/services/users/internal/setup/submit-access.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 import YarStub from '../../../../support/stubs/yar.stub.js'

--- a/test/services/users/internal/setup/submit-cancel.service.test.js
+++ b/test/services/users/internal/setup/submit-cancel.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 

--- a/test/services/users/internal/setup/submit-check.service.test.js
+++ b/test/services/users/internal/setup/submit-check.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 import YarStub from '../../../../support/stubs/yar.stub.js'

--- a/test/services/users/internal/setup/submit-email.service.test.js
+++ b/test/services/users/internal/setup/submit-email.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 import YarStub from '../../../../support/stubs/yar.stub.js'

--- a/test/services/users/internal/setup/submit-permissions.service.test.js
+++ b/test/services/users/internal/setup/submit-permissions.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 import YarStub from '../../../../support/stubs/yar.stub.js'

--- a/test/services/users/internal/setup/view-access.service.test.js
+++ b/test/services/users/internal/setup/view-access.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 

--- a/test/services/users/internal/setup/view-cancel.service.test.js
+++ b/test/services/users/internal/setup/view-cancel.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 

--- a/test/services/users/internal/setup/view-check.service.test.js
+++ b/test/services/users/internal/setup/view-check.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 

--- a/test/services/users/internal/setup/view-email.service.test.js
+++ b/test/services/users/internal/setup/view-email.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 

--- a/test/services/users/internal/setup/view-permissions.service.test.js
+++ b/test/services/users/internal/setup/view-permissions.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 

--- a/test/services/users/internal/view-communications.service.test.js
+++ b/test/services/users/internal/view-communications.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as UsersFixture from '../../../support/fixtures/users.fixture.js'
 

--- a/test/services/users/internal/view-details.service.test.js
+++ b/test/services/users/internal/view-details.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as UsersFixture from '../../../support/fixtures/users.fixture.js'
 

--- a/test/services/users/submit-index-users.service.test.js
+++ b/test/services/users/submit-index-users.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as UsersFixture from '../../support/fixtures/users.fixture.js'
 

--- a/test/services/users/submit-profile-details.service.test.js
+++ b/test/services/users/submit-profile-details.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import YarStub from '../../support/stubs/yar.stub.js'
 

--- a/test/services/users/view-notification.service.test.js
+++ b/test/services/users/view-notification.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import * as NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
 import * as UsersFixture from '../../support/fixtures/users.fixture.js'

--- a/test/services/users/view-profile-details.service.test.js
+++ b/test/services/users/view-profile-details.service.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Test helpers
 import YarStub from '../../support/stubs/yar.stub.js'
 

--- a/test/validators/notices/setup/renewal-notice/licence-renewal.validator.test.js
+++ b/test/validators/notices/setup/renewal-notice/licence-renewal.validator.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Helpers
 import LicenceModel from '../../../../../app/models/licence.model.js'
 import { generateUUID } from '../../../../../app/lib/general.lib.js'

--- a/test/views/filters/markdown.filter.test.js
+++ b/test/views/filters/markdown.filter.test.js
@@ -1,5 +1,3 @@
-// Test framework dependencies
-
 // Thing under test
 import MarkdownFilter from '../../../app/views/filters/markdown.filter.js'
 


### PR DESCRIPTION
## Summary
- Removes the `// Test framework dependencies` heading from 507 test files where it no longer had any imports underneath it — a leftover from the Hapi Lab to Vitest migration
- Tightens the remaining 7 files where real imports were sitting under that heading, so the import now sits directly below the comment with no blank line