### PR TITLE
Make test fixtures export a single default object

### DIFF
--- a/test/controllers/notifications.controller.test.js
+++ b/test/controllers/notifications.controller.test.js
@@ -2,9 +2,9 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as NoticesFixture from '../support/fixtures/notices.fixture.js'
-import * as NotificationsFixture from '../support/fixtures/notifications.fixture.js'
 import LicenceHelper from '../support/helpers/licence.helper.js'
+import NoticesFixture from '../support/fixtures/notices.fixture.js'
+import NotificationsFixture from '../support/fixtures/notifications.fixture.js'
 import { generateUUID } from '../../app/lib/general.lib.js'
 import http2 from 'node:http2'
 

--- a/test/dal/company-contacts/fetch-notifications.dal.test.js
+++ b/test/dal/company-contacts/fetch-notifications.dal.test.js
@@ -2,10 +2,10 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as NoticesFixture from '../../support/fixtures/notices.fixture.js'
-import * as NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
 import EventHelper from '../../support/helpers/event.helper.js'
+import NoticesFixture from '../../support/fixtures/notices.fixture.js'
 import NotificationHelper from '../../support/helpers/notification.helper.js'
+import NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
 import { generateUUID } from '../../../app/lib/general.lib.js'
 
 // Thing under test

--- a/test/dal/jobs/notification-status/fetch-critical-notices.dal.test.js
+++ b/test/dal/jobs/notification-status/fetch-critical-notices.dal.test.js
@@ -2,11 +2,11 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as NoticesFixture from '../../../support/fixtures/notices.fixture.js'
-import * as NotificationsFixture from '../../../support/fixtures/notifications.fixture.js'
 import EventHelper from '../../../support/helpers/event.helper.js'
 import EventModel from '../../../../app/models/event.model.js'
+import NoticesFixture from '../../../support/fixtures/notices.fixture.js'
 import NotificationHelper from '../../../support/helpers/notification.helper.js'
+import NotificationsFixture from '../../../support/fixtures/notifications.fixture.js'
 
 // Thing under test
 import FetchCriticalNoticesDal from '../../../../app/dal/jobs/notification-status/fetch-critical-notices.dal.js'

--- a/test/dal/licences/fetch-notifications.dal.test.js
+++ b/test/dal/licences/fetch-notifications.dal.test.js
@@ -2,11 +2,11 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as NoticesFixture from '../../support/fixtures/notices.fixture.js'
-import * as NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
 import EventHelper from '../../support/helpers/event.helper.js'
 import LicenceHelper from '../../support/helpers/licence.helper.js'
+import NoticesFixture from '../../support/fixtures/notices.fixture.js'
 import NotificationHelper from '../../support/helpers/notification.helper.js'
+import NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
 
 // Thing under test
 import FetchNotificationsDal from '../../../app/dal/licences/fetch-notifications.dal.js'

--- a/test/dal/return-logs/fetch-notifications.dal.test.js
+++ b/test/dal/return-logs/fetch-notifications.dal.test.js
@@ -2,10 +2,10 @@
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as NoticesFixture from '../../support/fixtures/notices.fixture.js'
-import * as NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
 import EventHelper from '../../support/helpers/event.helper.js'
+import NoticesFixture from '../../support/fixtures/notices.fixture.js'
 import NotificationHelper from '../../support/helpers/notification.helper.js'
+import NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
 
 import LicenceHelper from '../../support/helpers/licence.helper.js'
 

--- a/test/dal/users/external/fetch-notifications.dal.test.js
+++ b/test/dal/users/external/fetch-notifications.dal.test.js
@@ -2,9 +2,9 @@
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as NotificationsFixture from '../../../support/fixtures/notifications.fixture.js'
-import * as UsersFixture from '../../../support/fixtures/users.fixture.js'
 import NotificationHelper from '../../../support/helpers/notification.helper.js'
+import NotificationsFixture from '../../../support/fixtures/notifications.fixture.js'
+import UsersFixture from '../../../support/fixtures/users.fixture.js'
 import { today } from '../../../../app/lib/general.lib.js'
 import { yesterday } from '../../../support/general.js'
 

--- a/test/dal/users/external/setup/unregister-licences.dal.test.js
+++ b/test/dal/users/external/setup/unregister-licences.dal.test.js
@@ -2,10 +2,10 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as UsersFixture from '../../../../support/fixtures/users.fixture.js'
 import LicenceDocumentHeaderHelper from '../../../../support/helpers/licence-document-header.helper.js'
 import LicenceDocumentHeaderModel from '../../../../../app/models/licence-document-header.model.js'
 import LicenceUnregistrationModel from '../../../../../app/models/licence-unregistration.model.js'
+import UsersFixture from '../../../../support/fixtures/users.fixture.js'
 import { generateUUID } from '../../../../../app/lib/general.lib.js'
 
 // Thing under test

--- a/test/dal/users/fetch-legacy-id.dal.test.js
+++ b/test/dal/users/fetch-legacy-id.dal.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as UsersFixture from '../../support/fixtures/users.fixture.js'
+import UsersFixture from '../../support/fixtures/users.fixture.js'
 
 // Thing under test
 import FetchLegacyIdDal from '../../../app/dal/users/fetch-legacy-id.dal.js'

--- a/test/dal/users/fetch-notification.dal.test.js
+++ b/test/dal/users/fetch-notification.dal.test.js
@@ -2,9 +2,9 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
-import * as UsersFixture from '../../support/fixtures/users.fixture.js'
 import NotificationHelper from '../../support/helpers/notification.helper.js'
+import NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
+import UsersFixture from '../../support/fixtures/users.fixture.js'
 
 // Thing under test
 import FetchNotificationDal from '../../../app/dal/users/fetch-notification.dal.js'

--- a/test/dal/users/fetch-user.dal.test.js
+++ b/test/dal/users/fetch-user.dal.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as UsersFixture from '../../support/fixtures/users.fixture.js'
+import UsersFixture from '../../support/fixtures/users.fixture.js'
 
 // Thing under test
 import FetchUserDal from '../../../app/dal/users/fetch-user.dal.js'

--- a/test/dal/users/fetch-users.dal.test.js
+++ b/test/dal/users/fetch-users.dal.test.js
@@ -5,12 +5,12 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import DatabaseConfig from '../../../config/database.config.js'
 
 // Test helpers
-import * as UsersFixture from '../../support/fixtures/users.fixture.js'
 import LicenceDocumentHeaderHelper from '../../support/helpers/licence-document-header.helper.js'
 import LicenceEntityHelper from '../../support/helpers/licence-entity.helper.js'
 import LicenceEntityRoleHelper from '../../support/helpers/licence-entity-role.helper.js'
 import LicenceHelper from '../../support/helpers/licence.helper.js'
 import UserHelper from '../../support/helpers/user.helper.js'
+import UsersFixture from '../../support/fixtures/users.fixture.js'
 import { generateUUID } from '../../../app/lib/general.lib.js'
 
 // Thing under test

--- a/test/dal/users/internal/fetch-notifications.dal.test.js
+++ b/test/dal/users/internal/fetch-notifications.dal.test.js
@@ -2,9 +2,9 @@
 import { afterAll, beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as NotificationsFixture from '../../../support/fixtures/notifications.fixture.js'
-import * as UsersFixture from '../../../support/fixtures/users.fixture.js'
 import NotificationHelper from '../../../support/helpers/notification.helper.js'
+import NotificationsFixture from '../../../support/fixtures/notifications.fixture.js'
+import UsersFixture from '../../../support/fixtures/users.fixture.js'
 import { today } from '../../../../app/lib/general.lib.js'
 import { yesterday } from '../../../support/general.js'
 

--- a/test/dal/users/internal/fetch-user-details.dal.test.js
+++ b/test/dal/users/internal/fetch-user-details.dal.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as UsersFixture from '../../../support/fixtures/users.fixture.js'
+import UsersFixture from '../../../support/fixtures/users.fixture.js'
 
 // Thing under test
 import FetchUserDetailsDal from '../../../../app/dal/users/internal/fetch-user-details.dal.js'

--- a/test/presenters/bill-runs/review/authorised.presenter.test.js
+++ b/test/presenters/bill-runs/review/authorised.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
+import BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 
 // Thing under test
 import AuthorisedPresenter from '../../../../app/presenters/bill-runs/review/authorised.presenter.js'

--- a/test/presenters/bill-runs/review/edit.presenter.test.js
+++ b/test/presenters/bill-runs/review/edit.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
+import BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 
 // Thing under test
 import EditPresenter from '../../../../app/presenters/bill-runs/review/edit.presenter.js'

--- a/test/presenters/bill-runs/review/factors.presenter.test.js
+++ b/test/presenters/bill-runs/review/factors.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
+import BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 
 // Thing under test
 import FactorsPresenter from '../../../../app/presenters/bill-runs/review/factors.presenter.js'

--- a/test/presenters/bill-runs/review/remove.presenter.test.js
+++ b/test/presenters/bill-runs/review/remove.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
+import BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 
 // Thing under test
 import RemovePresenter from '../../../../app/presenters/bill-runs/review/remove.presenter.js'

--- a/test/presenters/bill-runs/review/review-charge-element.presenter.test.js
+++ b/test/presenters/bill-runs/review/review-charge-element.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
+import BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 
 // Thing under test
 import ReviewChargeElementPresenter from '../../../../app/presenters/bill-runs/review/review-charge-element.presenter.js'

--- a/test/presenters/bill-runs/review/review-charge-reference.presenter.test.js
+++ b/test/presenters/bill-runs/review/review-charge-reference.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
+import BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 
 // Thing under test
 import ReviewChargeReferencePresenter from '../../../../app/presenters/bill-runs/review/review-charge-reference.presenter.js'

--- a/test/presenters/bill-runs/review/review-licence.presenter.test.js
+++ b/test/presenters/bill-runs/review/review-licence.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
+import BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 
 // Thing under test
 import ReviewLicencePresenter from '../../../../app/presenters/bill-runs/review/review-licence.presenter.js'

--- a/test/presenters/billing-accounts/setup/account-type.presenter.test.js
+++ b/test/presenters/billing-accounts/setup/account-type.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import { generateUUID } from '../../../../app/lib/general.lib.js'
 
 // Thing under test

--- a/test/presenters/billing-accounts/setup/account.presenter.test.js
+++ b/test/presenters/billing-accounts/setup/account.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 
 // Thing under test
 import AccountPresenter from '../../../../app/presenters/billing-accounts/setup/account.presenter.js'

--- a/test/presenters/billing-accounts/setup/check.presenter.test.js
+++ b/test/presenters/billing-accounts/setup/check.presenter.test.js
@@ -2,8 +2,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
-import * as CustomersFixture from '../../../support/fixtures/customers.fixture.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
+import CustomersFixture from '../../../support/fixtures/customers.fixture.js'
 import LicenceHelper from '../../../support/helpers/licence.helper.js'
 import { generateUUID } from '../../../../app/lib/general.lib.js'
 

--- a/test/presenters/billing-accounts/setup/company-search.presenter.test.js
+++ b/test/presenters/billing-accounts/setup/company-search.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 
 // Thing under test
 import CompanySearchPresenter from '../../../../app/presenters/billing-accounts/setup/company-search.presenter.js'

--- a/test/presenters/billing-accounts/setup/contact-name.presenter.test.js
+++ b/test/presenters/billing-accounts/setup/contact-name.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 
 // Thing under test
 import ContactNamePresenter from '../../../../app/presenters/billing-accounts/setup/contact-name.presenter.js'

--- a/test/presenters/billing-accounts/setup/contact.presenter.test.js
+++ b/test/presenters/billing-accounts/setup/contact.presenter.test.js
@@ -2,8 +2,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
-import * as CustomersFixture from '../../../support/fixtures/customers.fixture.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
+import CustomersFixture from '../../../support/fixtures/customers.fixture.js'
 
 // Thing under test
 import ContactPresenter from '../../../../app/presenters/billing-accounts/setup/contact.presenter.js'

--- a/test/presenters/billing-accounts/setup/existing-account.presenter.test.js
+++ b/test/presenters/billing-accounts/setup/existing-account.presenter.test.js
@@ -2,8 +2,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
-import * as CustomersFixture from '../../../support/fixtures/customers.fixture.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
+import CustomersFixture from '../../../support/fixtures/customers.fixture.js'
 import { generateUUID } from '../../../../app/lib/general.lib.js'
 
 // Thing under test

--- a/test/presenters/billing-accounts/setup/existing-address.presenter.test.js
+++ b/test/presenters/billing-accounts/setup/existing-address.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import { generateUUID } from '../../../../app/lib/general.lib.js'
 
 // Thing under test

--- a/test/presenters/billing-accounts/setup/fao.presenter.test.js
+++ b/test/presenters/billing-accounts/setup/fao.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import { generateUUID } from '../../../../app/lib/general.lib.js'
 
 // Thing under test

--- a/test/presenters/billing-accounts/setup/select-company.presenter.test.js
+++ b/test/presenters/billing-accounts/setup/select-company.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import { generateUUID } from '../../../../app/lib/general.lib.js'
 
 // Thing under test

--- a/test/presenters/billing-accounts/view-billing-account.presenter.test.js
+++ b/test/presenters/billing-accounts/view-billing-account.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../support/fixtures/billing-accounts.fixture.js'
+import BillingAccountsFixture from '../../support/fixtures/billing-accounts.fixture.js'
 import { generateUUID } from '../../../app/lib/general.lib.js'
 
 // Thing under test

--- a/test/presenters/companies/billing-accounts.presenter.test.js
+++ b/test/presenters/companies/billing-accounts.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../support/fixtures/customers.fixture.js'
 
 // Thing under test
 import BillingAccountsPresenter from '../../../app/presenters/companies/billing-accounts.presenter.js'

--- a/test/presenters/companies/company-with-address.presenter.test.js
+++ b/test/presenters/companies/company-with-address.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../support/fixtures/customers.fixture.js'
 
 // Thing under test
 import CompanyWithAddressPresenter from '../../../app/presenters/companies/company-with-address.presenter.js'

--- a/test/presenters/companies/company.presenter.test.js
+++ b/test/presenters/companies/company.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../support/fixtures/customers.fixture.js'
 import { formatLongDate } from '../../../app/presenters/base.presenter.js'
 import { tomorrow } from '../../support/general.js'
 

--- a/test/presenters/companies/contacts.presenter.test.js
+++ b/test/presenters/companies/contacts.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../support/fixtures/customers.fixture.js'
 import { generateUUID } from '../../../app/lib/general.lib.js'
 
 // Thing under test

--- a/test/presenters/companies/history.presenter.test.js
+++ b/test/presenters/companies/history.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../support/fixtures/customers.fixture.js'
 
 // Thing under test
 import HistoryPresenter from '../../../app/presenters/companies/history.presenter.js'

--- a/test/presenters/companies/licences.presenter.test.js
+++ b/test/presenters/companies/licences.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../support/fixtures/customers.fixture.js'
 import LicenceHelper from '../../support/helpers/licence.helper.js'
 import LicenceModel from '../../../app/models/licence.model.js'
 import { generateUUID } from '../../../app/lib/general.lib.js'

--- a/test/presenters/company-contacts/communications.presenter.test.js
+++ b/test/presenters/company-contacts/communications.presenter.test.js
@@ -2,9 +2,9 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../support/fixtures/customers.fixture.js'
-import * as NoticesFixture from '../../support/fixtures/notices.fixture.js'
-import * as NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
+import CustomersFixtures from '../../support/fixtures/customers.fixture.js'
+import NoticesFixture from '../../support/fixtures/notices.fixture.js'
+import NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
 
 // Thing under test
 import CommunicationsPresenter from '../../../app/presenters/company-contacts/communications.presenter.js'

--- a/test/presenters/company-contacts/contact-details.presenter.test.js
+++ b/test/presenters/company-contacts/contact-details.presenter.test.js
@@ -2,8 +2,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../support/fixtures/customers.fixture.js'
-import { licenceEnds } from '../../support/fixtures/licence.fixture.js'
+import CustomersFixtures from '../../support/fixtures/customers.fixture.js'
+import LicenceFixture from '../../support/fixtures/licence.fixture.js'
 import { yesterday } from '../../support/general.js'
 
 // Thing under test
@@ -126,7 +126,7 @@ describe('Company Contacts - Contact Details presenter', () => {
 
         describe('when the abstractionAlertType is "some"', () => {
           beforeEach(() => {
-            licences = [licenceEnds()]
+            licences = [LicenceFixture.licenceEnds()]
 
             companyContact.abstractionAlerts = true
             companyContact.abstractionAlertLicences = [licences[0].id]
@@ -152,7 +152,7 @@ describe('Company Contacts - Contact Details presenter', () => {
 
       describe('when one or more licences have ended', () => {
         beforeEach(() => {
-          licences = [licenceEnds(yesterday())]
+          licences = [LicenceFixture.licenceEnds(yesterday())]
         })
 
         it('returns a warning object', () => {

--- a/test/presenters/company-contacts/remove-company-contact.presenter.test.js
+++ b/test/presenters/company-contacts/remove-company-contact.presenter.test.js
@@ -2,8 +2,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../support/fixtures/customers.fixture.js'
-import { licenceEnds } from '../../support/fixtures/licence.fixture.js'
+import CustomersFixtures from '../../support/fixtures/customers.fixture.js'
+import LicenceFixture from '../../support/fixtures/licence.fixture.js'
 
 // Thing under test
 import RemoveCompanyContactPresenter from '../../../app/presenters/company-contacts/remove-company-contact.presenter.js'
@@ -52,7 +52,7 @@ describe('Company Contacts - Remove Company Contact Presenter', () => {
 
       describe('when the abstractionAlertType is "some"', () => {
         beforeEach(() => {
-          licences = [licenceEnds()]
+          licences = [LicenceFixture.licenceEnds()]
 
           companyContact.abstractionAlerts = true
           companyContact.abstractionAlertLicences = [licences[0].id]

--- a/test/presenters/company-contacts/setup/abstraction-alerts.presenter.test.js
+++ b/test/presenters/company-contacts/setup/abstraction-alerts.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import { generateUUID } from '../../../../app/lib/general.lib.js'
 
 // Thing under test

--- a/test/presenters/company-contacts/setup/cancel.presenter.test.js
+++ b/test/presenters/company-contacts/setup/cancel.presenter.test.js
@@ -2,9 +2,9 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
+import LicenceFixture from '../../../support/fixtures/licence.fixture.js'
 import { generateUUID } from '../../../../app/lib/general.lib.js'
-import { licence } from '../../../support/fixtures/licence.fixture.js'
 
 // Thing under test
 import CancelPresenter from '../../../../app/presenters/company-contacts/setup/cancel.presenter.js'
@@ -17,7 +17,7 @@ describe('Company Contacts - Setup - Cancel Presenter', () => {
   beforeEach(() => {
     company = CustomersFixtures.company()
 
-    licences = [licence()]
+    licences = [LicenceFixture.licence()]
 
     session = {
       abstractionAlertLicences: null,

--- a/test/presenters/company-contacts/setup/check.presenter.test.js
+++ b/test/presenters/company-contacts/setup/check.presenter.test.js
@@ -2,9 +2,9 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
+import LicenceFixture from '../../../support/fixtures/licence.fixture.js'
 import { generateUUID } from '../../../../app/lib/general.lib.js'
-import { licence } from '../../../support/fixtures/licence.fixture.js'
 import { yesterday } from '../../../support/general.js'
 
 // Thing under test
@@ -31,7 +31,7 @@ describe('Company Contacts - Setup - Check Presenter', () => {
     name = companyContact.contact.department
     email = companyContact.contact.email
 
-    licences = [licence()]
+    licences = [LicenceFixture.licence()]
 
     sentNotification = undefined
 

--- a/test/presenters/company-contacts/setup/contact-email.presenter.test.js
+++ b/test/presenters/company-contacts/setup/contact-email.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import { generateUUID } from '../../../../app/lib/general.lib.js'
 
 // Thing under test

--- a/test/presenters/company-contacts/setup/contact-name.presenter.test.js
+++ b/test/presenters/company-contacts/setup/contact-name.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import { generateUUID } from '../../../../app/lib/general.lib.js'
 
 // Thing under test

--- a/test/presenters/company-contacts/setup/licences.presenter.test.js
+++ b/test/presenters/company-contacts/setup/licences.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import LicenceHelper from '../../../support/helpers/licence.helper.js'
 import { generateUUID } from '../../../../app/lib/general.lib.js'
 

--- a/test/presenters/company-contacts/setup/restore.presenter.test.js
+++ b/test/presenters/company-contacts/setup/restore.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import { generateUUID } from '../../../../app/lib/general.lib.js'
 
 // Thing under test

--- a/test/presenters/crm.presenter.test.js
+++ b/test/presenters/crm.presenter.test.js
@@ -2,8 +2,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
+import LicenceFixture from '../support/fixtures/licence.fixture.js'
 import { generateUUID } from '../../app/lib/general.lib.js'
-import { licence } from '../support/fixtures/licence.fixture.js'
 
 // Thing under test
 import * as CRMPresenter from '../../app/presenters/crm.presenter.js'
@@ -264,7 +264,7 @@ describe('CRM presenter', () => {
 
     describe('when there are "liveLicences"', () => {
       beforeEach(() => {
-        liveLicences = [licence()]
+        liveLicences = [LicenceFixture.licence()]
       })
 
       describe('and the user is set to receive "some" notices', () => {

--- a/test/presenters/customer.presenter.test.js
+++ b/test/presenters/customer.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../support/fixtures/customers.fixture.js'
 
 // Thing under test
 import * as CustomerPresenter from '../../app/presenters/customer.presenter.js'

--- a/test/presenters/licence-versions/view.presenter.test.js
+++ b/test/presenters/licence-versions/view.presenter.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'
+import ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'
 import { generateUUID } from '../../../app/lib/general.lib.js'
 
 // Things we need to stub

--- a/test/presenters/licence.presenter.test.js
+++ b/test/presenters/licence.presenter.test.js
@@ -2,10 +2,10 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as ViewLicencesFixture from '../support/fixtures/view-licences.fixture.js'
+import LicenceFixture from '../support/fixtures/licence.fixture.js'
 import PointModel from '../../app/models/point.model.js'
+import ViewLicencesFixture from '../support/fixtures/view-licences.fixture.js'
 import { generateUUID } from '../../app/lib/general.lib.js'
-import { licenceEnds } from '../support/fixtures/licence.fixture.js'
 
 // Thing under test
 import * as LicencePresenter from '../../app/presenters/licence.presenter.js'
@@ -731,7 +731,7 @@ describe('Licences presenter', () => {
 
     describe('when the licence does not have an "end" date', () => {
       beforeEach(() => {
-        licence = licenceEnds()
+        licence = LicenceFixture.licenceEnds()
       })
 
       it('returns null', () => {
@@ -744,7 +744,7 @@ describe('Licences presenter', () => {
     describe('when the licence does have an "end" date', () => {
       describe('but it is in the future', () => {
         beforeEach(() => {
-          licence = licenceEnds(new Date('2099-04-01'))
+          licence = LicenceFixture.licenceEnds(new Date('2099-04-01'))
         })
 
         it('returns null', () => {
@@ -756,7 +756,7 @@ describe('Licences presenter', () => {
 
       describe('because it expired in the past', () => {
         beforeEach(() => {
-          licence = licenceEnds(new Date('2019-04-01'))
+          licence = LicenceFixture.licenceEnds(new Date('2019-04-01'))
         })
 
         it('returns "This licence expired on 1 April 2019"', () => {
@@ -771,7 +771,7 @@ describe('Licences presenter', () => {
 
       describe('because it lapsed in the past', () => {
         beforeEach(() => {
-          licence = licenceEnds()
+          licence = LicenceFixture.licenceEnds()
           licence.lapsedDate = new Date('2019-04-01')
         })
 
@@ -787,7 +787,7 @@ describe('Licences presenter', () => {
 
       describe('because it was revoked in the past', () => {
         beforeEach(() => {
-          licence = licenceEnds()
+          licence = LicenceFixture.licenceEnds()
           licence.revokedDate = new Date('2019-04-01')
         })
 

--- a/test/presenters/licences/communications.presenter.test.js
+++ b/test/presenters/licences/communications.presenter.test.js
@@ -2,9 +2,9 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test Helpers
-import * as NoticesFixture from '../../support/fixtures/notices.fixture.js'
-import * as NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
 import LicenceHelper from '../../support/helpers/licence.helper.js'
+import NoticesFixture from '../../support/fixtures/notices.fixture.js'
+import NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
 import { generateUUID } from '../../../app/lib/general.lib.js'
 
 // Thing under test

--- a/test/presenters/licences/conditions.presenter.test.js
+++ b/test/presenters/licences/conditions.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'
+import ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'
 
 // Thing under test
 import ConditionsPresenter from '../../../app/presenters/licences/conditions.presenter.js'

--- a/test/presenters/licences/points.presenter.test.js
+++ b/test/presenters/licences/points.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'
+import ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'
 
 // Thing under test
 import PointsPresenter from '../../../app/presenters/licences/points.presenter.js'

--- a/test/presenters/licences/purposes.presenter.test.js
+++ b/test/presenters/licences/purposes.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'
+import ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'
 
 // Thing under test
 import PurposesPresenter from '../../../app/presenters/licences/purposes.presenter.js'

--- a/test/presenters/licences/set-up.presenter.test.js
+++ b/test/presenters/licences/set-up.presenter.test.js
@@ -2,8 +2,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'
 import ReturnVersionModel from '../../../app/models/return-version.model.js'
+import ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'
 import { generateUUID } from '../../../app/lib/general.lib.js'
 
 // Thing under test

--- a/test/presenters/licences/summary-heading.presenter.test.js
+++ b/test/presenters/licences/summary-heading.presenter.test.js
@@ -2,9 +2,9 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'
+import LicenceFixture from '../../support/fixtures/licence.fixture.js'
 import LicenceModel from '../../../app/models/licence.model.js'
-import { licenceEnds } from '../../support/fixtures/licence.fixture.js'
+import ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'
 
 // Thing under test
 import SummaryHeadingPresenter from '../../../app/presenters/licences/summary-heading.presenter.js'
@@ -110,7 +110,7 @@ describe('Licences - Summary Heading presenter', () => {
   describe('the "warning" property', () => {
     describe('when the licence has ended', () => {
       beforeEach(() => {
-        licence = licenceEnds(new Date('2019-04-01'))
+        licence = LicenceFixture.licenceEnds(new Date('2019-04-01'))
       })
 
       it('returns the warning', () => {

--- a/test/presenters/licences/summary.presenter.test.js
+++ b/test/presenters/licences/summary.presenter.test.js
@@ -2,10 +2,10 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'
 import CompanyModel from '../../../app/models/company.model.js'
 import LicenceModel from '../../../app/models/licence.model.js'
 import PointModel from '../../../app/models/point.model.js'
+import ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'
 import { generateUUID, today } from '../../../app/lib/general.lib.js'
 
 // Thing under test

--- a/test/presenters/monitoring-stations/view-licence.presenter.test.js
+++ b/test/presenters/monitoring-stations/view-licence.presenter.test.js
@@ -2,9 +2,9 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
+import LicenceFixture from '../../support/fixtures/licence.fixture.js'
 import UserHelper from '../../support/helpers/user.helper.js'
 import { generateUUID } from '../../../app/lib/general.lib.js'
-import { licenceEnds } from '../../support/fixtures/licence.fixture.js'
 
 // Thing under test
 import ViewLicencePresenter from '../../../app/presenters/monitoring-stations/view-licence.presenter.js'
@@ -22,7 +22,7 @@ describe('Monitoring Stations - View Licence presenter', () => {
       }
     }
 
-    licence = licenceEnds()
+    licence = LicenceFixture.licenceEnds()
 
     licenceMonitoringStations = [
       {
@@ -399,7 +399,7 @@ describe('Monitoring Stations - View Licence presenter', () => {
   describe('the "warning" property', () => {
     describe('when the licence has ended', () => {
       beforeEach(() => {
-        licence = licenceEnds(new Date('2000-01-01'))
+        licence = LicenceFixture.licenceEnds(new Date('2000-01-01'))
       })
 
       it('returns the warning', () => {

--- a/test/presenters/notices/base.presenter.test.js
+++ b/test/presenters/notices/base.presenter.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as RecipientsFixture from '../../support/fixtures/recipients.fixture.js'
+import RecipientsFixture from '../../support/fixtures/recipients.fixture.js'
 
 // Thing under test
 import * as BasePresenter from '../../../app/presenters/notices/base.presenter.js'

--- a/test/presenters/notices/index-notices.presenter.test.js
+++ b/test/presenters/notices/index-notices.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as NoticesFixture from '../../support/fixtures/notices.fixture.js'
+import NoticesFixture from '../../support/fixtures/notices.fixture.js'
 
 // Thing under test
 import IndexNoticesPresenter from '../../../app/presenters/notices/index-notices.presenter.js'

--- a/test/presenters/notices/setup/abstraction-alert-notifications.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alert-notifications.presenter.test.js
@@ -2,8 +2,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as AbstractionAlertSessionDataFixture from '../../../support/fixtures/abstraction-alert-session-data.fixture.js'
-import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
+import AbstractionAlertSessionDataFixture from '../../../support/fixtures/abstraction-alert-session-data.fixture.js'
+import RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 
 // Thing under test
 import AbstractionAlertNotificationsPresenter from '../../../../app/presenters/notices/setup/abstraction-alert-notifications.presenter.js'

--- a/test/presenters/notices/setup/abstraction-alerts/alert-email-address.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alerts/alert-email-address.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
+import AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 
 // Thing under test
 import AlertEmailAddressPresenter from '../../../../../app/presenters/notices/setup/abstraction-alerts/alert-email-address.presenter.js'

--- a/test/presenters/notices/setup/abstraction-alerts/alert-thresholds.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alerts/alert-thresholds.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
+import AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 
 // Thing under test
 import AlertThresholdsPresenter from '../../../../../app/presenters/notices/setup/abstraction-alerts/alert-thresholds.presenter.js'

--- a/test/presenters/notices/setup/abstraction-alerts/alert-type.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alerts/alert-type.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
+import AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 
 // Thing under test
 import AlertTypePresenter from '../../../../../app/presenters/notices/setup/abstraction-alerts/alert-type.presenter.js'

--- a/test/presenters/notices/setup/abstraction-alerts/cancel-alerts.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alerts/cancel-alerts.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
+import AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 
 // Thing under test
 import CancelAlertsPresenter from '../../../../../app/presenters/notices/setup/abstraction-alerts/cancel-alerts.presenter.js'

--- a/test/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
+import AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 
 // Thing under test
 import CheckLicenceMatchesPresenter from '../../../../../app/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.js'

--- a/test/presenters/notices/setup/check.presenter.test.js
+++ b/test/presenters/notices/setup/check.presenter.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
+import RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 import { generateNoticeReferenceCode, generateUUID } from '../../../../app/lib/general.lib.js'
 
 //

--- a/test/presenters/notices/setup/contact.presenter.test.js
+++ b/test/presenters/notices/setup/contact.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
+import RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 
 // Thing under test
 import ContactPresenter from '../../../../app/presenters/notices/setup/contact.presenter.js'

--- a/test/presenters/notices/setup/create-notice.presenter.test.js
+++ b/test/presenters/notices/setup/create-notice.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
+import RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 import { formatDateObjectToISO } from '../../../../app/lib/dates.lib.js'
 import { futureDueDate } from '../../../../app/presenters/notices/base.presenter.js'
 

--- a/test/presenters/notices/setup/download-abstraction-alert.presenter.test.js
+++ b/test/presenters/notices/setup/download-abstraction-alert.presenter.test.js
@@ -2,8 +2,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as AbstractionAlertSessionData from '../../../support/fixtures/abstraction-alert-session-data.fixture.js'
-import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
+import AbstractionAlertSessionData from '../../../support/fixtures/abstraction-alert-session-data.fixture.js'
+import RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 
 // Thing under test
 import DownloadAbstractionAlertPresenter from '../../../../app/presenters/notices/setup/download-abstraction-alert.presenter.js'

--- a/test/presenters/notices/setup/download-renewal-invitation.presenter.test.js
+++ b/test/presenters/notices/setup/download-renewal-invitation.presenter.test.js
@@ -2,9 +2,9 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as NoticeSessionFixture from '../../../support/fixtures/notice-session.fixture.js'
-import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 import LicenceHelper from '../../../support/helpers/licence.helper.js'
+import NoticeSessionFixture from '../../../support/fixtures/notice-session.fixture.js'
+import RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 import { addressToCSV } from '../../../../app/presenters/notices/base.presenter.js'
 import { transformArrayToCSVRow } from '../../../../app/lib/transform-to-csv.lib.js'
 

--- a/test/presenters/notices/setup/download-returns-notice.presenter.test.js
+++ b/test/presenters/notices/setup/download-returns-notice.presenter.test.js
@@ -2,8 +2,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as NoticeSessionFixture from '../../../support/fixtures/notice-session.fixture.js'
-import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
+import NoticeSessionFixture from '../../../support/fixtures/notice-session.fixture.js'
+import RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 import { addressToCSV } from '../../../../app/presenters/notices/base.presenter.js'
 import { transformArrayToCSVRow } from '../../../../app/lib/transform-to-csv.lib.js'
 

--- a/test/presenters/notices/setup/paper-return-notifications.presenter.test.js
+++ b/test/presenters/notices/setup/paper-return-notifications.presenter.test.js
@@ -2,9 +2,9 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
-import * as ReturnLogFixture from '../../../support/fixtures/return-logs.fixture.js'
 import LicenceHelper from '../../../support/helpers/licence.helper.js'
+import RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
+import ReturnLogFixture from '../../../support/fixtures/return-logs.fixture.js'
 import { formatLongDate } from '../../../../app/presenters/base.presenter.js'
 import { futureDueDate } from '../../../../app/presenters/notices/base.presenter.js'
 

--- a/test/presenters/notices/setup/prepare-paper-return.presenter.test.js
+++ b/test/presenters/notices/setup/prepare-paper-return.presenter.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as ReturnLogFixture from '../../../support/fixtures/return-logs.fixture.js'
+import ReturnLogFixture from '../../../support/fixtures/return-logs.fixture.js'
 
 // Thing under test
 import PreparePaperReturnPresenter from '../../../../app/presenters/notices/setup/prepare-paper-return.presenter.js'

--- a/test/presenters/notices/setup/preview/preview-check-alert.presenter.test.js
+++ b/test/presenters/notices/setup/preview/preview-check-alert.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
+import AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 
 // Thing under test
 import PreviewCheckAlertPresenter from '../../../../../app/presenters/notices/setup/preview/preview-check-alert.presenter.js'

--- a/test/presenters/notices/setup/renewal-invitation-notifications.presenter.test.js
+++ b/test/presenters/notices/setup/renewal-invitation-notifications.presenter.test.js
@@ -2,9 +2,9 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 import LicenceHelper from '../../../support/helpers/licence.helper.js'
 import { NOTIFY_TEMPLATES } from '../../../../app/lib/notify-templates.lib.js'
+import RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 
 // Thing under test
 import RenewalInvitationNotificationsPresenter from '../../../../app/presenters/notices/setup/renewal-invitation-notice-notifications.presenter.js'

--- a/test/presenters/notices/setup/returns-notice-notifications.presenter.test.js
+++ b/test/presenters/notices/setup/returns-notice-notifications.presenter.test.js
@@ -2,8 +2,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 import { NOTIFY_TEMPLATES } from '../../../../app/lib/notify-templates.lib.js'
+import RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 import { formatLongDate } from '../../../../app/presenters/base.presenter.js'
 import { futureDueDate } from '../../../../app/presenters/notices/base.presenter.js'
 import { generateUUID } from '../../../../app/lib/general.lib.js'

--- a/test/presenters/notices/setup/select-recipients.presenter.test.js
+++ b/test/presenters/notices/setup/select-recipients.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
+import RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 import { generateNoticeReferenceCode } from '../../../../app/lib/general.lib.js'
 
 // Thing under test

--- a/test/presenters/notifications/notification-error.presenter.test.js
+++ b/test/presenters/notifications/notification-error.presenter.test.js
@@ -2,8 +2,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as NoticesFixture from '../../support/fixtures/notices.fixture.js'
-import * as NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
+import NoticesFixture from '../../support/fixtures/notices.fixture.js'
+import NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
 
 // Thing under test
 import NotificationErrorPresenter from '../../../app/presenters/notifications/notification-error.presenter.js'

--- a/test/presenters/notifications/notifications-table.presenter.test.js
+++ b/test/presenters/notifications/notifications-table.presenter.test.js
@@ -2,8 +2,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as NoticesFixture from '../../support/fixtures/notices.fixture.js'
-import * as NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
+import NoticesFixture from '../../support/fixtures/notices.fixture.js'
+import NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
 import { generateUUID } from '../../../app/lib/general.lib.js'
 
 // Thing under test

--- a/test/presenters/notifications/view-notification.presenter.test.js
+++ b/test/presenters/notifications/view-notification.presenter.test.js
@@ -2,9 +2,9 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as NoticesFixture from '../../support/fixtures/notices.fixture.js'
-import * as NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
 import LicenceHelper from '../../support/helpers/licence.helper.js'
+import NoticesFixture from '../../support/fixtures/notices.fixture.js'
+import NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
 import { generateUUID } from '../../../app/lib/general.lib.js'
 
 // Thing under test

--- a/test/presenters/return-logs/communications.presenter.test.js
+++ b/test/presenters/return-logs/communications.presenter.test.js
@@ -2,9 +2,9 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as NoticesFixture from '../../support/fixtures/notices.fixture.js'
-import * as NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
 import LicenceHelper from '../../support/helpers/licence.helper.js'
+import NoticesFixture from '../../support/fixtures/notices.fixture.js'
+import NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
 import { generateUUID } from '../../../app/lib/general.lib.js'
 
 // Thing under test

--- a/test/presenters/return-logs/details.presenter.test.js
+++ b/test/presenters/return-logs/details.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as ReturnLogsFixture from '../../support/fixtures/return-logs.fixture.js'
+import ReturnLogsFixture from '../../support/fixtures/return-logs.fixture.js'
 import { formatNumber } from '../../../app/presenters/base.presenter.js'
 import { today } from '../../../app/lib/general.lib.js'
 import { unitNames } from '../../../app/lib/static-lookups.lib.js'

--- a/test/presenters/return-logs/download-return-log.presenter.test.js
+++ b/test/presenters/return-logs/download-return-log.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeAll, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as ReturnLogsFixture from '../../support/fixtures/return-logs.fixture.js'
+import ReturnLogsFixture from '../../support/fixtures/return-logs.fixture.js'
 import { formatDateObjectToISO } from '../../../app/lib/dates.lib.js'
 
 // Thing under test

--- a/test/presenters/users/external/communications.presenter.test.js
+++ b/test/presenters/users/external/communications.presenter.test.js
@@ -2,8 +2,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as NotificationsFixture from '../../../support/fixtures/notifications.fixture.js'
-import * as UsersFixture from '../../../support/fixtures/users.fixture.js'
+import NotificationsFixture from '../../../support/fixtures/notifications.fixture.js'
+import UsersFixture from '../../../support/fixtures/users.fixture.js'
 
 // Thing under test
 import CommunicationsPresenter from '../../../../app/presenters/users/external/communications.presenter.js'

--- a/test/presenters/users/external/details.presenter.test.js
+++ b/test/presenters/users/external/details.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as UsersFixture from '../../../support/fixtures/users.fixture.js'
+import UsersFixture from '../../../support/fixtures/users.fixture.js'
 
 // Thing under test
 import DetailsPresenter from '../../../../app/presenters/users/external/details.presenter.js'

--- a/test/presenters/users/external/licences.presenter.test.js
+++ b/test/presenters/users/external/licences.presenter.test.js
@@ -2,8 +2,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as UsersFixture from '../../../support/fixtures/users.fixture.js'
-import { licenceEnds } from '../../../support/fixtures/licence.fixture.js'
+import LicenceFixture from '../../../support/fixtures/licence.fixture.js'
+import UsersFixture from '../../../support/fixtures/users.fixture.js'
 import { tomorrow } from '../../../support/general.js'
 import { generateUUID, today } from '../../../../app/lib/general.lib.js'
 
@@ -147,7 +147,7 @@ function _licence(licenceRef, expiredDate, role) {
   const licenceVersionId = generateUUID()
   const licenceDocumentHeaderId = generateUUID()
 
-  const licence = licenceEnds(expiredDate)
+  const licence = LicenceFixture.licenceEnds(expiredDate)
 
   licence.licenceVersions = [
     {

--- a/test/presenters/users/external/setup/cancel.presenter.test.js
+++ b/test/presenters/users/external/setup/cancel.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as UserSessionsFixture from '../../../../support/fixtures/user-sessions.fixture.js'
+import UserSessionsFixture from '../../../../support/fixtures/user-sessions.fixture.js'
 
 // Thing under test
 import CancelPresenter from '../../../../../app/presenters/users/external/setup/cancel.presenter.js'

--- a/test/presenters/users/external/setup/check.presenter.test.js
+++ b/test/presenters/users/external/setup/check.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as UserSessionsFixture from '../../../../support/fixtures/user-sessions.fixture.js'
+import UserSessionsFixture from '../../../../support/fixtures/user-sessions.fixture.js'
 
 // Thing under test
 import CheckPresenter from '../../../../../app/presenters/users/external/setup/check.presenter.js'

--- a/test/presenters/users/external/setup/licences.presenter.test.js
+++ b/test/presenters/users/external/setup/licences.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as UserSessionsFixture from '../../../../support/fixtures/user-sessions.fixture.js'
+import UserSessionsFixture from '../../../../support/fixtures/user-sessions.fixture.js'
 
 // Thing under test
 import LicencesPresenter from '../../../../../app/presenters/users/external/setup/licences.presenter.js'

--- a/test/presenters/users/external/verifications.presenter.test.js
+++ b/test/presenters/users/external/verifications.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as UsersFixture from '../../../support/fixtures/users.fixture.js'
+import UsersFixture from '../../../support/fixtures/users.fixture.js'
 import { formatLongDate } from '../../../../app/presenters/base.presenter.js'
 import { yesterday } from '../../../support/general.js'
 import { generateUUID, today } from '../../../../app/lib/general.lib.js'

--- a/test/presenters/users/index-users.presenter.test.js
+++ b/test/presenters/users/index-users.presenter.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as UsersFixture from '../../support/fixtures/users.fixture.js'
+import UsersFixture from '../../support/fixtures/users.fixture.js'
 
 // Things we need to stub
 import FeatureFlagsConfig from '../../../config/feature-flags.config.js'

--- a/test/presenters/users/internal/communications.presenter.test.js
+++ b/test/presenters/users/internal/communications.presenter.test.js
@@ -2,8 +2,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as NotificationsFixture from '../../../support/fixtures/notifications.fixture.js'
-import * as UsersFixture from '../../../support/fixtures/users.fixture.js'
+import NotificationsFixture from '../../../support/fixtures/notifications.fixture.js'
+import UsersFixture from '../../../support/fixtures/users.fixture.js'
 
 // Thing under test
 import CommunicationsPresenter from '../../../../app/presenters/users/internal/communications.presenter.js'

--- a/test/presenters/users/internal/details.presenter.test.js
+++ b/test/presenters/users/internal/details.presenter.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as UsersFixture from '../../../support/fixtures/users.fixture.js'
+import UsersFixture from '../../../support/fixtures/users.fixture.js'
 
 // Thing under test
 import DetailsPresenter from '../../../../app/presenters/users/internal/details.presenter.js'

--- a/test/presenters/users/notification.presenter.test.js
+++ b/test/presenters/users/notification.presenter.test.js
@@ -2,8 +2,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
-import * as UsersFixture from '../../support/fixtures/users.fixture.js'
+import NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
+import UsersFixture from '../../support/fixtures/users.fixture.js'
 
 // Thing under test
 import NotificationPresenter from '../../../app/presenters/users/notification.presenter.js'

--- a/test/presenters/users/notifications-table.presenter.test.js
+++ b/test/presenters/users/notifications-table.presenter.test.js
@@ -2,8 +2,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
-import * as UsersFixture from '../../support/fixtures/users.fixture.js'
+import NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
+import UsersFixture from '../../support/fixtures/users.fixture.js'
 
 // Thing under test
 import NotificationsTablePresenter from '../../../app/presenters/users/notifications-table.presenter.js'

--- a/test/services/bill-runs/review/preview.service.test.js
+++ b/test/services/bill-runs/review/preview.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
+import BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 import http2 from 'node:http2'
 
 // Test helpers

--- a/test/services/bill-runs/review/submit-authorised.service.test.js
+++ b/test/services/bill-runs/review/submit-authorised.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
+import BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 import YarStub from '../../../support/stubs/yar.stub.js'
 
 // Things we need to stub

--- a/test/services/bill-runs/review/submit-edit.service.test.js
+++ b/test/services/bill-runs/review/submit-edit.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
+import BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 import YarStub from '../../../support/stubs/yar.stub.js'
 
 // Things we need to stub

--- a/test/services/bill-runs/review/submit-factors.service.test.js
+++ b/test/services/bill-runs/review/submit-factors.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
+import BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 import YarStub from '../../../support/stubs/yar.stub.js'
 
 // Things we need to stub

--- a/test/services/bill-runs/review/submit-remove.service.test.js
+++ b/test/services/bill-runs/review/submit-remove.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
+import BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 import YarStub from '../../../support/stubs/yar.stub.js'
 
 // Things we need to stub

--- a/test/services/bill-runs/review/submit-review-licence.service.test.js
+++ b/test/services/bill-runs/review/submit-review-licence.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
+import BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 import ReviewLicenceModel from '../../../../app/models/review-licence.model.js'
 import YarStub from '../../../support/stubs/yar.stub.js'
 

--- a/test/services/bill-runs/review/view-authorised.service.test.js
+++ b/test/services/bill-runs/review/view-authorised.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
+import BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 
 // Things we need to stub
 import * as FetchReviewChargeReferenceService from '../../../../app/services/bill-runs/review/fetch-review-charge-reference.service.js'

--- a/test/services/bill-runs/review/view-edit.service.test.js
+++ b/test/services/bill-runs/review/view-edit.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
+import BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 
 // Things we need to stub
 import * as FetchReviewChargeElementService from '../../../../app/services/bill-runs/review/fetch-review-charge-element.service.js'

--- a/test/services/bill-runs/review/view-factors.service.test.js
+++ b/test/services/bill-runs/review/view-factors.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
+import BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 
 // Things we need to stub
 import * as FetchReviewChargeReferenceService from '../../../../app/services/bill-runs/review/fetch-review-charge-reference.service.js'

--- a/test/services/bill-runs/review/view-remove.service.test.js
+++ b/test/services/bill-runs/review/view-remove.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
+import BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 
 // Things we need to stub
 import * as FetchRemoveReviewLicenceService from '../../../../app/services/bill-runs/review/fetch-remove-review-licence.service.js'

--- a/test/services/bill-runs/review/view-review-charge-element.service.test.js
+++ b/test/services/bill-runs/review/view-review-charge-element.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
+import BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 import YarStub from '../../../support/stubs/yar.stub.js'
 
 // Things we need to stub

--- a/test/services/bill-runs/review/view-review-charge-reference.service.test.js
+++ b/test/services/bill-runs/review/view-review-charge-reference.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
+import BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 import YarStub from '../../../support/stubs/yar.stub.js'
 
 // Things we need to stub

--- a/test/services/bill-runs/review/view-review-licence.service.test.js
+++ b/test/services/bill-runs/review/view-review-licence.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
+import BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 import YarStub from '../../../support/stubs/yar.stub.js'
 
 // Things we need to stub

--- a/test/services/bill-runs/tpt-supplementary/process-billing-period.service.test.js
+++ b/test/services/bill-runs/tpt-supplementary/process-billing-period.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as TwoPartTariffFixture from '../../../support/fixtures/two-part-tariff.fixture.js'
 import RegionHelper from '../../../support/helpers/region.helper.js'
+import TwoPartTariffFixture from '../../../support/fixtures/two-part-tariff.fixture.js'
 
 // Things we need to stub
 import * as FetchPreviousTransactionsService from '../../../../app/services/bill-runs/fetch-previous-transactions.service.js'

--- a/test/services/bill-runs/two-part-tariff/process-billing-period.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/process-billing-period.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as TwoPartTariffFixture from '../../../support/fixtures/two-part-tariff.fixture.js'
 import RegionHelper from '../../../support/helpers/region.helper.js'
+import TwoPartTariffFixture from '../../../support/fixtures/two-part-tariff.fixture.js'
 
 // Things we need to stub
 import * as GenerateTwoPartTariffTransactionService from '../../../../app/services/bill-runs/generate-two-part-tariff-transaction.service.js'

--- a/test/services/billing-accounts/setup/initiate-session.service.test.js
+++ b/test/services/billing-accounts/setup/initiate-session.service.test.js
@@ -2,7 +2,7 @@
 import { beforeAll, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 
 // Things we need to stub
 import * as FetchViewBillingAccountService from '../../../../app/services/billing-accounts/fetch-view-billing-account.service.js'

--- a/test/services/billing-accounts/setup/submit-account-type.service.test.js
+++ b/test/services/billing-accounts/setup/submit-account-type.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 
 // Things we need to stub

--- a/test/services/billing-accounts/setup/submit-account.service.test.js
+++ b/test/services/billing-accounts/setup/submit-account.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 
 // Things we need to stub

--- a/test/services/billing-accounts/setup/submit-check.service.test.js
+++ b/test/services/billing-accounts/setup/submit-check.service.test.js
@@ -2,12 +2,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as CustomersFixture from '../../../support/fixtures/customers.fixture.js'
 import AddressHelper from '../../../support/helpers/address.helper.js'
 import BillingAccountAddressHelper from '../../../support/helpers/billing-account-address.helper.js'
 import BillingAccountHelper from '../../../support/helpers/billing-account.helper.js'
 import CompanyHelper from '../../../support/helpers/company.helper.js'
 import ContactHelper from '../../../support/helpers/contact.helper.js'
+import CustomersFixture from '../../../support/fixtures/customers.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 
 // Things to stub

--- a/test/services/billing-accounts/setup/submit-company-search.service.test.js
+++ b/test/services/billing-accounts/setup/submit-company-search.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 
 // Things we need to stub

--- a/test/services/billing-accounts/setup/submit-contact-name.service.test.js
+++ b/test/services/billing-accounts/setup/submit-contact-name.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 
 // Things we need to stub

--- a/test/services/billing-accounts/setup/submit-contact.service.test.js
+++ b/test/services/billing-accounts/setup/submit-contact.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
-import * as CustomersFixture from '../../../support/fixtures/customers.fixture.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
+import CustomersFixture from '../../../support/fixtures/customers.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 
 // Things we need to stub

--- a/test/services/billing-accounts/setup/submit-existing-account.service.test.js
+++ b/test/services/billing-accounts/setup/submit-existing-account.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 
 import { generateUUID } from '../../../../app/lib/general.lib.js'

--- a/test/services/billing-accounts/setup/submit-existing-address.service.test.js
+++ b/test/services/billing-accounts/setup/submit-existing-address.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import { generateUUID } from '../../../../app/lib/general.lib.js'
 

--- a/test/services/billing-accounts/setup/submit-fao.service.test.js
+++ b/test/services/billing-accounts/setup/submit-fao.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 
 // Things we need to stub

--- a/test/services/billing-accounts/setup/submit-select-company.service.test.js
+++ b/test/services/billing-accounts/setup/submit-select-company.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import * as FetchCompaniesService from '../../../../app/services/billing-accounts/setup/fetch-companies.service.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 
 // Things we need to stub

--- a/test/services/billing-accounts/setup/view-account-type.service.test.js
+++ b/test/services/billing-accounts/setup/view-account-type.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 
 // Things we need to stub

--- a/test/services/billing-accounts/setup/view-account.service.test.js
+++ b/test/services/billing-accounts/setup/view-account.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 
 // Things we need to stub

--- a/test/services/billing-accounts/setup/view-check.service.test.js
+++ b/test/services/billing-accounts/setup/view-check.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 
 // Things we need to stub

--- a/test/services/billing-accounts/setup/view-company-search.service.test.js
+++ b/test/services/billing-accounts/setup/view-company-search.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 
 // Things we need to stub

--- a/test/services/billing-accounts/setup/view-contact-name.service.test.js
+++ b/test/services/billing-accounts/setup/view-contact-name.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 
 // Things we need to stub

--- a/test/services/billing-accounts/setup/view-contact.service.test.js
+++ b/test/services/billing-accounts/setup/view-contact.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
-import * as CustomersFixture from '../../../support/fixtures/customers.fixture.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
+import CustomersFixture from '../../../support/fixtures/customers.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 
 // Things we need to stub

--- a/test/services/billing-accounts/setup/view-existing-account.service.test.js
+++ b/test/services/billing-accounts/setup/view-existing-account.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import { generateUUID } from '../../../../app/lib/general.lib.js'
 

--- a/test/services/billing-accounts/setup/view-existing-address.service.test.js
+++ b/test/services/billing-accounts/setup/view-existing-address.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 
 // Things we need to stub

--- a/test/services/billing-accounts/setup/view-fao.service.test.js
+++ b/test/services/billing-accounts/setup/view-fao.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 
 // Things we need to stub

--- a/test/services/billing-accounts/setup/view-select-company.service.test.js
+++ b/test/services/billing-accounts/setup/view-select-company.service.test.js
@@ -9,7 +9,7 @@ import * as FetchCompaniesService from '../../../../app/services/billing-account
 import * as FetchSessionDal from '../../../../app/dal/fetch-session.dal.js'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
+import BillingAccountsFixture from '../../../support/fixtures/billing-accounts.fixture.js'
 
 // Thing under test
 import ViewSelectCompanyService from '../../../../app/services/billing-accounts/setup/view-select-company.service.js'

--- a/test/services/billing-accounts/view-billing-account.service.test.js
+++ b/test/services/billing-accounts/view-billing-account.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as BillingAccountsFixture from '../../support/fixtures/billing-accounts.fixture.js'
+import BillingAccountsFixture from '../../support/fixtures/billing-accounts.fixture.js'
 import { generateUUID } from '../../../app/lib/general.lib.js'
 
 // Things we need to stub

--- a/test/services/companies/view-billing-accounts.service.test.js
+++ b/test/services/companies/view-billing-accounts.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../support/fixtures/customers.fixture.js'
 
 // Things we need to stub
 import * as FetchBillingAccountsDal from '../../../app/dal/companies/fetch-billing-accounts.dal.js'

--- a/test/services/companies/view-company-with-address.service.test.js
+++ b/test/services/companies/view-company-with-address.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../support/fixtures/customers.fixture.js'
 
 // Things we need to stub
 import * as FetchAddressDal from '../../../app/dal/companies/fetch-address.dal.js'

--- a/test/services/companies/view-company.service.test.js
+++ b/test/services/companies/view-company.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../support/fixtures/customers.fixture.js'
 
 // Things we need to stub
 import * as FetchCompanyDetailsDal from '../../../app/dal/companies/fetch-company-details.dal.js'

--- a/test/services/companies/view-contacts.service.test.js
+++ b/test/services/companies/view-contacts.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../support/fixtures/customers.fixture.js'
 import { generateUUID } from '../../../app/lib/general.lib.js'
 
 // Test helpers

--- a/test/services/companies/view-history.service.test.js
+++ b/test/services/companies/view-history.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../support/fixtures/customers.fixture.js'
 
 // Things we need to stub
 import * as FetchCompanyDal from '../../../app/dal/companies/fetch-company.dal.js'

--- a/test/services/companies/view-licences.service.test.js
+++ b/test/services/companies/view-licences.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../support/fixtures/customers.fixture.js'
 import LicenceModel from '../../../app/models/licence.model.js'
 
 // Things we need to stub

--- a/test/services/company-contacts/fetch-notification.service.test.js
+++ b/test/services/company-contacts/fetch-notification.service.test.js
@@ -2,10 +2,10 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as NoticesFixture from '../../support/fixtures/notices.fixture.js'
-import * as NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
 import EventHelper from '../../support/helpers/event.helper.js'
+import NoticesFixture from '../../support/fixtures/notices.fixture.js'
 import NotificationHelper from '../../support/helpers/notification.helper.js'
+import NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
 import { generateUUID } from '../../../app/lib/general.lib.js'
 
 // Thing under test

--- a/test/services/company-contacts/setup/initiate-edit-session.service.test.js
+++ b/test/services/company-contacts/setup/initiate-edit-session.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import CompanyContactModel from '../../../../app/models/company-contact.model.js'
+import CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import LicenceHelper from '../../../support/helpers/licence.helper.js'
 import SessionModel from '../../../../app/models/session.model.js'
 import { generateUUID } from '../../../../app/lib/general.lib.js'

--- a/test/services/company-contacts/setup/initiate-session.service.test.js
+++ b/test/services/company-contacts/setup/initiate-session.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import LicenceHelper from '../../../support/helpers/licence.helper.js'
 import SessionModel from '../../../../app/models/session.model.js'
 import { generateUUID } from '../../../../app/lib/general.lib.js'

--- a/test/services/company-contacts/setup/submit-abstraction-alerts.service.test.js
+++ b/test/services/company-contacts/setup/submit-abstraction-alerts.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import YarStub from '../../../support/stubs/yar.stub.js'
 

--- a/test/services/company-contacts/setup/submit-cancel.service.test.js
+++ b/test/services/company-contacts/setup/submit-cancel.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import { generateUUID } from '../../../../app/lib/general.lib.js'
 

--- a/test/services/company-contacts/setup/submit-check.service.test.js
+++ b/test/services/company-contacts/setup/submit-check.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import SessionModel from '../../../../app/models/session.model.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import { generateUUID } from '../../../../app/lib/general.lib.js'

--- a/test/services/company-contacts/setup/submit-contact-email.service.test.js
+++ b/test/services/company-contacts/setup/submit-contact-email.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import YarStub from '../../../support/stubs/yar.stub.js'
 

--- a/test/services/company-contacts/setup/submit-contact-name.service.test.js
+++ b/test/services/company-contacts/setup/submit-contact-name.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import YarStub from '../../../support/stubs/yar.stub.js'
 

--- a/test/services/company-contacts/setup/submit-licences.service.test.js
+++ b/test/services/company-contacts/setup/submit-licences.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import LicenceHelper from '../../../support/helpers/licence.helper.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import { generateUUID } from '../../../../app/lib/general.lib.js'

--- a/test/services/company-contacts/setup/submit-restore.service.test.js
+++ b/test/services/company-contacts/setup/submit-restore.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import { generateUUID } from '../../../../app/lib/general.lib.js'
 

--- a/test/services/company-contacts/setup/view-abstraction-alerts.service.test.js
+++ b/test/services/company-contacts/setup/view-abstraction-alerts.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 
 // Things we need to stub

--- a/test/services/company-contacts/setup/view-cancel.service.test.js
+++ b/test/services/company-contacts/setup/view-cancel.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 
 // Things we need to stub

--- a/test/services/company-contacts/setup/view-check.service.test.js
+++ b/test/services/company-contacts/setup/view-check.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import YarStub from '../../../support/stubs/yar.stub.js'
 

--- a/test/services/company-contacts/setup/view-contact-email.service.test.js
+++ b/test/services/company-contacts/setup/view-contact-email.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 
 // Things we need to stub

--- a/test/services/company-contacts/setup/view-contact-name.service.test.js
+++ b/test/services/company-contacts/setup/view-contact-name.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 
 // Things we need to stub

--- a/test/services/company-contacts/setup/view-licences.service.test.js
+++ b/test/services/company-contacts/setup/view-licences.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import LicenceHelper from '../../../support/helpers/licence.helper.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import { generateUUID } from '../../../../app/lib/general.lib.js'

--- a/test/services/company-contacts/setup/view-restore.service.test.js
+++ b/test/services/company-contacts/setup/view-restore.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../../support/fixtures/customers.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 
 // Things we need to stub

--- a/test/services/company-contacts/submit-remove-company-contact.service.test.js
+++ b/test/services/company-contacts/submit-remove-company-contact.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../support/fixtures/customers.fixture.js'
 import YarStub from '../../support/stubs/yar.stub.js'
 
 // Things we need to stub

--- a/test/services/company-contacts/view-communications.service.test.js
+++ b/test/services/company-contacts/view-communications.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../support/fixtures/customers.fixture.js'
 import { generateUUID } from '../../../app/lib/general.lib.js'
 
 // Things we need to stub

--- a/test/services/company-contacts/view-contact-details.service.test.js
+++ b/test/services/company-contacts/view-contact-details.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../support/fixtures/customers.fixture.js'
 import YarStub from '../../support/stubs/yar.stub.js'
 
 // Things we need to stub

--- a/test/services/company-contacts/view-remove-company-contact.service.test.js
+++ b/test/services/company-contacts/view-remove-company-contact.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as CustomersFixtures from '../../support/fixtures/customers.fixture.js'
+import CustomersFixtures from '../../support/fixtures/customers.fixture.js'
 
 // Things we need to stub
 import * as FetchAbstractionAlertLicencesDal from '../../../app/dal/company-contacts/fetch-abstraction-alert-licences.dal.js'

--- a/test/services/jobs/notification-status/fetch-notifications.service.test.js
+++ b/test/services/jobs/notification-status/fetch-notifications.service.test.js
@@ -2,10 +2,10 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as NoticesFixture from '../../../support/fixtures/notices.fixture.js'
-import * as NotificationsFixture from '../../../support/fixtures/notifications.fixture.js'
+import NoticesFixture from '../../../support/fixtures/notices.fixture.js'
 import NotificationHelper from '../../../support/helpers/notification.helper.js'
 import NotificationModel from '../../../../app/models/notification.model.js'
+import NotificationsFixture from '../../../support/fixtures/notifications.fixture.js'
 import { today } from '../../../../app/lib/general.lib.js'
 import { yesterday } from '../../../support/general.js'
 

--- a/test/services/jobs/notification-status/process-notification-status.service.test.js
+++ b/test/services/jobs/notification-status/process-notification-status.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as NoticesFixture from '../../../support/fixtures/notices.fixture.js'
-import * as NotificationsFixture from '../../../support/fixtures/notifications.fixture.js'
+import NoticesFixture from '../../../support/fixtures/notices.fixture.js'
+import NotificationsFixture from '../../../support/fixtures/notifications.fixture.js'
 
 // Things we need to stub
 import * as CheckNotificationStatusService from '../../../../app/services/notifications/check-notification-status.service.js'

--- a/test/services/jobs/return-logs/process-return-logs.service.test.js
+++ b/test/services/jobs/return-logs/process-return-logs.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as ReturnCyclesFixture from '../../../support/fixtures/return-cycles.fixture.js'
-import * as ReturnRequirementsFixture from '../../../support/fixtures/return-requirements.fixture.js'
+import ReturnCyclesFixture from '../../../support/fixtures/return-cycles.fixture.js'
+import ReturnRequirementsFixture from '../../../support/fixtures/return-requirements.fixture.js'
 
 // Things we need to stub
 import * as CheckReturnCycleService from '../../../../app/services/jobs/return-logs/check-return-cycle.service.js'

--- a/test/services/licence-versions/view.service.test.js
+++ b/test/services/licence-versions/view.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'
+import ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'
 
 // Things we need to stub
 import * as FetchConditionsService from '../../../app/services/licences/fetch-conditions.service.js'

--- a/test/services/licences/view-communications.service.test.js
+++ b/test/services/licences/view-communications.service.test.js
@@ -2,9 +2,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test Helpers
-import * as NoticesFixture from '../../support/fixtures/notices.fixture.js'
-import * as NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
 import LicenceHelper from '../../support/helpers/licence.helper.js'
+import NoticesFixture from '../../support/fixtures/notices.fixture.js'
+import NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
 import { generateUUID } from '../../../app/lib/general.lib.js'
 
 // Things we need to stub

--- a/test/services/licences/view-conditions.service.test.js
+++ b/test/services/licences/view-conditions.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'
+import ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'
 
 // Things we need to stub
 import * as FetchConditionsService from '../../../app/services/licences/fetch-conditions.service.js'

--- a/test/services/licences/view-points.service.test.js
+++ b/test/services/licences/view-points.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'
+import ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'
 
 // Things we need to stub
 import * as FetchLicenceService from '../../../app/services/licences/fetch-licence.service.js'

--- a/test/services/licences/view-purposes.service.test.js
+++ b/test/services/licences/view-purposes.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'
+import ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'
 
 // Things we need to stub
 import * as FetchLicenceService from '../../../app/services/licences/fetch-licence.service.js'

--- a/test/services/licences/view-set-up.service.test.js
+++ b/test/services/licences/view-set-up.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'
 import ReturnVersionModel from '../../../app/models/return-version.model.js'
+import ViewLicencesFixture from '../../support/fixtures/view-licences.fixture.js'
 import { generateUUID } from '../../../app/lib/general.lib.js'
 
 // Things we need to stub

--- a/test/services/monitoring-stations/view-licence.service.test.js
+++ b/test/services/monitoring-stations/view-licence.service.test.js
@@ -2,9 +2,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
+import LicenceFixture from '../../support/fixtures/licence.fixture.js'
 import UserHelper from '../../support/helpers/user.helper.js'
 import { generateUUID } from '../../../app/lib/general.lib.js'
-import { licenceEnds } from '../../support/fixtures/licence.fixture.js'
 
 // Things we need to stub
 import * as FetchLicenceMonitoringStationsDal from '../../../app/dal/monitoring-stations/fetch-licence-monitoring-stations.dal.js'
@@ -25,7 +25,7 @@ describe('Monitoring Stations - View Licence service', () => {
       }
     }
 
-    licence = licenceEnds()
+    licence = LicenceFixture.licenceEnds()
 
     licenceMonitoringStations = [
       {

--- a/test/services/notices/fetch-notices.service.test.js
+++ b/test/services/notices/fetch-notices.service.test.js
@@ -5,9 +5,9 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import DatabaseConfig from '../../../config/database.config.js'
 
 // Test helpers
-import * as NoticesFixture from '../../support/fixtures/notices.fixture.js'
 import EventHelper from '../../support/helpers/event.helper.js'
 import EventModel from '../../../app/models/event.model.js'
+import NoticesFixture from '../../support/fixtures/notices.fixture.js'
 
 // Thing under test
 import FetchNoticesService from '../../../app/services/notices/fetch-notices.service.js'

--- a/test/services/notices/index-notices.service.test.js
+++ b/test/services/notices/index-notices.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as NoticesFixture from '../../support/fixtures/notices.fixture.js'
+import NoticesFixture from '../../support/fixtures/notices.fixture.js'
 import YarStub from '../../support/stubs/yar.stub.js'
 
 // Things to stub

--- a/test/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
+import LicenceFixture from '../../../../support/fixtures/licence.fixture.js'
 import { generateUUID } from '../../../../../app/lib/general.lib.js'
-import { licenceEnds } from '../../../../support/fixtures/licence.fixture.js'
 import { yesterday } from '../../../../support/general.js'
 
 // Things we need to stub
@@ -41,7 +41,7 @@ describe('Notices Setup - Abstraction Alerts - Determine Licence Monitoring Stat
         thresholdUnit: 'm3/s',
         thresholdValue: 100,
         latestNotification: null,
-        licence: licenceEnds(),
+        licence: LicenceFixture.licenceEnds(),
         licenceVersionPurposeCondition: null
       },
       {
@@ -55,7 +55,7 @@ describe('Notices Setup - Abstraction Alerts - Determine Licence Monitoring Stat
         thresholdUnit: 'm3/s',
         thresholdValue: 100,
         latestNotification: null,
-        licence: licenceEnds(),
+        licence: LicenceFixture.licenceEnds(),
         licenceVersionPurposeCondition: {
           id: generateUUID(),
           notes: 'I have a bad feeling about this'
@@ -68,7 +68,7 @@ describe('Notices Setup - Abstraction Alerts - Determine Licence Monitoring Stat
         abstractionPeriodStartMonth: 1,
         id: generateUUID(),
         latestNotification: null,
-        licence: licenceEnds(),
+        licence: LicenceFixture.licenceEnds(),
         licenceVersionPurposeCondition: {
           id: generateUUID(),
           notes: '"                   "             "                    "'

--- a/test/services/notices/setup/abstraction-alerts/determine-relevant-licence-monitoring-stations-by-alert-type.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/determine-relevant-licence-monitoring-stations-by-alert-type.service.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
+import AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 
 // Thing under test
 import DetermineRelevantLicenceMonitoringStationsByAlertTypeService from '../../../../../app/services/notices/setup/abstraction-alerts/determine-relevant-licence-monitoring-stations-by-alert-type.service.js'

--- a/test/services/notices/setup/abstraction-alerts/determine-relevant-licence-monitoring-stations.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/determine-relevant-licence-monitoring-stations.service.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
+import AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 
 // Thing under test
 import DetermineRelevantLicenceMonitoringStationsService from '../../../../../app/services/notices/setup/abstraction-alerts/determine-relevant-licence-monitoring-stations.service.js'

--- a/test/services/notices/setup/abstraction-alerts/process-remove-threshold.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/process-remove-threshold.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
+import AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 import YarStub from '../../../../support/stubs/yar.stub.js'
 

--- a/test/services/notices/setup/abstraction-alerts/submit-alert-email-address.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/submit-alert-email-address.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
+import AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 
 // Things we need to stub

--- a/test/services/notices/setup/abstraction-alerts/submit-alert-thresholds.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/submit-alert-thresholds.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
+import AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 
 // Things we need to stub

--- a/test/services/notices/setup/abstraction-alerts/submit-alert-type.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/submit-alert-type.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
+import AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 
 // Things we need to stub

--- a/test/services/notices/setup/abstraction-alerts/submit-check-licence-matches.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/submit-check-licence-matches.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
+import AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 
 // Things we need to stub

--- a/test/services/notices/setup/abstraction-alerts/view-alert-email-address.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/view-alert-email-address.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
+import AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 
 // Things we need to stub

--- a/test/services/notices/setup/abstraction-alerts/view-alert-thresholds.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/view-alert-thresholds.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
+import AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 
 // Things we need to stub

--- a/test/services/notices/setup/abstraction-alerts/view-alert-type.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/view-alert-type.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
+import AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 
 // Things we need to stub

--- a/test/services/notices/setup/abstraction-alerts/view-cancel-alerts.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/view-cancel-alerts.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
+import AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 
 // Things we need to stub

--- a/test/services/notices/setup/abstraction-alerts/view-check-licence-matches.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/view-check-licence-matches.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
+import AbstractionAlertSessionData from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 import YarStub from '../../../../support/stubs/yar.stub.js'
 

--- a/test/services/notices/setup/create-alternate-renewal-notice.service.test.js
+++ b/test/services/notices/setup/create-alternate-renewal-notice.service.test.js
@@ -2,11 +2,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as NoticesFixture from '../../../support/fixtures/notices.fixture.js'
-import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 import EventModel from '../../../../app/models/event.model.js'
 import { NOTIFY_TEMPLATES } from '../../../../app/lib/notify-templates.lib.js'
+import NoticesFixture from '../../../support/fixtures/notices.fixture.js'
 import NotificationModel from '../../../../app/models/notification.model.js'
+import RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 
 // Things we need to stub
 import * as FetchAlternateRenewalRecipientsService from '../../../../app/services/notices/setup/renewal-notice/fetch-alternate-renewal-recipients.service.js'

--- a/test/services/notices/setup/create-alternate-returns-notice.service.test.js
+++ b/test/services/notices/setup/create-alternate-returns-notice.service.test.js
@@ -2,11 +2,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as NoticesFixture from '../../../support/fixtures/notices.fixture.js'
-import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 import EventModel from '../../../../app/models/event.model.js'
 import { NOTIFY_TEMPLATES } from '../../../../app/lib/notify-templates.lib.js'
+import NoticesFixture from '../../../support/fixtures/notices.fixture.js'
 import NotificationModel from '../../../../app/models/notification.model.js'
+import RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 import { formatLongDate } from '../../../../app/presenters/base.presenter.js'
 import { futureDueDate } from '../../../../app/presenters/notices/base.presenter.js'
 

--- a/test/services/notices/setup/create-notice.service.test.js
+++ b/test/services/notices/setup/create-notice.service.test.js
@@ -2,8 +2,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 import EventModel from '../../../../app/models/event.model.js'
+import RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 import { generateNoticeReferenceCode } from '../../../../app/lib/general.lib.js'
 
 // Thing under test

--- a/test/services/notices/setup/create-notifications.service.test.js
+++ b/test/services/notices/setup/create-notifications.service.test.js
@@ -2,8 +2,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 import { NOTIFY_TEMPLATES } from '../../../../app/lib/notify-templates.lib.js'
+import RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 import { formatLongDate } from '../../../../app/presenters/base.presenter.js'
 import { futureDueDate } from '../../../../app/presenters/notices/base.presenter.js'
 import { generateNoticeReferenceCode, generateUUID } from '../../../../app/lib/general.lib.js'

--- a/test/services/notices/setup/fetch-recipients.service.test.js
+++ b/test/services/notices/setup/fetch-recipients.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
+import RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 import { NoticeJourney, NoticeType } from '../../../../app/lib/static-lookups.lib.js'
 
 // Things we need to stub

--- a/test/services/notices/setup/initiate-session.service.test.js
+++ b/test/services/notices/setup/initiate-session.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as AbstractionAlertSessionData from '../../../support/fixtures/abstraction-alert-session-data.fixture.js'
+import AbstractionAlertSessionData from '../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 import SessionModel from '../../../../app/models/session.model.js'
 
 // Things we need to stub

--- a/test/services/notices/setup/merge-recipients.service.test.js
+++ b/test/services/notices/setup/merge-recipients.service.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
+import RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 
 // Thing under test
 import MergeRecipientsService from '../../../../app/services/notices/setup/merge-recipients.service.js'

--- a/test/services/notices/setup/prepare-paper-return.service.test.js
+++ b/test/services/notices/setup/prepare-paper-return.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as ReturnLogFixture from '../../../support/fixtures/return-logs.fixture.js'
 import LicenceHelper from '../../../support/helpers/licence.helper.js'
+import ReturnLogFixture from '../../../support/fixtures/return-logs.fixture.js'
 import { formatLongDate } from '../../../../app/presenters/base.presenter.js'
 
 // Things we need to stub

--- a/test/services/notices/setup/preview/view-preview-check-alert.service.test.js
+++ b/test/services/notices/setup/preview/view-preview-check-alert.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as AbstractionAlertSessionDataFixture from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
-import * as RecipientsFixture from '../../../../support/fixtures/recipients.fixture.js'
+import AbstractionAlertSessionDataFixture from '../../../../support/fixtures/abstraction-alert-session-data.fixture.js'
+import RecipientsFixture from '../../../../support/fixtures/recipients.fixture.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 import { generateNoticeReferenceCode } from '../../../../../app/lib/general.lib.js'
 

--- a/test/services/notices/setup/preview/view-preview.service.test.js
+++ b/test/services/notices/setup/preview/view-preview.service.test.js
@@ -4,8 +4,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 // Test helpers
 import http2 from 'node:http2'
 
-import * as RecipientsFixture from '../../../../support/fixtures/recipients.fixture.js'
 import LicenceHelper from '../../../../support/helpers/licence.helper.js'
+import RecipientsFixture from '../../../../support/fixtures/recipients.fixture.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
 import { generateNoticeReferenceCode, generateUUID } from '../../../../../app/lib/general.lib.js'
 

--- a/test/services/notices/setup/process-download-recipients.service.test.js
+++ b/test/services/notices/setup/process-download-recipients.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as NoticeSessionFixture from '../../../support/fixtures/notice-session.fixture.js'
-import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
+import NoticeSessionFixture from '../../../support/fixtures/notice-session.fixture.js'
+import RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 import { addressToCSV } from '../../../../app/presenters/notices/base.presenter.js'
 import { transformArrayToCSVRow } from '../../../../app/lib/transform-to-csv.lib.js'
 import { formatAbstractionPeriod, formatValueUnit } from '../../../../app/presenters/base.presenter.js'

--- a/test/services/notices/setup/process-preview-paper-return.service.test.js
+++ b/test/services/notices/setup/process-preview-paper-return.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
-import * as ReturnLogFixture from '../../../support/fixtures/return-logs.fixture.js'
+import RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
+import ReturnLogFixture from '../../../support/fixtures/return-logs.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import { formatLongDate } from '../../../../app/presenters/base.presenter.js'
 

--- a/test/services/notices/setup/renewal-notice/fetch-failed-renewal-invitations.service.test.js
+++ b/test/services/notices/setup/renewal-notice/fetch-failed-renewal-invitations.service.test.js
@@ -2,11 +2,11 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as NoticesFixture from '../../../../support/fixtures/notices.fixture.js'
-import * as NotificationsFixture from '../../../../support/fixtures/notifications.fixture.js'
 import EventHelper from '../../../../support/helpers/event.helper.js'
 import LicenceHelper from '../../../../support/helpers/licence.helper.js'
+import NoticesFixture from '../../../../support/fixtures/notices.fixture.js'
 import NotificationHelper from '../../../../support/helpers/notification.helper.js'
+import NotificationsFixture from '../../../../support/fixtures/notifications.fixture.js'
 import { compareStrings, generateUUID } from '../../../../../app/lib/general.lib.js'
 
 // Thing under test

--- a/test/services/notices/setup/returns-notice/fetch-failed-returns-invitations.service.test.js
+++ b/test/services/notices/setup/returns-notice/fetch-failed-returns-invitations.service.test.js
@@ -2,11 +2,11 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as NoticesFixture from '../../../../support/fixtures/notices.fixture.js'
-import * as NotificationsFixture from '../../../../support/fixtures/notifications.fixture.js'
 import EventHelper from '../../../../support/helpers/event.helper.js'
 import LicenceHelper from '../../../../support/helpers/licence.helper.js'
+import NoticesFixture from '../../../../support/fixtures/notices.fixture.js'
 import NotificationHelper from '../../../../support/helpers/notification.helper.js'
+import NotificationsFixture from '../../../../support/fixtures/notifications.fixture.js'
 import { futureDueDate } from '../../../../../app/presenters/notices/base.presenter.js'
 import { compareStrings, generateUUID } from '../../../../../app/lib/general.lib.js'
 

--- a/test/services/notices/setup/returns-notice/fetch-paper-returns-recipients.service.test.js
+++ b/test/services/notices/setup/returns-notice/fetch-paper-returns-recipients.service.test.js
@@ -2,8 +2,8 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as NoticeSessionFixture from '../../../../support/fixtures/notice-session.fixture.js'
 import * as RecipientScenariosSeeder from '../../../../support/seeders/recipient-scenarios.seeder.js'
+import NoticeSessionFixture from '../../../../support/fixtures/notice-session.fixture.js'
 import ReturnLogHelper from '../../../../support/helpers/return-log.helper.js'
 
 // Thing under test

--- a/test/services/notices/setup/returns-notice/fetch-returns-invitation-recipients.service.test.js
+++ b/test/services/notices/setup/returns-notice/fetch-returns-invitation-recipients.service.test.js
@@ -2,8 +2,8 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as NoticeSessionFixture from '../../../../support/fixtures/notice-session.fixture.js'
 import * as RecipientScenariosSeeder from '../../../../support/seeders/recipient-scenarios.seeder.js'
+import NoticeSessionFixture from '../../../../support/fixtures/notice-session.fixture.js'
 import ReturnLogHelper from '../../../../support/helpers/return-log.helper.js'
 import { futureDueDate } from '../../../../../app/presenters/notices/base.presenter.js'
 import { compareStrings, generateUUID } from '../../../../../app/lib/general.lib.js'

--- a/test/services/notices/setup/returns-notice/fetch-returns-reminder-recipients.service.test.js
+++ b/test/services/notices/setup/returns-notice/fetch-returns-reminder-recipients.service.test.js
@@ -2,8 +2,8 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as NoticeSessionFixture from '../../../../support/fixtures/notice-session.fixture.js'
 import * as RecipientScenariosSeeder from '../../../../support/seeders/recipient-scenarios.seeder.js'
+import NoticeSessionFixture from '../../../../support/fixtures/notice-session.fixture.js'
 import ReturnLogHelper from '../../../../support/helpers/return-log.helper.js'
 
 // Thing under test

--- a/test/services/notices/setup/send/renewal-invitation-alternate-notice.service.test.js
+++ b/test/services/notices/setup/send/renewal-invitation-alternate-notice.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as NoticesFixture from '../../../../support/fixtures/notices.fixture.js'
-import * as NotificationsFixture from '../../../../support/fixtures/notifications.fixture.js'
+import NoticesFixture from '../../../../support/fixtures/notices.fixture.js'
+import NotificationsFixture from '../../../../support/fixtures/notifications.fixture.js'
 
 // Things we need to stub
 import * as CreateAlternateRenewalNoticeService from '../../../../../app/services/notices/setup/create-alternate-renewal-notice.service.js'

--- a/test/services/notices/setup/send/returns-invitation-alternate-notice.service.test.js
+++ b/test/services/notices/setup/send/returns-invitation-alternate-notice.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as NoticesFixture from '../../../../support/fixtures/notices.fixture.js'
-import * as NotificationsFixture from '../../../../support/fixtures/notifications.fixture.js'
+import NoticesFixture from '../../../../support/fixtures/notices.fixture.js'
+import NotificationsFixture from '../../../../support/fixtures/notifications.fixture.js'
 
 // Things we need to stub
 import * as CreateAlternateReturnsNoticeService from '../../../../../app/services/notices/setup/create-alternate-returns-notice.service.js'

--- a/test/services/notices/setup/send/send-alternate-notice.service.test.js
+++ b/test/services/notices/setup/send/send-alternate-notice.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as NoticesFixture from '../../../../support/fixtures/notices.fixture.js'
-import * as NotificationsFixture from '../../../../support/fixtures/notifications.fixture.js'
+import NoticesFixture from '../../../../support/fixtures/notices.fixture.js'
+import NotificationsFixture from '../../../../support/fixtures/notifications.fixture.js'
 import { generateUUID } from '../../../../../app/lib/general.lib.js'
 
 // Things we need to stub

--- a/test/services/notices/setup/send/send-email-notification.service.test.js
+++ b/test/services/notices/setup/send/send-email-notification.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as NotificationsFixture from '../../../../support/fixtures/notifications.fixture.js'
-import * as NotifyResponseFixture from '../../../../support/fixtures/notify-response.fixture.js'
+import NotificationsFixture from '../../../../support/fixtures/notifications.fixture.js'
+import NotifyResponseFixture from '../../../../support/fixtures/notify-response.fixture.js'
 import { generateNoticeReferenceCode } from '../../../../../app/lib/general.lib.js'
 
 // Things we need to stub

--- a/test/services/notices/setup/send/send-letter-notification.service.test.js
+++ b/test/services/notices/setup/send/send-letter-notification.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as NotificationsFixture from '../../../../support/fixtures/notifications.fixture.js'
-import * as NotifyResponseFixture from '../../../../support/fixtures/notify-response.fixture.js'
+import NotificationsFixture from '../../../../support/fixtures/notifications.fixture.js'
+import NotifyResponseFixture from '../../../../support/fixtures/notify-response.fixture.js'
 import { generateNoticeReferenceCode } from '../../../../../app/lib/general.lib.js'
 
 // Things we need to stub

--- a/test/services/notices/setup/send/send-main-notice.service.test.js
+++ b/test/services/notices/setup/send/send-main-notice.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as NoticesFixture from '../../../../support/fixtures/notices.fixture.js'
-import * as NotificationsFixture from '../../../../support/fixtures/notifications.fixture.js'
+import NoticesFixture from '../../../../support/fixtures/notices.fixture.js'
+import NotificationsFixture from '../../../../support/fixtures/notifications.fixture.js'
 
 // Things we need to stub
 import * as CheckNotificationStatusService from '../../../../../app/services/notifications/check-notification-status.service.js'

--- a/test/services/notices/setup/send/send-notice.service.test.js
+++ b/test/services/notices/setup/send/send-notice.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as NoticesFixture from '../../../../support/fixtures/notices.fixture.js'
-import * as NotificationsFixture from '../../../../support/fixtures/notifications.fixture.js'
+import NoticesFixture from '../../../../support/fixtures/notices.fixture.js'
+import NotificationsFixture from '../../../../support/fixtures/notifications.fixture.js'
 
 // Things we need to stub
 import * as SendAlternateNoticeService from '../../../../../app/services/notices/setup/send/send-alternate-notice.service.js'

--- a/test/services/notices/setup/send/send-paper-return-notification.service.test.js
+++ b/test/services/notices/setup/send/send-paper-return-notification.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as NotificationsFixture from '../../../../support/fixtures/notifications.fixture.js'
-import * as NotifyResponseFixture from '../../../../support/fixtures/notify-response.fixture.js'
+import NotificationsFixture from '../../../../support/fixtures/notifications.fixture.js'
+import NotifyResponseFixture from '../../../../support/fixtures/notify-response.fixture.js'
 import { generateNoticeReferenceCode } from '../../../../../app/lib/general.lib.js'
 
 // Things we need to stub

--- a/test/services/notices/setup/submit-check.service.test.js
+++ b/test/services/notices/setup/submit-check.service.test.js
@@ -2,10 +2,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as NoticesFixture from '../../../support/fixtures/notices.fixture.js'
-import * as NotificationsFixture from '../../../support/fixtures/notifications.fixture.js'
-import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 import LicenceHelper from '../../../support/helpers/licence.helper.js'
+import NoticesFixture from '../../../support/fixtures/notices.fixture.js'
+import NotificationsFixture from '../../../support/fixtures/notifications.fixture.js'
+import RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import { generateNoticeReferenceCode, generateUUID } from '../../../../app/lib/general.lib.js'
 

--- a/test/services/notices/setup/submit-select-recipients.service.test.js
+++ b/test/services/notices/setup/submit-select-recipients.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
+import RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import { generateNoticeReferenceCode } from '../../../../app/lib/general.lib.js'
 

--- a/test/services/notices/setup/view-check.service.test.js
+++ b/test/services/notices/setup/view-check.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as NoticeSessionFixture from '../../../support/fixtures/notice-session.fixture.js'
-import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
+import NoticeSessionFixture from '../../../support/fixtures/notice-session.fixture.js'
+import RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 import YarStub from '../../../support/stubs/yar.stub.js'
 
 // Things we need to stub

--- a/test/services/notices/setup/view-select-recipients.service.test.js
+++ b/test/services/notices/setup/view-select-recipients.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
+import RecipientsFixture from '../../../support/fixtures/recipients.fixture.js'
 import SessionModelStub from '../../../support/stubs/session.stub.js'
 import { generateNoticeReferenceCode } from '../../../../app/lib/general.lib.js'
 

--- a/test/services/notices/submit-index-notices.service.test.js
+++ b/test/services/notices/submit-index-notices.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as NoticesFixture from '../../support/fixtures/notices.fixture.js'
+import NoticesFixture from '../../support/fixtures/notices.fixture.js'
 
 // Things to stub
 import * as FetchNoticesService from '../../../app/services/notices/fetch-notices.service.js'

--- a/test/services/notifications/check-notification-status.service.test.js
+++ b/test/services/notifications/check-notification-status.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as NoticesFixture from '../../support/fixtures/notices.fixture.js'
-import * as NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
+import NoticesFixture from '../../support/fixtures/notices.fixture.js'
+import NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
 
 // Things we need to stub
 import * as ViewMessageDataRequest from '../../../app/requests/notify/view-message-data.request.js'

--- a/test/services/notifications/fetch-notification.service.test.js
+++ b/test/services/notifications/fetch-notification.service.test.js
@@ -2,11 +2,11 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as NoticesFixture from '../../support/fixtures/notices.fixture.js'
-import * as NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
 import EventHelper from '../../support/helpers/event.helper.js'
 import LicenceHelper from '../../support/helpers/licence.helper.js'
+import NoticesFixture from '../../support/fixtures/notices.fixture.js'
 import NotificationHelper from '../../support/helpers/notification.helper.js'
+import NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
 
 // Thing under test
 import FetchNotificationService from '../../../app/services/notifications/fetch-notification.service.js'

--- a/test/services/notifications/view-notification.service.test.js
+++ b/test/services/notifications/view-notification.service.test.js
@@ -2,9 +2,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as NoticesFixture from '../../support/fixtures/notices.fixture.js'
-import * as NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
 import LicenceHelper from '../../support/helpers/licence.helper.js'
+import NoticesFixture from '../../support/fixtures/notices.fixture.js'
+import NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
 import { generateUUID } from '../../../app/lib/general.lib.js'
 
 // Things we need to stub

--- a/test/services/return-logs/create-return-logs.service.test.js
+++ b/test/services/return-logs/create-return-logs.service.test.js
@@ -2,10 +2,10 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as ReturnCyclesFixture from '../../support/fixtures/return-cycles.fixture.js'
-import * as ReturnRequirementsFixture from '../../support/fixtures/return-requirements.fixture.js'
+import ReturnCyclesFixture from '../../support/fixtures/return-cycles.fixture.js'
 import ReturnLogHelper from '../../support/helpers/return-log.helper.js'
 import ReturnLogModel from '../../../app/models/return-log.model.js'
+import ReturnRequirementsFixture from '../../support/fixtures/return-requirements.fixture.js'
 import { formatDateObjectToISO } from '../../../app/lib/dates.lib.js'
 
 // Thing under test

--- a/test/services/return-logs/download-return-log.service.test.js
+++ b/test/services/return-logs/download-return-log.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as ReturnLogsFixture from '../../support/fixtures/return-logs.fixture.js'
+import ReturnLogsFixture from '../../support/fixtures/return-logs.fixture.js'
 import { formatDateObjectToISO } from '../../../app/lib/dates.lib.js'
 
 // Things we need to stub

--- a/test/services/return-logs/generate-return-log.service.test.js
+++ b/test/services/return-logs/generate-return-log.service.test.js
@@ -2,8 +2,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as ReturnCyclesFixture from '../../support/fixtures/return-cycles.fixture.js'
-import * as ReturnRequirementsFixture from '../../support/fixtures/return-requirements.fixture.js'
+import ReturnCyclesFixture from '../../support/fixtures/return-cycles.fixture.js'
+import ReturnRequirementsFixture from '../../support/fixtures/return-requirements.fixture.js'
 
 // Thing under test
 import GenerateReturnLogService from '../../../app/services/return-logs/generate-return-log.service.js'

--- a/test/services/return-logs/process-licence-return-logs.service.test.js
+++ b/test/services/return-logs/process-licence-return-logs.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as ReturnCyclesFixture from '../../support/fixtures/return-cycles.fixture.js'
-import * as ReturnRequirementsFixture from '../../support/fixtures/return-requirements.fixture.js'
+import ReturnCyclesFixture from '../../support/fixtures/return-cycles.fixture.js'
+import ReturnRequirementsFixture from '../../support/fixtures/return-requirements.fixture.js'
 
 // Things we need to stub
 import * as CreateReturnLogsService from '../../../app/services/return-logs/create-return-logs.service.js'

--- a/test/services/return-logs/view-details.service.test.js
+++ b/test/services/return-logs/view-details.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as ReturnLogsFixture from '../../support/fixtures/return-logs.fixture.js'
 import ReturnLogHelper from '../../support/helpers/return-log.helper.js'
+import ReturnLogsFixture from '../../support/fixtures/return-logs.fixture.js'
 
 // Things we need to stub
 import * as FetchReturnLogDetailsService from '../../../app/services/return-logs/fetch-return-log-details.service.js'

--- a/test/services/users/external/setup/initiate-session.service.test.js
+++ b/test/services/users/external/setup/initiate-session.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as UsersFixture from '../../../../support/fixtures/users.fixture.js'
 import SessionModel from '../../../../../app/models/session.model.js'
+import UsersFixture from '../../../../support/fixtures/users.fixture.js'
 import { generateUUID } from '../../../../../app/lib/general.lib.js'
 
 // Things to stub

--- a/test/services/users/external/setup/submit-cancel.service.test.js
+++ b/test/services/users/external/setup/submit-cancel.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as UserSessionsFixture from '../../../../support/fixtures/user-sessions.fixture.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
+import UserSessionsFixture from '../../../../support/fixtures/user-sessions.fixture.js'
 
 // Things we need to stub
 import * as DeleteSessionDal from '../../../../../app/dal/delete-session.dal.js'

--- a/test/services/users/external/setup/submit-check.service.test.js
+++ b/test/services/users/external/setup/submit-check.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as UserSessionsFixture from '../../../../support/fixtures/user-sessions.fixture.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
+import UserSessionsFixture from '../../../../support/fixtures/user-sessions.fixture.js'
 import YarStub from '../../../../support/stubs/yar.stub.js'
 import { generateUUID } from '../../../../../app/lib/general.lib.js'
 

--- a/test/services/users/external/setup/submit-licences.service.test.js
+++ b/test/services/users/external/setup/submit-licences.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as UserSessionsFixture from '../../../../support/fixtures/user-sessions.fixture.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
+import UserSessionsFixture from '../../../../support/fixtures/user-sessions.fixture.js'
 import YarStub from '../../../../support/stubs/yar.stub.js'
 
 // Things we need to stub

--- a/test/services/users/external/setup/view-cancel.service.test.js
+++ b/test/services/users/external/setup/view-cancel.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as UserSessionsFixture from '../../../../support/fixtures/user-sessions.fixture.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
+import UserSessionsFixture from '../../../../support/fixtures/user-sessions.fixture.js'
 
 // Things we need to stub
 import * as FetchSessionDal from '../../../../../app/dal/fetch-session.dal.js'

--- a/test/services/users/external/setup/view-check.service.test.js
+++ b/test/services/users/external/setup/view-check.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as UserSessionsFixture from '../../../../support/fixtures/user-sessions.fixture.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
+import UserSessionsFixture from '../../../../support/fixtures/user-sessions.fixture.js'
 import YarStub from '../../../../support/stubs/yar.stub.js'
 
 // Things we need to stub

--- a/test/services/users/external/setup/view-licences.service.test.js
+++ b/test/services/users/external/setup/view-licences.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as UserSessionsFixture from '../../../../support/fixtures/user-sessions.fixture.js'
 import SessionModelStub from '../../../../support/stubs/session.stub.js'
+import UserSessionsFixture from '../../../../support/fixtures/user-sessions.fixture.js'
 
 // Things we need to stub
 import * as FetchSessionDal from '../../../../../app/dal/fetch-session.dal.js'

--- a/test/services/users/external/view-communications.service.test.js
+++ b/test/services/users/external/view-communications.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as UsersFixture from '../../../support/fixtures/users.fixture.js'
+import UsersFixture from '../../../support/fixtures/users.fixture.js'
 
 // Things we want to stub
 import * as FetchNotificationsDal from '../../../../app/dal/users/external/fetch-notifications.dal.js'

--- a/test/services/users/external/view-details.service.test.js
+++ b/test/services/users/external/view-details.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as UsersFixture from '../../../support/fixtures/users.fixture.js'
+import UsersFixture from '../../../support/fixtures/users.fixture.js'
 
 // Things we want to stub
 import * as FetchUserDetailsDal from '../../../../app/dal/users/external/fetch-user-details.dal.js'

--- a/test/services/users/external/view-licences.service.test.js
+++ b/test/services/users/external/view-licences.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as UsersFixture from '../../../support/fixtures/users.fixture.js'
+import UsersFixture from '../../../support/fixtures/users.fixture.js'
 import YarStub from '../../../support/stubs/yar.stub.js'
 
 // Things we want to stub

--- a/test/services/users/external/view-verifications.service.test.js
+++ b/test/services/users/external/view-verifications.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as UsersFixture from '../../../support/fixtures/users.fixture.js'
+import UsersFixture from '../../../support/fixtures/users.fixture.js'
 
 // Things we want to stub
 import * as FetchUserDal from '../../../../app/dal/users/fetch-user.dal.js'

--- a/test/services/users/index-users.service.test.js
+++ b/test/services/users/index-users.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as UsersFixture from '../../support/fixtures/users.fixture.js'
+import UsersFixture from '../../support/fixtures/users.fixture.js'
 import YarStub from '../../support/stubs/yar.stub.js'
 
 // Things to stub

--- a/test/services/users/internal/view-communications.service.test.js
+++ b/test/services/users/internal/view-communications.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as UsersFixture from '../../../support/fixtures/users.fixture.js'
+import UsersFixture from '../../../support/fixtures/users.fixture.js'
 
 // Things we need to stub
 import * as FetchNotificationsDal from '../../../../app/dal/users/internal/fetch-notifications.dal.js'

--- a/test/services/users/internal/view-details.service.test.js
+++ b/test/services/users/internal/view-details.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as UsersFixture from '../../../support/fixtures/users.fixture.js'
+import UsersFixture from '../../../support/fixtures/users.fixture.js'
 
 // Things we want to stub
 import * as FetchUserDetailsDal from '../../../../app/dal/users/internal/fetch-user-details.dal.js'

--- a/test/services/users/submit-index-users.service.test.js
+++ b/test/services/users/submit-index-users.service.test.js
@@ -2,7 +2,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as UsersFixture from '../../support/fixtures/users.fixture.js'
+import UsersFixture from '../../support/fixtures/users.fixture.js'
 
 // Things to stub
 import * as FetchUsersDal from '../../../app/dal/users/fetch-users.dal.js'

--- a/test/services/users/view-notification.service.test.js
+++ b/test/services/users/view-notification.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import * as NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
-import * as UsersFixture from '../../support/fixtures/users.fixture.js'
+import NotificationsFixture from '../../support/fixtures/notifications.fixture.js'
+import UsersFixture from '../../support/fixtures/users.fixture.js'
 
 // Things we need to stub
 import * as FetchNotificationDal from '../../../app/dal/users/fetch-notification.dal.js'

--- a/test/support/fixtures/abstraction-alert-session-data.fixture.js
+++ b/test/support/fixtures/abstraction-alert-session-data.fixture.js
@@ -6,7 +6,7 @@ import { generateUUID } from '../../../app/lib/general.lib.js'
  *
  * @returns {object} - Returns three unique licence monitoring stations
  */
-export function licenceMonitoringStations() {
+function licenceMonitoringStations() {
   return {
     one: {
       abstractionPeriodEndDay: 1,
@@ -70,7 +70,7 @@ export function licenceMonitoringStations() {
  *
  * @returns {object} - Returns nine unique unsorted licence monitoring stations
  */
-export function unsortedLicenceMonitoringStations() {
+function unsortedLicenceMonitoringStations() {
   return {
     one: {
       abstractionPeriodEndDay: 1,
@@ -246,7 +246,7 @@ export function unsortedLicenceMonitoringStations() {
  *
  * @returns {object} an object representing the monitoring stations service
  */
-export function get(_licenceMonitoringStations) {
+function get(_licenceMonitoringStations) {
   const lms = _licenceMonitoringStations || licenceMonitoringStations()
 
   return {
@@ -271,7 +271,7 @@ export function get(_licenceMonitoringStations) {
  *
  * @returns {object[]} an array of the licence monitoring station
  */
-export function relevantLicenceMonitoringStations(licenceRefs, _licenceMonitoringStations) {
+function relevantLicenceMonitoringStations(licenceRefs, _licenceMonitoringStations) {
   const lms = _licenceMonitoringStations || licenceMonitoringStations()
 
   const lmsArray = [...Object.values(lms)]
@@ -285,4 +285,11 @@ export function relevantLicenceMonitoringStations(licenceRefs, _licenceMonitorin
   }
 
   return lmsArray
+}
+
+export default {
+  licenceMonitoringStations,
+  unsortedLicenceMonitoringStations,
+  get,
+  relevantLicenceMonitoringStations
 }

--- a/test/support/fixtures/bill-runs-review.fixture.js
+++ b/test/support/fixtures/bill-runs-review.fixture.js
@@ -5,7 +5,7 @@ import BillingAccountModel from '../../../app/models/billing-account.model.js'
  *
  * @returns {object}
  */
-export function removeReviewLicence() {
+function removeReviewLicence() {
   return {
     id: 'bb779166-0576-4581-b504-edbc0227d763',
     licenceId: '32416c67-f755-4c3f-8816-ecde0ee596bd',
@@ -30,7 +30,7 @@ export function removeReviewLicence() {
  *
  * @returns {object}
  */
-export function reviewChargeElement() {
+function reviewChargeElement() {
   return {
     id: 'a1840523-a04c-4c64-bff7-4a515e8ba1c1',
     amendedAllocated: 0,
@@ -102,7 +102,7 @@ export function reviewChargeElement() {
  *
  * @returns {object}
  */
-export function reviewChargeReference() {
+function reviewChargeReference() {
   return {
     id: '6b3d11f2-d361-4eaa-bce2-5561283bd023',
     abatementAgreement: 1,
@@ -157,7 +157,7 @@ export function reviewChargeReference() {
  *
  * @returns {object}
  */
-export function reviewLicence() {
+function reviewLicence() {
   return {
     id: 'bb779166-0576-4581-b504-edbc0227d763',
     billRunId: '287aeb25-cf11-429d-8c6f-f98f06db021d',
@@ -335,4 +335,11 @@ export function reviewLicence() {
       }
     ]
   }
+}
+
+export default {
+  removeReviewLicence,
+  reviewChargeElement,
+  reviewChargeReference,
+  reviewLicence
 }

--- a/test/support/fixtures/billing-accounts.fixture.js
+++ b/test/support/fixtures/billing-accounts.fixture.js
@@ -8,7 +8,7 @@ import { generateUUID } from '../../../app/lib/general.lib.js'
  *
  * @returns {object} an object representing the billing account, bills and its related licence
  */
-export function billingAccount() {
+function billingAccount() {
   const contact = ContactModel.fromJson({
     id: generateUUID(),
     contactType: 'person',
@@ -66,4 +66,8 @@ export function billingAccount() {
     ],
     totalNumber: 1
   }
+}
+
+export default {
+  billingAccount
 }

--- a/test/support/fixtures/customers.fixture.js
+++ b/test/support/fixtures/customers.fixture.js
@@ -11,7 +11,7 @@ import { generateUUID } from '../../../app/lib/general.lib.js'
  *
  * @returns {object[]} A array of billing accounts
  */
-export function billingAccounts() {
+function billingAccounts() {
   return [
     BillingAccountModel.fromJson({
       accountNumber: BillingAccountHelper.generateAccountNumber(),
@@ -48,7 +48,7 @@ export function billingAccounts() {
  *
  * @returns {object} A company object
  */
-export function company() {
+function company() {
   return {
     id: generateUUID(),
     name: 'Tyrell Corporation'
@@ -60,7 +60,7 @@ export function company() {
  *
  * @returns {object[]} A array of company objects
  */
-export function companies() {
+function companies() {
   return [
     {
       id: generateUUID(),
@@ -74,7 +74,7 @@ export function companies() {
  *
  * @returns {module:CompanyAddressModel} A company address
  */
-export function companyAddress() {
+function companyAddress() {
   return {
     id: generateUUID(),
     address: {
@@ -96,7 +96,7 @@ export function companyAddress() {
  *
  * @returns {module:CompanyContactModel} A company contact
  */
-export function companyContact() {
+function companyContact() {
   return CompanyContactModel.fromJson({
     id: generateUUID(),
     abstractionAlertLicences: null,
@@ -126,7 +126,7 @@ export function companyContact() {
  *
  * @returns {object[]} An array of company contact
  */
-export function companyContacts() {
+function companyContacts() {
   return [
     {
       ...companyContact(),
@@ -142,7 +142,7 @@ export function companyContacts() {
  *
  * @returns {object[]} A contact
  */
-export function contact() {
+function contact() {
   return ContactModel.fromJson({
     id: generateUUID(),
     salutation: null,
@@ -163,7 +163,7 @@ export function contact() {
  *
  * @returns {object[]} A array of licences
  */
-export function licences() {
+function licences() {
   return [
     LicenceModel.fromJson({
       expiredDate: null,
@@ -181,4 +181,15 @@ export function licences() {
       startDate: new Date('2022-01-01')
     })
   ]
+}
+
+export default {
+  billingAccounts,
+  company,
+  companies,
+  companyAddress,
+  companyContact,
+  companyContacts,
+  contact,
+  licences
 }

--- a/test/support/fixtures/licence.fixture.js
+++ b/test/support/fixtures/licence.fixture.js
@@ -11,7 +11,7 @@ import { generateUUID } from '../../../app/lib/general.lib.js'
  *
  * @returns {module:LicenceModel} A licence with a licence ref
  */
-export function licence(data = {}) {
+function licence(data = {}) {
   return LicenceModel.fromJson({
     id: generateUUID(),
     licenceRef: LicenceHelper.generateLicenceRef(),
@@ -30,10 +30,15 @@ export function licence(data = {}) {
  *
  * @returns {module:LicenceModel} A licence to be used in tests that uses the 'ends' or 'ended' instance method
  */
-export function licenceEnds(endDate = null) {
+function licenceEnds(endDate = null) {
   return licence({
     expiredDate: endDate,
     lapsedDate: null,
     revokedDate: null
   })
+}
+
+export default {
+  licence,
+  licenceEnds
 }

--- a/test/support/fixtures/notice-session.fixture.js
+++ b/test/support/fixtures/notice-session.fixture.js
@@ -14,7 +14,7 @@ import { generateNoticeReferenceCode, generateUUID } from '../../../app/lib/gene
  *
  * @returns {object} The notice setup session fixture
  */
-export function abstractionAlertStop(licenceRef = null) {
+function abstractionAlertStop(licenceRef = null) {
   if (!licenceRef) {
     licenceRef = LicenceHelper.generateLicenceRef()
   }
@@ -93,7 +93,7 @@ export function abstractionAlertStop(licenceRef = null) {
  *
  * @returns {object} The notice setup session fixture
  */
-export function adHocRenewalInvitation(licenceRef = null) {
+function adHocRenewalInvitation(licenceRef = null) {
   if (!licenceRef) {
     licenceRef = LicenceHelper.generateLicenceRef()
   }
@@ -126,7 +126,7 @@ export function adHocRenewalInvitation(licenceRef = null) {
  *
  * @returns {object} The notice setup session fixture
  */
-export function adHocInvitation(licenceRef = null) {
+function adHocInvitation(licenceRef = null) {
   if (!licenceRef) {
     licenceRef = LicenceHelper.generateLicenceRef()
   }
@@ -169,7 +169,7 @@ export function adHocInvitation(licenceRef = null) {
  *
  * @returns {object} The notice setup session fixture
  */
-export function adHocReminder(licenceRef = null) {
+function adHocReminder(licenceRef = null) {
   if (!licenceRef) {
     licenceRef = LicenceHelper.generateLicenceRef()
   }
@@ -214,7 +214,7 @@ export function adHocReminder(licenceRef = null) {
  *
  * @returns {object} The notice setup session fixture
  */
-export function paperReturn(licenceRef = null, selectedReturnLog = null) {
+function paperReturn(licenceRef = null, selectedReturnLog = null) {
   if (!licenceRef) {
     licenceRef = LicenceHelper.generateLicenceRef()
   }
@@ -259,7 +259,7 @@ export function paperReturn(licenceRef = null, selectedReturnLog = null) {
  *
  * @returns {object} The notice setup session fixture
  */
-export function standardInvitation(licenceRef = null) {
+function standardInvitation(licenceRef = null) {
   if (!licenceRef) {
     licenceRef = LicenceHelper.generateLicenceRef()
   }
@@ -310,7 +310,7 @@ export function standardInvitation(licenceRef = null) {
  *
  * @returns {object} The notice setup session fixture
  */
-export function standardReminder(licenceRef = null) {
+function standardReminder(licenceRef = null) {
   if (!licenceRef) {
     licenceRef = LicenceHelper.generateLicenceRef()
   }
@@ -391,4 +391,14 @@ function _transformReturnLog(returnLog) {
     startDate: returnLog.startDate.toISOString(),
     twoPartTariff: isTwoPartTariff
   }
+}
+
+export default {
+  abstractionAlertStop,
+  adHocRenewalInvitation,
+  adHocInvitation,
+  adHocReminder,
+  paperReturn,
+  standardInvitation,
+  standardReminder
 }

--- a/test/support/fixtures/notices.fixture.js
+++ b/test/support/fixtures/notices.fixture.js
@@ -6,7 +6,7 @@ import { generateNoticeReferenceCode, generateRandomInteger, generateUUID } from
  *
  * @returns {object}
  */
-export function alertReduce() {
+function alertReduce() {
   const data = _defaults()
 
   data.metadata = {
@@ -29,7 +29,7 @@ export function alertReduce() {
  *
  * @returns {object}
  */
-export function alertResume() {
+function alertResume() {
   const data = _defaults()
 
   data.metadata = {
@@ -52,7 +52,7 @@ export function alertResume() {
  *
  * @returns {object}
  */
-export function alertStop() {
+function alertStop() {
   const data = _defaults()
 
   data.metadata = {
@@ -75,7 +75,7 @@ export function alertStop() {
  *
  * @returns {object}
  */
-export function alertWarning() {
+function alertWarning() {
   const data = _defaults()
 
   data.metadata = {
@@ -100,7 +100,7 @@ export function alertWarning() {
  *
  * @returns {object}
  */
-export function legacyHandsOffFlow() {
+function legacyHandsOffFlow() {
   const data = _defaults()
 
   data.metadata = {
@@ -124,7 +124,7 @@ export function legacyHandsOffFlow() {
  *
  * @returns {object}
  */
-export function legacyRenewal() {
+function legacyRenewal() {
   const data = _defaults()
 
   data.metadata = {
@@ -148,7 +148,7 @@ export function legacyRenewal() {
  *
  * @returns {object[]} Array of mapped notice objects.
  */
-export function mapToFetchNoticesResult(notices) {
+function mapToFetchNoticesResult(notices) {
   return notices.map((notice) => {
     const { createdAt, id, issuer, referenceCode, subtype, metadata } = notice
 
@@ -171,7 +171,7 @@ export function mapToFetchNoticesResult(notices) {
  *
  * @returns {object[]} all the notices as an array
  */
-export function notices() {
+function notices() {
   return [
     alertReduce(),
     alertResume(),
@@ -191,7 +191,7 @@ export function notices() {
  *
  * @returns {object}
  */
-export function renewalInvitation() {
+function renewalInvitation() {
   const data = _defaults()
 
   data.metadata = {
@@ -213,7 +213,7 @@ export function renewalInvitation() {
  *
  * @returns {object}
  */
-export function returnsInvitation() {
+function returnsInvitation() {
   const data = _defaults()
 
   data.metadata = {
@@ -234,7 +234,7 @@ export function returnsInvitation() {
  *
  * @returns {object}
  */
-export function returnsPaperForm() {
+function returnsPaperForm() {
   const data = _defaults()
 
   data.metadata = {
@@ -255,7 +255,7 @@ export function returnsPaperForm() {
  *
  * @returns {object}
  */
-export function returnsReminder() {
+function returnsReminder() {
   const data = _defaults()
 
   data.metadata = {
@@ -291,4 +291,19 @@ function _defaults() {
     type: 'notification',
     updatedAt: new Date('2025-03-25')
   }
+}
+
+export default {
+  alertReduce,
+  alertResume,
+  alertStop,
+  alertWarning,
+  legacyHandsOffFlow,
+  legacyRenewal,
+  mapToFetchNoticesResult,
+  notices,
+  renewalInvitation,
+  returnsInvitation,
+  returnsPaperForm,
+  returnsReminder
 }

--- a/test/support/fixtures/notifications.fixture.js
+++ b/test/support/fixtures/notifications.fixture.js
@@ -25,7 +25,7 @@ const ADDRESS = {
  *
  * @returns {object} The generated abstraction alert email object
  */
-export function abstractionAlertEmail(notice) {
+function abstractionAlertEmail(notice) {
   const licenceMonitoringStationId = generateUUID()
 
   const notification = {
@@ -79,7 +79,7 @@ export function abstractionAlertEmail(notice) {
  *
  * @returns {object} The generated abstraction alert letter object
  */
-export function abstractionAlertLetter(notice) {
+function abstractionAlertLetter(notice) {
   const licenceMonitoringStationId = generateUUID()
 
   const notification = {
@@ -134,7 +134,7 @@ export function abstractionAlertLetter(notice) {
  *
  * @returns {object} The generated legacy hands off flow letter object
  */
-export function legacyHandsOfFlow(notice) {
+function legacyHandsOfFlow(notice) {
   const notification = {
     contactType: null,
     createdAt: new Date('2022-10-09'),
@@ -184,7 +184,7 @@ export function legacyHandsOfFlow(notice) {
  *
  * @returns {object} The generated legacy renewal letter object
  */
-export function legacyRenewal(notice) {
+function legacyRenewal(notice) {
   const notification = {
     contactType: null,
     createdAt: new Date('2022-10-09'),
@@ -232,7 +232,7 @@ export function legacyRenewal(notice) {
  *
  * @returns {object} an object representing the notification and its related licence
  */
-export function notification() {
+function notification() {
   const licence = LicenceModel.fromJson({
     id: '136bfed6-7e14-4144-a06f-35a21ceb4aa2',
     licenceRef: '01/117'
@@ -290,7 +290,7 @@ export function notification() {
  *
  * @returns {object} The generated paper return notification object
  */
-export function paperReturn(notice) {
+function paperReturn(notice) {
   const returnLogId = generateUUID()
 
   const notification = {
@@ -339,7 +339,7 @@ export function paperReturn(notice) {
  *
  * @returns {object} The generated renewal invitation email object
  */
-export function renewalInvitationEmail(notice) {
+function renewalInvitationEmail(notice) {
   const notification = {
     contactType: 'primary user',
     createdAt: new Date('2025-04-02'),
@@ -381,7 +381,7 @@ export function renewalInvitationEmail(notice) {
  *
  * @returns {object} The generated renewal invitation letter object
  */
-export function renewalInvitationLetter(notice) {
+function renewalInvitationLetter(notice) {
   const notification = {
     contactType: 'licence holder',
     createdAt: new Date('2025-04-02'),
@@ -425,7 +425,7 @@ export function renewalInvitationLetter(notice) {
  *
  * @returns {object} The generated returns invitation email object
  */
-export function returnsInvitationAdHocEmail(notice) {
+function returnsInvitationAdHocEmail(notice) {
   const notification = _returnsInvitationDefaults(notice)
 
   return {
@@ -457,7 +457,7 @@ export function returnsInvitationAdHocEmail(notice) {
  *
  * @returns {object} The generated returns invitation letter object
  */
-export function returnsInvitationAdHocLetter(notice) {
+function returnsInvitationAdHocLetter(notice) {
   const notification = _returnsInvitationDefaults(notice)
 
   return {
@@ -493,7 +493,7 @@ export function returnsInvitationAdHocLetter(notice) {
  *
  * @returns {object} The generated returns invitation letter object
  */
-export function returnsInvitationAlternateLetter(notice) {
+function returnsInvitationAlternateLetter(notice) {
   const notification = _returnsInvitationDefaults(notice)
 
   return {
@@ -527,7 +527,7 @@ export function returnsInvitationAlternateLetter(notice) {
  *
  * @returns {object} The generated returns invitation email object
  */
-export function returnsInvitationEmail(notice) {
+function returnsInvitationEmail(notice) {
   const notification = _returnsInvitationDefaults(notice)
 
   return {
@@ -559,7 +559,7 @@ export function returnsInvitationEmail(notice) {
  *
  * @returns {object} The generated returns invitation letter object
  */
-export function returnsInvitationLetter(notice) {
+function returnsInvitationLetter(notice) {
   const notification = _returnsInvitationDefaults(notice)
 
   return {
@@ -593,7 +593,7 @@ export function returnsInvitationLetter(notice) {
  *
  * @returns {object} The generated returns reminder email object
  */
-export function returnsReminderEmail(notice) {
+function returnsReminderEmail(notice) {
   const notification = {
     contactType: 'primary user',
     createdAt: new Date('2025-04-18'),
@@ -635,7 +635,7 @@ export function returnsReminderEmail(notice) {
  *
  * @returns {object} The generated returns reminder letter object
  */
-export function returnsReminderLetter(notice) {
+function returnsReminderLetter(notice) {
   const notification = {
     contactType: 'licence holder',
     createdAt: new Date('2025-04-18'),
@@ -682,7 +682,7 @@ export function returnsReminderLetter(notice) {
  *
  * @returns {object} The generated user external email object
  */
-export function userExternalPasswordResetEmail(recipient, overrides = {}) {
+function userExternalPasswordResetEmail(recipient, overrides = {}) {
   return _userPasswordResetEmail(recipient, false, overrides)
 }
 
@@ -695,7 +695,7 @@ export function userExternalPasswordResetEmail(recipient, overrides = {}) {
  *
  * @returns {object} The generated user external email object
  */
-export function userExternalShareExistingEmail(recipient, sender, overrides = {}) {
+function userExternalShareExistingEmail(recipient, sender, overrides = {}) {
   const notification = {
     contactType: null,
     createdAt: new Date('2025-04-18'),
@@ -738,7 +738,7 @@ export function userExternalShareExistingEmail(recipient, sender, overrides = {}
  *
  * @returns {object} The generated user internal email object
  */
-export function userInternalPasswordResetEmail(recipient, overrides = {}) {
+function userInternalPasswordResetEmail(recipient, overrides = {}) {
   return _userPasswordResetEmail(recipient, true, overrides)
 }
 
@@ -750,7 +750,7 @@ export function userInternalPasswordResetEmail(recipient, overrides = {}) {
  *
  * @returns {object} The generated user new internal email object
  */
-export function userNewInternalEmail(recipient, overrides = {}) {
+function userNewInternalEmail(recipient, overrides = {}) {
   const notification = {
     contactType: null,
     createdAt: new Date('2025-04-18'),
@@ -833,4 +833,26 @@ function _userPasswordResetEmail(recipient, internal, overrides) {
   }
 
   return { ...notification, ...overrides }
+}
+
+export default {
+  abstractionAlertEmail,
+  abstractionAlertLetter,
+  legacyHandsOfFlow,
+  legacyRenewal,
+  notification,
+  paperReturn,
+  renewalInvitationEmail,
+  renewalInvitationLetter,
+  returnsInvitationAdHocEmail,
+  returnsInvitationAdHocLetter,
+  returnsInvitationAlternateLetter,
+  returnsInvitationEmail,
+  returnsInvitationLetter,
+  returnsReminderEmail,
+  returnsReminderLetter,
+  userExternalPasswordResetEmail,
+  userExternalShareExistingEmail,
+  userInternalPasswordResetEmail,
+  userNewInternalEmail
 }

--- a/test/support/fixtures/notify-response.fixture.js
+++ b/test/support/fixtures/notify-response.fixture.js
@@ -10,7 +10,7 @@ const { HTTP_STATUS_OK } = http2.constants
  *
  * @returns {object} an object representing the successful response from the Notify API
  */
-export function successfulResponse(referenceCode) {
+function successfulResponse(referenceCode) {
   return {
     email: {
       succeeded: true,
@@ -67,4 +67,8 @@ export function successfulResponse(referenceCode) {
       }
     }
   }
+}
+
+export default {
+  successfulResponse
 }

--- a/test/support/fixtures/recipients.fixture.js
+++ b/test/support/fixtures/recipients.fixture.js
@@ -16,7 +16,7 @@ import { generateUUID } from '../../../app/lib/general.lib.js'
  *
  * @returns {object} The ad-hoc returns notice additional email recipient fixture
  */
-export function additionalEmailRecipient(licenceRef = null, email = null) {
+function additionalEmailRecipient(licenceRef = null, email = null) {
   const recipientLicenceRef = licenceRef ?? LicenceHelper.generateLicenceRef()
   const recipientEmail = email ?? 'additional@returns-notice.com'
 
@@ -48,7 +48,7 @@ export function additionalEmailRecipient(licenceRef = null, email = null) {
  *
  * @returns {object} The ad-hoc returns notice additional postal recipient fixture
  */
-export function additionalPostalRecipient(licenceRef = null, contact = null) {
+function additionalPostalRecipient(licenceRef = null, contact = null) {
   const recipientLicenceRef = licenceRef ?? LicenceHelper.generateLicenceRef()
 
   // NOTE: We take what our helper function would generate for a contact and modify it to match would be set after
@@ -84,7 +84,7 @@ export function additionalPostalRecipient(licenceRef = null, contact = null) {
  *
  * @returns {object} The abstraction alert additional contact recipient fixture
  */
-export function alertNoticeAdditionalContact() {
+function alertNoticeAdditionalContact() {
   const email = 'additional.contact@abs-alerts.com'
 
   return {
@@ -105,7 +105,7 @@ export function alertNoticeAdditionalContact() {
  *
  * @returns {object} The abstraction alert licence holder recipient fixture
  */
-export function alertNoticeLicenceHolder() {
+function alertNoticeLicenceHolder() {
   const contact = _contact('Alertholder', 'Licence holder')
 
   return {
@@ -126,7 +126,7 @@ export function alertNoticeLicenceHolder() {
  *
  * @returns {object} The abstraction alert primary user recipient fixture
  */
-export function alertNoticePrimaryUser() {
+function alertNoticePrimaryUser() {
   const email = 'primary.user@abs-alerts.com'
 
   return {
@@ -147,7 +147,7 @@ export function alertNoticePrimaryUser() {
  *
  * @returns {object} The renewal invitation licence holder recipient fixture
  */
-export function renewalInvitationLicenceHolder() {
+function renewalInvitationLicenceHolder() {
   const contact = _contact('4', 'Renewal licence holder')
 
   const recipient = {
@@ -170,7 +170,7 @@ export function renewalInvitationLicenceHolder() {
  *
  * @returns {object} The renewal invitation primary user recipient fixture
  */
-export function renewalInvitationPrimaryUser() {
+function renewalInvitationPrimaryUser() {
   const email = 'primary.user@renewal-invitation.com'
 
   const recipient = {
@@ -195,7 +195,7 @@ export function renewalInvitationPrimaryUser() {
  *
  * @returns {object} The returns notice licence holder recipient fixture
  */
-export function returnsNoticeLicenceHolder(download = false) {
+function returnsNoticeLicenceHolder(download = false) {
   const contact = _contact('4', 'Returnsholder')
 
   const recipient = {
@@ -231,7 +231,7 @@ export function returnsNoticeLicenceHolder(download = false) {
  *
  * @returns {object} The returns notice primary user recipient fixture
  */
-export function returnsNoticePrimaryUser(download = false) {
+function returnsNoticePrimaryUser(download = false) {
   const email = 'primary.user@returns-notice.com'
 
   const recipient = {
@@ -267,7 +267,7 @@ export function returnsNoticePrimaryUser(download = false) {
  *
  * @returns {object} The returns notice returns user recipient fixture
  */
-export function returnsNoticeReturnsAgent(download = false) {
+function returnsNoticeReturnsAgent(download = false) {
   const email = 'returns.agent@returns-notice.com'
 
   const recipient = {
@@ -303,7 +303,7 @@ export function returnsNoticeReturnsAgent(download = false) {
  *
  * @returns {object} The returns notice returns to recipient fixture
  */
-export function returnsNoticeReturnsTo(download = false) {
+function returnsNoticeReturnsTo(download = false) {
   const contact = _contact('4', 'Returnsto')
 
   const recipient = {
@@ -335,7 +335,7 @@ export function returnsNoticeReturnsTo(download = false) {
  *
  * @returns {object} - Returns recipients for primaryUser, licenceHolder and additional contact
  */
-export function alertsRecipients() {
+function alertsRecipients() {
   const licenceHolder = _addLicenceHolder()
 
   return {
@@ -351,7 +351,7 @@ export function alertsRecipients() {
  * @returns {object} - Returns recipients for primaryUser, returnsUser, licenceHolder, returnsTo and
  * licenceHolderWithMultipleLicences
  */
-export function recipients() {
+function recipients() {
   return {
     primaryUser: _addPrimaryUser(),
     returnsUser: _addReturnsAgent(),
@@ -495,4 +495,20 @@ function _nonDownloadRecipient(recipient) {
     notificationDueDate: recipient.notificationDueDate,
     return_log_ids: [generateUUID()]
   }
+}
+
+export default {
+  additionalEmailRecipient,
+  additionalPostalRecipient,
+  alertNoticeAdditionalContact,
+  alertNoticeLicenceHolder,
+  alertNoticePrimaryUser,
+  renewalInvitationLicenceHolder,
+  renewalInvitationPrimaryUser,
+  returnsNoticeLicenceHolder,
+  returnsNoticePrimaryUser,
+  returnsNoticeReturnsAgent,
+  returnsNoticeReturnsTo,
+  alertsRecipients,
+  recipients
 }

--- a/test/support/fixtures/return-cycles.fixture.js
+++ b/test/support/fixtures/return-cycles.fixture.js
@@ -5,7 +5,7 @@ import { generateUUID } from '../../../app/lib/general.lib.js'
  *
  * @returns {object} A summer return cycle object with id, dates, and flags
  */
-export function summerCycle() {
+function summerCycle() {
   return {
     id: generateUUID(),
     startDate: new Date('2025-11-01'),
@@ -21,7 +21,7 @@ export function summerCycle() {
  *
  * @returns {object} A winter return cycle object with id, dates, and flags
  */
-export function winterCycle() {
+function winterCycle() {
   return {
     id: generateUUID(),
     startDate: new Date('2025-04-01'),
@@ -38,7 +38,7 @@ export function winterCycle() {
  * @param {number} [numberOfCycles=2] - the number of return cycles to return - defaults to the first two
  * @returns {object[]} an array of objects, each representing a return cycle
  */
-export function returnCycles(numberOfCycles = 2) {
+function returnCycles(numberOfCycles = 2) {
   const cycles = [
     summerCycle(),
     winterCycle(),
@@ -77,4 +77,10 @@ export function returnCycles(numberOfCycles = 2) {
   ]
 
   return cycles.slice(0, numberOfCycles)
+}
+
+export default {
+  summerCycle,
+  winterCycle,
+  returnCycles
 }

--- a/test/support/fixtures/return-logs.fixture.js
+++ b/test/support/fixtures/return-logs.fixture.js
@@ -15,7 +15,7 @@ import { generateRandomInteger, generateUUID } from '../../../app/lib/general.li
  *
  * @param {module:ReturnLogModel} returnLog - The return log instance to apply the fields to
  */
-export function applyFetchReturnLogFields(returnLog) {
+function applyFetchReturnLogFields(returnLog) {
   returnLog.siteDescription = returnLog.metadata.description
   returnLog.periodStartDay = returnLog.metadata.nald.periodStartDay
   returnLog.periodStartMonth = returnLog.metadata.nald.periodStartMonth
@@ -33,7 +33,7 @@ export function applyFetchReturnLogFields(returnLog) {
  *
  * @returns {object} Returns an enhanced version of the module:ReturnLogModel in line with the fetch service
  */
-export function dueReturn() {
+function dueReturn() {
   const dueReturn = returnLog()
 
   // NOTE: Due date is calculated 28 days after todays date. But when dealing with dates in code the addition is
@@ -62,7 +62,7 @@ export function dueReturn() {
  * @returns {module:ReturnLogModel} The generated return log instance with attributes such as start date, end date,
  * licence reference, return reference, and status
  */
-export function returnLog(returnsFrequency = 'month', addLicence = false) {
+function returnLog(returnsFrequency = 'month', addLicence = false) {
   const returnLogData = _returnLogData(returnsFrequency)
   const returnLog = ReturnLogModel.fromJson(returnLogData)
 
@@ -85,7 +85,7 @@ export function returnLog(returnsFrequency = 'month', addLicence = false) {
  *
  * @returns {module:ReturnSubmissionModel} The generated return submission
  */
-export function returnSubmission(returnLog, type = 'estimated', userUnit = 'm³') {
+function returnSubmission(returnLog, type = 'estimated', userUnit = 'm³') {
   returnLog.status = 'completed'
   returnLog.receivedDate = new Date('2023-04-12')
 
@@ -217,4 +217,11 @@ function _returnSubmissionLines(returnLog, returnSubmissionId, type, userUnit) {
       userUnit
     })
   })
+}
+
+export default {
+  applyFetchReturnLogFields,
+  dueReturn,
+  returnLog,
+  returnSubmission
 }

--- a/test/support/fixtures/return-requirements.fixture.js
+++ b/test/support/fixtures/return-requirements.fixture.js
@@ -14,7 +14,7 @@ import { generateUUID } from '../../../app/lib/general.lib.js'
  *
  * @returns {string} The formatted return log prefix string
  */
-export function returnLogPrefix(returnRequirement) {
+function returnLogPrefix(returnRequirement) {
   const { reference, returnVersion } = returnRequirement
 
   const licenceRef = returnVersion.licence.licenceRef
@@ -34,7 +34,7 @@ export function returnLogPrefix(returnRequirement) {
  *
  * @returns {object} A summer return requirement fixture object
  */
-export function summerReturnRequirement() {
+function summerReturnRequirement() {
   const returnVersion = _returnVersion(false)
   const reference = ReturnRequirementHelper.generateReference()
 
@@ -72,7 +72,7 @@ export function summerReturnRequirement() {
  *
  * @returns {object} A winter all-year return requirement fixture object
  */
-export function winterReturnRequirement(quarterlyReturns = false) {
+function winterReturnRequirement(quarterlyReturns = false) {
   const returnVersion = _returnVersion(quarterlyReturns)
   const reference = ReturnRequirementHelper.generateReference()
 
@@ -140,4 +140,10 @@ function _returnVersion(quarterlyReturns) {
     quarterlyReturns,
     multipleUpload: false
   }
+}
+
+export default {
+  returnLogPrefix,
+  summerReturnRequirement,
+  winterReturnRequirement
 }

--- a/test/support/fixtures/two-part-tariff.fixture.js
+++ b/test/support/fixtures/two-part-tariff.fixture.js
@@ -9,7 +9,7 @@ import { generateUUID } from '../../../app/lib/general.lib.js'
  *
  * @returns {object} Bill run object with generated UUIDs
  */
-export function billRun(regionId) {
+function billRun(regionId) {
   return {
     id: generateUUID(),
     externalId: generateUUID(),
@@ -22,7 +22,7 @@ export function billRun(regionId) {
  *
  * @returns {object} Billing account object with generated UUID and account number
  */
-export function billingAccount() {
+function billingAccount() {
   return {
     id: generateUUID(),
     accountNumber: BillingAccountHelper.generateAccountNumber()
@@ -36,7 +36,7 @@ export function billingAccount() {
  *
  * @returns {object} Mock response object from the Charging Module API
  */
-export function chargingModuleResponse(transactionId) {
+function chargingModuleResponse(transactionId) {
   return {
     succeeded: true,
     response: {
@@ -57,7 +57,7 @@ export function chargingModuleResponse(transactionId) {
  *
  * @returns {object} Charge version object with generated UUID and licence
  */
-export function chargeVersion(billingAccountId, licence) {
+function chargeVersion(billingAccountId, licence) {
   // NOTE: We are faking an Objection model which comes with a toJSON() method that gets called as part
   // of processing the billing account.
   const toJSON = () => {
@@ -133,7 +133,7 @@ export function chargeVersion(billingAccountId, licence) {
  *
  * @returns {object} Licence object with generated UUID and licence reference
  */
-export function licence(region) {
+function licence(region) {
   return {
     id: generateUUID(),
     licenceRef: LicenceHelper.generateLicenceRef(),
@@ -149,4 +149,12 @@ export function licence(region) {
       chargeRegionId: region.chargeRegionId
     }
   }
+}
+
+export default {
+  billRun,
+  billingAccount,
+  chargingModuleResponse,
+  chargeVersion,
+  licence
 }

--- a/test/support/fixtures/user-sessions.fixture.js
+++ b/test/support/fixtures/user-sessions.fixture.js
@@ -1,5 +1,5 @@
-import * as UsersFixture from './users.fixture.js'
 import LicenceHelper from '../helpers/licence.helper.js'
+import UsersFixture from './users.fixture.js'
 import { generateUUID } from '../../../app/lib/general.lib.js'
 
 /**
@@ -9,7 +9,7 @@ import { generateUUID } from '../../../app/lib/general.lib.js'
  *
  * @returns {object} The external user unregistration setup session fixture
  */
-export function unregistrationSession() {
+function unregistrationSession() {
   const user = UsersFixture.jonLee()
 
   return {
@@ -61,4 +61,8 @@ export function unregistrationSession() {
       username: user.username
     }
   }
+}
+
+export default {
+  unregistrationSession
 }

--- a/test/support/fixtures/users.fixture.js
+++ b/test/support/fixtures/users.fixture.js
@@ -16,7 +16,7 @@ import { compareStrings, generateUUID } from '../../../app/lib/general.lib.js'
  *
  * @returns {module:UserModel} the populated `UserModel` instance
  */
-export function adminInternal() {
+function adminInternal() {
   return user(0)
 }
 
@@ -25,7 +25,7 @@ export function adminInternal() {
  *
  * @returns {module:UserModel} the populated `UserModel` instance
  */
-export function basicAccess() {
+function basicAccess() {
   return user(10)
 }
 
@@ -34,7 +34,7 @@ export function basicAccess() {
  *
  * @returns {module:UserModel} the populated `UserModel` instance
  */
-export function billingAndData() {
+function billingAndData() {
   return user(4)
 }
 
@@ -43,7 +43,7 @@ export function billingAndData() {
  *
  * @returns {module:UserModel} the populated `UserModel` instance
  */
-export function digitiseApprover() {
+function digitiseApprover() {
   return user(12)
 }
 
@@ -52,7 +52,7 @@ export function digitiseApprover() {
  *
  * @returns {module:UserModel} the populated `UserModel` instance
  */
-export function digitiseEditor() {
+function digitiseEditor() {
   return user(11)
 }
 
@@ -61,7 +61,7 @@ export function digitiseEditor() {
  *
  * @returns {module:UserModel} the populated `UserModel` instance
  */
-export function environmentOfficer() {
+function environmentOfficer() {
   return user(2)
 }
 
@@ -73,7 +73,7 @@ export function environmentOfficer() {
  *
  * @returns {module:UserModel} the populated `UserModel` instance
  */
-export function external(role = null) {
+function external(role = null) {
   const userData = user(7)
 
   if (role) {
@@ -91,7 +91,7 @@ export function external(role = null) {
  *
  * @returns {module:UserModel} the populated `UserModel` instance
  */
-export function jonLee(role = null) {
+function jonLee(role = null) {
   const userData = user(8)
 
   if (role) {
@@ -106,7 +106,7 @@ export function jonLee(role = null) {
  *
  * @returns {module:UserModel} the populated `UserModel` instance
  */
-export function nationalPermittingService() {
+function nationalPermittingService() {
   return user(6)
 }
 
@@ -115,7 +115,7 @@ export function nationalPermittingService() {
  *
  * @returns {module:UserModel} the populated `UserModel` instance
  */
-export function permittingSupportCentre() {
+function permittingSupportCentre() {
   return user(5)
 }
 
@@ -127,7 +127,7 @@ export function permittingSupportCentre() {
  *
  * @returns {module:UserModel} the populated `UserModel` instance
  */
-export function rachelStevens(role = null) {
+function rachelStevens(role = null) {
   const userData = user(9)
 
   if (role) {
@@ -142,7 +142,7 @@ export function rachelStevens(role = null) {
  *
  * @returns {module:UserModel} the populated `UserModel` instance
  */
-export function superUser() {
+function superUser() {
   return user(1)
 }
 
@@ -154,7 +154,7 @@ export function superUser() {
  *
  * @returns {module:UserModel} the populated `UserModel` instance
  */
-export function tinaBarrett(role = null) {
+function tinaBarrett(role = null) {
   const userData = user(13)
 
   if (role) {
@@ -175,7 +175,7 @@ export function tinaBarrett(role = null) {
  *
  * @param {object} user - The user fixture object to transform to `FetchUserInternalService` result format
  */
-export function transformToFetchUserInternalResult(user) {
+function transformToFetchUserInternalResult(user) {
   const groupRoles = GroupRoleHelper.data.filter((groupRole) => {
     return groupRole.groupId === user.groups[0].id
   })
@@ -211,7 +211,7 @@ export function transformToFetchUserInternalResult(user) {
  *
  * @returns {module:UserModel} The transformed user fixture object
  */
-export function transformToFetchUsersResult(user) {
+function transformToFetchUsersResult(user) {
   const {
     application,
     enabled,
@@ -258,7 +258,7 @@ export function transformToFetchUsersResult(user) {
  *
  * @returns {module:UserModel} the populated `UserModel` instance
  */
-export function user(seedIndex) {
+function user(seedIndex) {
   const user = UserHelper.select(seedIndex)
 
   user.groups = _groups(user.userId)
@@ -272,7 +272,7 @@ export function user(seedIndex) {
  *
  * @returns {module:UserModel} the populated `UserModel` instance
  */
-export function wasteIndustryRegulatoryServices() {
+function wasteIndustryRegulatoryServices() {
   return user(3)
 }
 
@@ -368,4 +368,24 @@ function _transformLicenceEntity(licenceEntity) {
       })
     })
   })
+}
+
+export default {
+  adminInternal,
+  basicAccess,
+  billingAndData,
+  digitiseApprover,
+  digitiseEditor,
+  environmentOfficer,
+  external,
+  jonLee,
+  nationalPermittingService,
+  permittingSupportCentre,
+  rachelStevens,
+  superUser,
+  tinaBarrett,
+  transformToFetchUserInternalResult,
+  transformToFetchUsersResult,
+  user,
+  wasteIndustryRegulatoryServices
 }

--- a/test/support/fixtures/view-licences.fixture.js
+++ b/test/support/fixtures/view-licences.fixture.js
@@ -13,7 +13,7 @@ import { generateUUID } from '../../../app/lib/general.lib.js'
  *
  * @returns {object} - licence condition
  **/
-export function condition() {
+function condition() {
   return {
     id: generateUUID(),
     displayTitle: 'Political cessation condition',
@@ -50,7 +50,7 @@ export function condition() {
  *
  * @returns {LicenceModel} - licence
  **/
-export function licence() {
+function licence() {
   return LicenceModel.fromJson({
     id: generateUUID(),
     licenceRef: LicenceHelper.generateLicenceRef(),
@@ -72,7 +72,7 @@ export function licence() {
  *
  * @returns {object} - licence version
  */
-export function licenceVersion() {
+function licenceVersion() {
   return LicenceVersionModel.fromJson({
     address: {
       address1: '12 GRIMMAULD PLACE',
@@ -117,7 +117,7 @@ export function licenceVersion() {
  *
  * @returns {object} - licence version purpose
  **/
-export function licenceVersionPurpose() {
+function licenceVersionPurpose() {
   return {
     id: generateUUID(),
     abstractionPeriodStartDay: 1,
@@ -159,7 +159,7 @@ export function licenceVersionPurpose() {
  *
  * @returns {PointModel} - licence point
  **/
-export function point() {
+function point() {
   return PointModel.fromJson({
     bgsReference: 'TL 14/123',
     category: 'Single Point',
@@ -197,7 +197,7 @@ export function point() {
  *
  * @returns {PointModel} - licence point
  **/
-export function pointWithSource() {
+function pointWithSource() {
   return PointModel.fromJson({
     bgsReference: 'TL 14/123',
     category: 'Single Point',
@@ -225,8 +225,18 @@ export function pointWithSource() {
  *
  * @returns {object} - licence purpose
  */
-export function purpose() {
+function purpose() {
   return {
     description: 'Spray Irrigation - Storage'
   }
+}
+
+export default {
+  condition,
+  licence,
+  licenceVersion,
+  licenceVersionPurpose,
+  point,
+  pointWithSource,
+  purpose
 }

--- a/test/validators/licence-monitoring-station/setup/licence-number.validator.test.js
+++ b/test/validators/licence-monitoring-station/setup/licence-number.validator.test.js
@@ -2,8 +2,8 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
+import LicenceFixture from '../../../support/fixtures/licence.fixture.js'
 import LicenceHelper from '../../../support/helpers/licence.helper.js'
-import { licenceEnds } from '../../../support/fixtures/licence.fixture.js'
 import { yesterday } from '../../../support/general.js'
 
 // Thing under test
@@ -14,7 +14,7 @@ describe('Licence Monitoring Station Setup - Licence Number Validator', () => {
   let payload = {}
 
   beforeEach(() => {
-    licence = licenceEnds()
+    licence = LicenceFixture.licenceEnds()
   })
 
   describe('when called with valid data', () => {
@@ -83,7 +83,7 @@ describe('Licence Monitoring Station Setup - Licence Number Validator', () => {
 
     describe('because the licence has ended', () => {
       beforeEach(() => {
-        licence = licenceEnds(yesterday())
+        licence = LicenceFixture.licenceEnds(yesterday())
 
         payload = {
           licenceRef: LicenceHelper.generateLicenceRef()

--- a/test/validators/notices/setup/alert-type.validator.test.js
+++ b/test/validators/notices/setup/alert-type.validator.test.js
@@ -2,7 +2,7 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
-import * as AbstractionAlertSessionData from '../../../support/fixtures/abstraction-alert-session-data.fixture.js'
+import AbstractionAlertSessionData from '../../../support/fixtures/abstraction-alert-session-data.fixture.js'
 
 // Thing under test
 import AlertTypeValidator from '../../../../app/validators/notices/setup/alert-type.validator.js'


### PR DESCRIPTION
## Summary
Test fixtures previously exported multiple named functions, some of which were consumed via `import * as X` namespace imports elsewhere in the test suite - the same pattern that let sinon/vi stub calls silently no-op against the frozen ES module namespace, fixed for test helpers in #3531.

- Every fixture in `test/support/fixtures/*.fixture.js` now exports only `export default { ... }`, matching the helper convention
- Every import site (237 `import * as X` namespace imports and 12 named destructured imports) now uses the matching default import consistently
- Fixed `user-sessions.fixture.js`, which imported `users.fixture.js` via `import * as` internally

🤖 Generated with [Claude Code](https://claude.com/claude-code)