### PR TITLE
Remove vi.mock usage and document the ban in the testing skill

### DIFF
--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -64,7 +64,7 @@ vi.spyOn(ReturnLogModel, 'query').mockReturnValue({
 })
 ```
 
-- To stub a module's default-exported function (e.g. a service or DAL), you can't spy on the default import binding directly — import it as a namespace instead and spy on the `'default'` property. This works for our own project source files, and for third-party packages that are shipped as CJS:
+- To stub a module's default-exported function (e.g. a service or DAL), you can't spy on the default import binding directly — import it as a namespace instead and spy on the `'default'` property:
 
 ```js
 import * as FetchBillService from '../../../app/services/bills/fetch-bill-service.js'
@@ -77,11 +77,10 @@ vi.spyOn(FetchBillService, 'default').mockResolvedValue(billData)
 
 ## Mocking
 
-- Never use `vi.mock()` or `vi.doMock()`. They hoist to the top of the file, auto-mock every export, and behave inconsistently between CJS and ESM — they've caused real problems in this codebase and are banned. Use the `vi.spyOn()` patterns above instead
-- A third-party package that ships as native ESM has a frozen module namespace — `vi.spyOn(SomePackage, 'someExport')` throws `Cannot redefine property`. There's no `vi.mock()`-shaped escape hatch for this; pick one of:
-  - **Prefer exercising the real thing** where the dependency is cheap and side-effect-free (e.g. a filesystem operation) — see `test/services/jobs/export/compress-schema-folder.service.test.js`, which really compresses a real temp folder with `tar` rather than stubbing it
-  - **Stub a project-owned wrapper** if the code already goes through one (e.g. `app/lib/got-wrapper.lib.js` wraps `got` — stub `gotWrapper`, not `got` itself)
-  - **`vi.resetModules()` + dynamic `import()`** when a module-level singleton in the thing under test needs a genuinely fresh instance per test — reset the registry, dynamically re-import every project-owned dependency the module reads at import time and spy on those fresh instances, then dynamically import the module under test so it picks them up. See `test/plugins/airbrake.plugin.test.js`'s `'when registering the plugin'` block. Note this also invalidates any other project-owned module (e.g. shared config) imported statically elsewhere in the file — reload and use a fresh reference to those too, rather than mutating the stale top-of-file import
+- Never use `vi.mock()` or `vi.doMock()`. They hoist to the top of the file, auto-mock every export, and behave inconsistently between CJS and ESM — they've caused real problems in this codebase and are banned
+- Use the `vi.spyOn()` patterns above instead
+- This also works for named exports of third-party packages, e.g. `vi.spyOn(Tar, 'create')` against `import * as Tar from 'tar'`
+- If a module genuinely cannot be stubbed this way (e.g. a CJS module with a module-level singleton, or a package whose live bindings can't be intercepted), use `Proxyquire` instead — see `test/plugins/airbrake.plugin.test.js` for an example. Don't reach for `vi.mock()`/`vi.doMock()` as a workaround
 
 ## Assertions
 

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -64,7 +64,7 @@ vi.spyOn(ReturnLogModel, 'query').mockReturnValue({
 })
 ```
 
-- To stub a module's default-exported function (e.g. a service or DAL), you can't spy on the default import binding directly — import it as a namespace instead and spy on the `'default'` property:
+- To stub a module's default-exported function (e.g. a service or DAL), you can't spy on the default import binding directly — import it as a namespace instead and spy on the `'default'` property. This works for our own project source files, and for third-party packages that are shipped as CJS:
 
 ```js
 import * as FetchBillService from '../../../app/services/bills/fetch-bill-service.js'
@@ -77,10 +77,11 @@ vi.spyOn(FetchBillService, 'default').mockResolvedValue(billData)
 
 ## Mocking
 
-- Never use `vi.mock()` or `vi.doMock()`. They hoist to the top of the file, auto-mock every export, and behave inconsistently between CJS and ESM — they've caused real problems in this codebase and are banned
-- Use the `vi.spyOn()` patterns above instead
-- This also works for named exports of third-party packages, e.g. `vi.spyOn(Tar, 'create')` against `import * as Tar from 'tar'`
-- If a module genuinely cannot be stubbed this way (e.g. a CJS module with a module-level singleton, or a package whose live bindings can't be intercepted), use `Proxyquire` instead — see `test/plugins/airbrake.plugin.test.js` for an example. Don't reach for `vi.mock()`/`vi.doMock()` as a workaround
+- Never use `vi.mock()` or `vi.doMock()`. They hoist to the top of the file, auto-mock every export, and behave inconsistently between CJS and ESM — they've caused real problems in this codebase and are banned. Use the `vi.spyOn()` patterns above instead
+- A third-party package that ships as native ESM has a frozen module namespace — `vi.spyOn(SomePackage, 'someExport')` throws `Cannot redefine property`. There's no `vi.mock()`-shaped escape hatch for this; pick one of:
+  - **Prefer exercising the real thing** where the dependency is cheap and side-effect-free (e.g. a filesystem operation) — see `test/services/jobs/export/compress-schema-folder.service.test.js`, which really compresses a real temp folder with `tar` rather than stubbing it
+  - **Stub a project-owned wrapper** if the code already goes through one (e.g. `app/lib/got-wrapper.lib.js` wraps `got` — stub `gotWrapper`, not `got` itself)
+  - **`vi.resetModules()` + dynamic `import()`** when a module-level singleton in the thing under test needs a genuinely fresh instance per test — reset the registry, dynamically re-import every project-owned dependency the module reads at import time and spy on those fresh instances, then dynamically import the module under test so it picks them up. See `test/plugins/airbrake.plugin.test.js`'s `'when registering the plugin'` block. Note this also invalidates any other project-owned module (e.g. shared config) imported statically elsewhere in the file — reload and use a fresh reference to those too, rather than mutating the stale top-of-file import
 
 ## Assertions
 

--- a/.agents/skills/testing/SKILL.md
+++ b/.agents/skills/testing/SKILL.md
@@ -7,35 +7,34 @@ description: Testing standards and conventions for this project
 
 ## Framework
 
-- Use `vitest` — not Jest, Mocha, or Chai
-- Use `sinon` for stubs and spies
-- `vitest` runs with `globals: true`, so `describe`, `it`, `expect`, `beforeAll`, `afterAll`, `beforeEach`, `afterEach`, and `vi` are all available without importing
+- Use `vitest` — not Jest, Mocha, Chai, or Sinon
+- `vitest` runs with `globals: false`, so `describe`, `it`, `expect`, `beforeAll`, `afterAll`, `beforeEach`, `afterEach`, and `vi` must always be imported explicitly from `'vitest'`
+- Test files are ESM. No `'use strict'`, no `require()` — use `import`
 
 ## Test file structure
 
-Test files do not use JSDoc or `@module`. The top-of-file order is `'use strict'` followed by imports grouped by section comment:
+Test files do not use JSDoc or `@module`. The top-of-file order is imports grouped by section comment:
 
 ```js
-'use strict'
-
-// Test framework dependencies
-const Sinon = require('sinon')
+// Test framework
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-const SomeModelStub = require('../support/stubs/some-model.stub.js')
+import SomeModelHelper from '../support/helpers/some-model.helper.js'
 
 // Things we need to stub
-const SomeDal = require('../../app/dal/some.dal.js')
+import * as SomeDal from '../../app/dal/some.dal.js'
 
 // Thing under test
-const SubjectUnderTest = require('../../app/services/subject-under-test.service.js')
+import SubjectUnderTest from '../../app/services/subject-under-test.service.js'
 ```
 
 - Use these section comments in order, omitting any that are not needed:
-  1. `// Test framework dependencies` (omit entirely when only Vitest globals are needed — i.e. no Sinon or other requires)
+  1. `// Test framework` (omit entirely when only Vitest globals are needed — i.e. no other imports)
   2. `// Test helpers`
   3. `// Things we need to stub`
   4. `// Thing under test`
+  5. `// For running our service` (controller tests only — the `init` import used to start the Hapi server)
 - Alphabetical ordering within each section still applies (alanisms rule 2)
 - The top-level `describe` label must reflect the file's folder path. Each path segment is title-cased and joined with ` - `, followed by the module type:
 
@@ -48,16 +47,44 @@ const SubjectUnderTest = require('../../app/services/subject-under-test.service.
 
 ## Controller tests
 
-- Always call `await server.stop()` in `after`
+- Start the server in `beforeAll` and stop it in `afterAll` with `await server.stop()`
 
-## Sinon
+## Stubbing and spying
 
-- Always call `Sinon.restore()` in `afterEach` whenever stubs are used
+Use `vi.spyOn()` and `vi.fn()` — vitest's built-in mocking, not Sinon.
+
+- To stub a static/class method (e.g. an Objection model), spy directly on the default import — mutating a method on the object works even though the import binding itself is read-only:
+
+```js
+import ReturnLogModel from '../../../app/models/return-log.model.js'
+
+vi.spyOn(ReturnLogModel, 'query').mockReturnValue({
+  patch: vi.fn().mockReturnThis(),
+  findById: vi.fn().mockResolvedValue()
+})
+```
+
+- To stub a module's default-exported function (e.g. a service or DAL), you can't spy on the default import binding directly — import it as a namespace instead and spy on the `'default'` property:
+
+```js
+import * as FetchBillService from '../../../app/services/bills/fetch-bill-service.js'
+
+vi.spyOn(FetchBillService, 'default').mockResolvedValue(billData)
+```
+
+- Always call `vi.restoreAllMocks()` in `afterEach` whenever stubs are used
 - Never leave stubs active across tests
+
+## Mocking
+
+- Never use `vi.mock()` or `vi.doMock()`. They hoist to the top of the file, auto-mock every export, and behave inconsistently between CJS and ESM — they've caused real problems in this codebase and are banned
+- Use the `vi.spyOn()` patterns above instead
+- This also works for named exports of third-party packages, e.g. `vi.spyOn(Tar, 'create')` against `import * as Tar from 'tar'`
+- If a module genuinely cannot be stubbed this way (e.g. a CJS module with a module-level singleton, or a package whose live bindings can't be intercepted), use `Proxyquire` instead — see `test/plugins/airbrake.plugin.test.js` for an example. Don't reach for `vi.mock()`/`vi.doMock()` as a workaround
 
 ## Assertions
 
-- Vitest assertions use `.toEqual()`, `.toBe()`, etc. directly on `expect()`:
+- Vitest assertions use `.toEqual()`, `.toBe()`, etc. directly on `expect()`
 - Never inline computed values directly in `expect()` — assign them to a variable first, then wrap in the array at the assertion. Always leave a blank line between the assignment and the `expect()`:
 
 ```js

--- a/templates/submit.service.test.js
+++ b/templates/submit.service.test.js
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import SessionModelStub from '__STUBS_SESSION_PATH__'
 
 // Things we need to stub
-import FetchSessionDal from '__FETCH_SESSION_DAL_TEST_PATH__'
+import * as FetchSessionDal from '__FETCH_SESSION_DAL_TEST_PATH__'
 
 // Thing under test
 import __MODULE_NAME__ from '__REQUIRE_PATH__'
@@ -21,8 +21,7 @@ describe('__DESCRIBE_LABEL__', () => {
 
     session = SessionModelStub.build(sessionData)
 
-    vi.mock('__FETCH_SESSION_DAL_TEST_PATH__')
-    FetchSessionDal.mockResolvedValue(session)
+    vi.spyOn(FetchSessionDal, 'default').mockResolvedValue(session)
   })
 
   afterEach(() => {

--- a/templates/view-service.test.js
+++ b/templates/view-service.test.js
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import SessionModelStub from '__STUBS_SESSION_PATH__'
 
 // Things we need to stub
-import FetchSessionDal from '__FETCH_SESSION_DAL_TEST_PATH__'
+import * as FetchSessionDal from '__FETCH_SESSION_DAL_TEST_PATH__'
 
 // Thing under test
 import __MODULE_NAME__ from '__REQUIRE_PATH__'
@@ -19,8 +19,7 @@ describe('__DESCRIBE_LABEL__', () => {
 
     session = SessionModelStub.build(sessionData)
 
-    vi.mock('__FETCH_SESSION_DAL_TEST_PATH__')
-    FetchSessionDal.mockResolvedValue(session)
+    vi.spyOn(FetchSessionDal, 'default').mockResolvedValue(session)
   })
 
   afterEach(() => {

--- a/test/plugins/airbrake.plugin.test.js
+++ b/test/plugins/airbrake.plugin.test.js
@@ -2,7 +2,6 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Things we need to stub
-import * as AirbrakeNode from '@airbrake/node'
 import serverConfig from '../../config/server.config.js'
 
 // For running our service
@@ -55,32 +54,29 @@ describe('Airbrake plugin', () => {
     })
   })
 
-  // airbrake.plugin.js holds a module-level _notifier singleton. The beforeAll above spins up a real Hapi server
-  // that sets it via the real plugin module. These tests need a completely fresh module instance (where _notifier
-  // is undefined) with Notifier and gotWrapper stubbed out. We get that by resetting Vitest's module registry and
-  // dynamically re-importing everything the plugin depends on before re-importing the plugin itself, then stubbing
-  // the fresh instances. This also picks up a fresh copy of server.config.js, so we mutate that fresh instance
-  // rather than the one imported at the top of this file.
-  describe('when registering the plugin', () => {
+  // TODO: Remove describe.skip once the project migrates to ESM. In CJS mode, airbrake.plugin.js holds a module-level
+  // _notifier singleton. The beforeAll above spins up a real Hapi server that sets it via the real plugin module.
+  // These tests need a completely fresh module instance (where _notifier is undefined) with Notifier and gotWrapper
+  // stubbed out. Proxyquire provides that isolation today. We do not use vi.mock() here or once the project is ESM
+  // — see the testing skill's Mocking section for why. Instead, once ESM, use vi.resetModules() + dynamic import()
+  // to load a fresh plugin instance per test, then vi.spyOn() the namespace imports of '@airbrake/node' and
+  // '../lib/got-wrapper.lib.js' to stub their exports.
+  describe.skip('when registering the plugin', () => {
     let AirbrakePluginWithStubs
     let fakeServer
-    let freshServerConfig
     let gotWrapperStub
     let NotifierStub
 
-    beforeEach(async () => {
-      vi.resetModules()
-
-      freshServerConfig = (await import('../../config/server.config.js')).default
-
-      const GotWrapperLib = await import('../../app/lib/got-wrapper.lib.js')
+    beforeEach(() => {
       gotWrapperStub = vi.fn().mockResolvedValue('fake-request-fn')
-      vi.spyOn(GotWrapperLib, 'gotWrapper').mockImplementation(gotWrapperStub)
-
       NotifierStub = vi.fn()
-      vi.spyOn(AirbrakeNode, 'Notifier').mockImplementation(NotifierStub)
 
-      AirbrakePluginWithStubs = (await import('../../app/plugins/airbrake.plugin.js')).default
+      // TODO: Replace with vi.spyOn() + dynamic import() once the project migrates to ESM
+      // AirbrakePluginWithStubs = Proxyquire('../../app/plugins/airbrake.plugin.js', {
+      //   '../lib/got-wrapper.lib.js': { gotWrapper: gotWrapperStub },
+      //   '@airbrake/node': { Notifier: NotifierStub },
+      //   '../../config/server.config.js': serverConfig
+      // })
 
       fakeServer = {
         app: {},
@@ -91,7 +87,7 @@ describe('Airbrake plugin', () => {
 
     describe('and httpProxy is set', () => {
       beforeEach(() => {
-        freshServerConfig.httpProxy = 'http://proxy.local:8080'
+        serverConfig.httpProxy = 'http://proxy.local:8080'
       })
 
       it('calls gotWrapper to create a Request function', async () => {
@@ -114,7 +110,7 @@ describe('Airbrake plugin', () => {
 
     describe('and httpProxy is not set', () => {
       beforeEach(() => {
-        freshServerConfig.httpProxy = null
+        serverConfig.httpProxy = null
       })
 
       it('does not call gotWrapper', async () => {

--- a/test/plugins/airbrake.plugin.test.js
+++ b/test/plugins/airbrake.plugin.test.js
@@ -2,6 +2,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Things we need to stub
+import * as AirbrakeNode from '@airbrake/node'
 import serverConfig from '../../config/server.config.js'
 
 // For running our service
@@ -54,29 +55,32 @@ describe('Airbrake plugin', () => {
     })
   })
 
-  // TODO: Remove describe.skip once the project migrates to ESM. In CJS mode, airbrake.plugin.js holds a module-level
-  // _notifier singleton. The beforeAll above spins up a real Hapi server that sets it via the real plugin module.
-  // These tests need a completely fresh module instance (where _notifier is undefined) with Notifier and gotWrapper
-  // stubbed out. Proxyquire provides that isolation today. We do not use vi.mock() here or once the project is ESM
-  // — see the testing skill's Mocking section for why. Instead, once ESM, use vi.resetModules() + dynamic import()
-  // to load a fresh plugin instance per test, then vi.spyOn() the namespace imports of '@airbrake/node' and
-  // '../lib/got-wrapper.lib.js' to stub their exports.
-  describe.skip('when registering the plugin', () => {
+  // airbrake.plugin.js holds a module-level _notifier singleton. The beforeAll above spins up a real Hapi server
+  // that sets it via the real plugin module. These tests need a completely fresh module instance (where _notifier
+  // is undefined) with Notifier and gotWrapper stubbed out. We get that by resetting Vitest's module registry and
+  // dynamically re-importing everything the plugin depends on before re-importing the plugin itself, then stubbing
+  // the fresh instances. This also picks up a fresh copy of server.config.js, so we mutate that fresh instance
+  // rather than the one imported at the top of this file.
+  describe('when registering the plugin', () => {
     let AirbrakePluginWithStubs
     let fakeServer
+    let freshServerConfig
     let gotWrapperStub
     let NotifierStub
 
-    beforeEach(() => {
-      gotWrapperStub = vi.fn().mockResolvedValue('fake-request-fn')
-      NotifierStub = vi.fn()
+    beforeEach(async () => {
+      vi.resetModules()
 
-      // TODO: Replace with vi.spyOn() + dynamic import() once the project migrates to ESM
-      // AirbrakePluginWithStubs = Proxyquire('../../app/plugins/airbrake.plugin.js', {
-      //   '../lib/got-wrapper.lib.js': { gotWrapper: gotWrapperStub },
-      //   '@airbrake/node': { Notifier: NotifierStub },
-      //   '../../config/server.config.js': serverConfig
-      // })
+      freshServerConfig = (await import('../../config/server.config.js')).default
+
+      const GotWrapperLib = await import('../../app/lib/got-wrapper.lib.js')
+      gotWrapperStub = vi.fn().mockResolvedValue('fake-request-fn')
+      vi.spyOn(GotWrapperLib, 'gotWrapper').mockImplementation(gotWrapperStub)
+
+      NotifierStub = vi.fn()
+      vi.spyOn(AirbrakeNode, 'Notifier').mockImplementation(NotifierStub)
+
+      AirbrakePluginWithStubs = (await import('../../app/plugins/airbrake.plugin.js')).default
 
       fakeServer = {
         app: {},
@@ -87,7 +91,7 @@ describe('Airbrake plugin', () => {
 
     describe('and httpProxy is set', () => {
       beforeEach(() => {
-        serverConfig.httpProxy = 'http://proxy.local:8080'
+        freshServerConfig.httpProxy = 'http://proxy.local:8080'
       })
 
       it('calls gotWrapper to create a Request function', async () => {
@@ -110,7 +114,7 @@ describe('Airbrake plugin', () => {
 
     describe('and httpProxy is not set', () => {
       beforeEach(() => {
-        serverConfig.httpProxy = null
+        freshServerConfig.httpProxy = null
       })
 
       it('does not call gotWrapper', async () => {

--- a/test/plugins/airbrake.plugin.test.js
+++ b/test/plugins/airbrake.plugin.test.js
@@ -57,9 +57,10 @@ describe('Airbrake plugin', () => {
   // TODO: Remove describe.skip once the project migrates to ESM. In CJS mode, airbrake.plugin.js holds a module-level
   // _notifier singleton. The beforeAll above spins up a real Hapi server that sets it via the real plugin module.
   // These tests need a completely fresh module instance (where _notifier is undefined) with Notifier and gotWrapper
-  // stubbed out. Proxyquire provides that isolation today but vi.mock() cannot replicate it in CJS. Once the project
-  // is ESM, replace Proxyquire with vi.mock('@airbrake/node', ...) and vi.mock('../lib/got-wrapper.lib.js', ...),
-  // then use vi.resetModules() + dynamic import() to load a fresh plugin instance per test.
+  // stubbed out. Proxyquire provides that isolation today. We do not use vi.mock() here or once the project is ESM
+  // — see the testing skill's Mocking section for why. Instead, once ESM, use vi.resetModules() + dynamic import()
+  // to load a fresh plugin instance per test, then vi.spyOn() the namespace imports of '@airbrake/node' and
+  // '../lib/got-wrapper.lib.js' to stub their exports.
   describe.skip('when registering the plugin', () => {
     let AirbrakePluginWithStubs
     let fakeServer
@@ -70,7 +71,7 @@ describe('Airbrake plugin', () => {
       gotWrapperStub = vi.fn().mockResolvedValue('fake-request-fn')
       NotifierStub = vi.fn()
 
-      // TODO: Replace with vi.mock() + dynamic import() once the project migrates to ESM
+      // TODO: Replace with vi.spyOn() + dynamic import() once the project migrates to ESM
       // AirbrakePluginWithStubs = Proxyquire('../../app/plugins/airbrake.plugin.js', {
       //   '../lib/got-wrapper.lib.js': { gotWrapper: gotWrapperStub },
       //   '@airbrake/node': { Notifier: NotifierStub },

--- a/test/services/bills/view-bill.service.test.js
+++ b/test/services/bills/view-bill.service.test.js
@@ -2,11 +2,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Things we need to stub
+import * as FetchBillService from '../../../app/services/bills/fetch-bill-service.js'
 import * as ViewBillLicencePresenter from '../../../app/presenters/bill-licences/view-bill-licence.presenter.js'
 import * as ViewBillPresenter from '../../../app/presenters/bills/view-bill.presenter.js'
 import * as ViewLicenceSummariesPresenter from '../../../app/presenters/bills/view-licence-summaries.presenter.js'
 import BillingAccountModel from '../../../app/models/billing-account.model.js'
-import FetchBillService from '../../../app/services/bills/fetch-bill-service.js'
 
 // Thing under test
 import ViewBillService from '../../../app/services/bills/view-bill.service.js'
@@ -21,8 +21,7 @@ describe('View Bill service', () => {
   describe('when a bill with a matching ID exists', () => {
     describe('and it is linked to multiple licences', () => {
       beforeEach(() => {
-        vi.mock('../../../app/services/bills/fetch-bill-service.js')
-        FetchBillService.mockResolvedValue({
+        vi.spyOn(FetchBillService, 'default').mockResolvedValue({
           bill: {
             id: 'a102d2b4-d0d5-4b26-82e2-d74a66e2cdc3',
             billingAccountId: '34183769-40d8-4d23-8bbb-f28e4d00c737'
@@ -84,8 +83,7 @@ describe('View Bill service', () => {
 
     describe('and it is linked to a single licence', () => {
       beforeEach(() => {
-        vi.mock('../../../app/services/bills/fetch-bill-service.js')
-        FetchBillService.mockResolvedValue({
+        vi.spyOn(FetchBillService, 'default').mockResolvedValue({
           bill: {
             id: 'a102d2b4-d0d5-4b26-82e2-d74a66e2cdc3',
             billingAccountId: '34183769-40d8-4d23-8bbb-f28e4d00c737'
@@ -118,8 +116,7 @@ describe('View Bill service', () => {
 
   describe('when a bill with a matching ID does not exist', () => {
     beforeEach(() => {
-      vi.mock('../../../app/services/bills/fetch-bill-service.js')
-      FetchBillService.mockResolvedValue({
+      vi.spyOn(FetchBillService, 'default').mockResolvedValue({
         bill: undefined,
         licenceSummaries: []
       })

--- a/test/services/jobs/export/compress-schema-folder.service.test.js
+++ b/test/services/jobs/export/compress-schema-folder.service.test.js
@@ -9,7 +9,9 @@ let CompressSchemaFolderService
 
 // TODO: Remove describe.skip once the project migrates to ESM. In CJS mode, Node.js v22's require(esm)
 // compatibility layer runs before Vitest's module interceptor so vi.doMock('tar') cannot replace the ESM
-// package's live bindings. Once test files are ESM, vi.mock('tar') with a static import will work correctly.
+// package's live bindings. We do not use vi.mock() / vi.doMock() here or once the project is ESM — see the
+// testing skill's Mocking section for why. Once test files are ESM, replace this dynamic require with a static
+// `import * as Tar from 'tar'` and stub its export with `vi.spyOn(Tar, 'create')`.
 describe.skip('Jobs - Export - Compress Schema Folder service', () => {
   beforeEach(() => {
     vi.doMock('tar', () => {

--- a/test/services/jobs/export/compress-schema-folder.service.test.js
+++ b/test/services/jobs/export/compress-schema-folder.service.test.js
@@ -1,40 +1,37 @@
 // Test framework
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
-// Things we need to stub (dynamically required in beforeEach to support mocking)
-let tar
+// Test helpers
+import fs from 'fs'
+import path from 'path'
 
-// Thing under test (dynamically required in beforeEach to support mocking)
-let CompressSchemaFolderService
+// Thing under test
+import CompressSchemaFolderService from '../../../../app/services/jobs/export/compress-schema-folder.service.js'
 
-// TODO: Remove describe.skip once the project migrates to ESM. In CJS mode, Node.js v22's require(esm)
-// compatibility layer runs before Vitest's module interceptor so vi.doMock('tar') cannot replace the ESM
-// package's live bindings. We do not use vi.mock() / vi.doMock() here or once the project is ESM — see the
-// testing skill's Mocking section for why. Once test files are ESM, replace this dynamic require with a static
-// `import * as Tar from 'tar'` and stub its export with `vi.spyOn(Tar, 'create')`.
-describe.skip('Jobs - Export - Compress Schema Folder service', () => {
+describe('Jobs - Export - Compress Schema Folder service', () => {
+  // NOTE: 'tar' is a native ESM package, so its module namespace is frozen and cannot be stubbed with vi.spyOn()
+  // (and we don't use vi.mock() — see the testing skill's Mocking section for why). So instead we exercise the real
+  // thing: create a real folder with a file in it, compress it, and assert the tarball exists on disk.
+  let schemaFolderPath
+  let tarballPath
+
   beforeEach(() => {
-    vi.doMock('tar', () => {
-      return { create: vi.fn().mockResolvedValue(undefined) }
-    })
-    vi.resetModules()
+    schemaFolderPath = '/tmp/compress-schema-folder-test'
+    tarballPath = `${schemaFolderPath}.tgz`
 
-    tar = require('tar')
-    CompressSchemaFolderService = require('../../../../app/services/jobs/export/compress-schema-folder.service.js')
+    fs.mkdirSync(schemaFolderPath, { recursive: true })
+    fs.writeFileSync(path.join(schemaFolderPath, 'test-file.csv'), 'some,csv,data')
   })
 
   afterEach(() => {
-    vi.resetAllMocks()
-    vi.resetModules()
+    fs.rmSync(schemaFolderPath, { recursive: true, force: true })
+    fs.rmSync(tarballPath, { force: true })
   })
 
   it('creates a compressed tarball from the given schema folder', async () => {
-    const schemaFolderPath = '/tmp/water'
-    const expectedTarballPath = '/tmp/water.tgz'
-
     const result = await CompressSchemaFolderService(schemaFolderPath)
 
-    expect(tar.create).toHaveBeenCalledOnce()
-    expect(result).toEqual(expectedTarballPath)
+    expect(result).toEqual(tarballPath)
+    expect(fs.existsSync(tarballPath)).toBe(true)
   })
 })

--- a/test/services/jobs/export/compress-schema-folder.service.test.js
+++ b/test/services/jobs/export/compress-schema-folder.service.test.js
@@ -1,37 +1,40 @@
 // Test framework
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-// Test helpers
-import fs from 'fs'
-import path from 'path'
+// Things we need to stub (dynamically required in beforeEach to support mocking)
+let tar
 
-// Thing under test
-import CompressSchemaFolderService from '../../../../app/services/jobs/export/compress-schema-folder.service.js'
+// Thing under test (dynamically required in beforeEach to support mocking)
+let CompressSchemaFolderService
 
-describe('Jobs - Export - Compress Schema Folder service', () => {
-  // NOTE: 'tar' is a native ESM package, so its module namespace is frozen and cannot be stubbed with vi.spyOn()
-  // (and we don't use vi.mock() — see the testing skill's Mocking section for why). So instead we exercise the real
-  // thing: create a real folder with a file in it, compress it, and assert the tarball exists on disk.
-  let schemaFolderPath
-  let tarballPath
-
+// TODO: Remove describe.skip once the project migrates to ESM. In CJS mode, Node.js v22's require(esm)
+// compatibility layer runs before Vitest's module interceptor so vi.doMock('tar') cannot replace the ESM
+// package's live bindings. We do not use vi.mock() / vi.doMock() here or once the project is ESM — see the
+// testing skill's Mocking section for why. Once test files are ESM, replace this dynamic require with a static
+// `import * as Tar from 'tar'` and stub its export with `vi.spyOn(Tar, 'create')`.
+describe.skip('Jobs - Export - Compress Schema Folder service', () => {
   beforeEach(() => {
-    schemaFolderPath = '/tmp/compress-schema-folder-test'
-    tarballPath = `${schemaFolderPath}.tgz`
+    vi.doMock('tar', () => {
+      return { create: vi.fn().mockResolvedValue(undefined) }
+    })
+    vi.resetModules()
 
-    fs.mkdirSync(schemaFolderPath, { recursive: true })
-    fs.writeFileSync(path.join(schemaFolderPath, 'test-file.csv'), 'some,csv,data')
+    tar = require('tar')
+    CompressSchemaFolderService = require('../../../../app/services/jobs/export/compress-schema-folder.service.js')
   })
 
   afterEach(() => {
-    fs.rmSync(schemaFolderPath, { recursive: true, force: true })
-    fs.rmSync(tarballPath, { force: true })
+    vi.resetAllMocks()
+    vi.resetModules()
   })
 
   it('creates a compressed tarball from the given schema folder', async () => {
+    const schemaFolderPath = '/tmp/water'
+    const expectedTarballPath = '/tmp/water.tgz'
+
     const result = await CompressSchemaFolderService(schemaFolderPath)
 
-    expect(result).toEqual(tarballPath)
-    expect(fs.existsSync(tarballPath)).toBe(true)
+    expect(tar.create).toHaveBeenCalledOnce()
+    expect(result).toEqual(expectedTarballPath)
   })
 })

--- a/test/services/notices/setup/initiate-session.service.test.js
+++ b/test/services/notices/setup/initiate-session.service.test.js
@@ -6,7 +6,7 @@ import AbstractionAlertSessionData from '../../../support/fixtures/abstraction-a
 import SessionModel from '../../../../app/models/session.model.js'
 
 // Things we need to stub
-import DetermineLicenceMonitoringStationsService from '../../../../app/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.js'
+import * as DetermineLicenceMonitoringStationsService from '../../../../app/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.js'
 
 // Thing under test
 import InitiateSessionService from '../../../../app/services/notices/setup/initiate-session.service.js'
@@ -77,10 +77,7 @@ describe('Notices - Setup - Initiate Session service', () => {
         journey = 'alerts'
         monitoringStationId = monitoringStationData.monitoringStationId
 
-        vi.mock(
-          '../../../../app/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.js'
-        )
-        DetermineLicenceMonitoringStationsService.mockResolvedValue(monitoringStationData)
+        vi.spyOn(DetermineLicenceMonitoringStationsService, 'default').mockResolvedValue(monitoringStationData)
       })
 
       it('initiates the session for the abstraction alerts setup journey and returns the session ID and redirect path', async () => {

--- a/test/services/return-versions/setup/existing/submit-existing.service.test.js
+++ b/test/services/return-versions/setup/existing/submit-existing.service.test.js
@@ -6,7 +6,7 @@ import SessionModelStub from '../../../../support/stubs/session.stub.js'
 
 // Things we need to stub
 import * as FetchSessionDal from '../../../../../app/dal/fetch-session.dal.js'
-import GenerateFromExistingRequirementsService from '../../../../../app/services/return-versions/setup/existing/generate-from-existing-requirements.service.js'
+import * as GenerateFromExistingRequirementsService from '../../../../../app/services/return-versions/setup/existing/generate-from-existing-requirements.service.js'
 
 // Thing under test
 import SubmitExistingService from '../../../../../app/services/return-versions/setup/existing/submit-existing.service.js'
@@ -73,10 +73,7 @@ describe('Return Versions - Setup - Submit Existing service', () => {
           existing: '60b5d10d-1372-4fb2-b222-bfac81da69ab'
         }
 
-        vi.mock(
-          '../../../../../app/services/return-versions/setup/existing/generate-from-existing-requirements.service.js'
-        )
-        GenerateFromExistingRequirementsService.mockResolvedValue({
+        vi.spyOn(GenerateFromExistingRequirementsService, 'default').mockResolvedValue({
           multipleUpload: false,
           quarterlyReturns: false,
           requirements: [_transformedReturnRequirement()]

--- a/test/services/return-versions/setup/method/generate-from-abstraction-data.service.test.js
+++ b/test/services/return-versions/setup/method/generate-from-abstraction-data.service.test.js
@@ -6,15 +6,13 @@ import LicenceModel from '../../../../../app/models/licence.model.js'
 import LicenceVersionPurposeModel from '../../../../../app/models/licence-version-purpose.model.js'
 
 // Things we need to stub
+import * as DetermineTwoPartTariffAgreementService from '../../../../../app/services/return-versions/setup/method/determine-two-part-tariff-agreement.service.js'
 import * as FetchAbstractionDataService from '../../../../../app/services/return-versions/setup/method/fetch-abstraction-data.service.js'
-import DetermineTwoPartTariffAgreementService from '../../../../../app/services/return-versions/setup/method/determine-two-part-tariff-agreement.service.js'
 
 // Thing under test
 import GenerateFromAbstractionDataService from '../../../../../app/services/return-versions/setup/method/generate-from-abstraction-data.service.js'
 
 describe('Return Versions - Setup - Generate From Abstraction Data service', () => {
-  vi.mock('../../../../../app/services/return-versions/setup/method/determine-two-part-tariff-agreement.service.js')
-
   const licenceId = 'af0e52a3-db43-4add-b388-1b2564a437c7'
   const licenceVersionId = '8e57b3c9-8656-4062-92ce-c7df34ca10bf'
   const startDate = new Date('2024-04-01')
@@ -33,7 +31,7 @@ describe('Return Versions - Setup - Generate From Abstraction Data service', () 
         twoPartTariffAgreement = false
 
         vi.spyOn(FetchAbstractionDataService, 'default').mockResolvedValue(abstractionData)
-        DetermineTwoPartTariffAgreementService.mockResolvedValue(twoPartTariffAgreement)
+        vi.spyOn(DetermineTwoPartTariffAgreementService, 'default').mockResolvedValue(twoPartTariffAgreement)
       })
 
       it('generates return requirements setup data', async () => {
@@ -113,7 +111,7 @@ describe('Return Versions - Setup - Generate From Abstraction Data service', () 
         twoPartTariffAgreement = true
 
         vi.spyOn(FetchAbstractionDataService, 'default').mockResolvedValue(abstractionData)
-        DetermineTwoPartTariffAgreementService.mockResolvedValue(twoPartTariffAgreement)
+        vi.spyOn(DetermineTwoPartTariffAgreementService, 'default').mockResolvedValue(twoPartTariffAgreement)
       })
 
       it('sets the collection frequency to "day" for the two-part tariff spray purpose', async () => {
@@ -137,7 +135,7 @@ describe('Return Versions - Setup - Generate From Abstraction Data service', () 
         twoPartTariffAgreement = false
 
         vi.spyOn(FetchAbstractionDataService, 'default').mockResolvedValue(abstractionData)
-        DetermineTwoPartTariffAgreementService.mockResolvedValue(twoPartTariffAgreement)
+        vi.spyOn(DetermineTwoPartTariffAgreementService, 'default').mockResolvedValue(twoPartTariffAgreement)
       })
 
       it('sets the agreements for each return requirement to be "two-part tariff"', async () => {
@@ -156,7 +154,7 @@ describe('Return Versions - Setup - Generate From Abstraction Data service', () 
         twoPartTariffAgreement = false
 
         vi.spyOn(FetchAbstractionDataService, 'default').mockResolvedValue(abstractionData)
-        DetermineTwoPartTariffAgreementService.mockResolvedValue(twoPartTariffAgreement)
+        vi.spyOn(DetermineTwoPartTariffAgreementService, 'default').mockResolvedValue(twoPartTariffAgreement)
       })
 
       it('sets the collection and reporting frequencies to "day"', async () => {


### PR DESCRIPTION
## Summary
- Replace all active `vi.mock()` usages with `vi.spyOn()` against a namespace import (the pattern already used elsewhere in these files)
- Update the two test templates (`templates/submit.service.test.js`, `templates/view-service.test.js`) to match
- Update stale TODO comments in `test/plugins/airbrake.plugin.test.js` and `test/services/jobs/export/compress-schema-folder.service.test.js` that had recommended `vi.mock()`/`vi.doMock()` as the future fix
- Rewrite `.agents/skills/testing/SKILL.md`, which was still describing CJS `require()`, `'use strict'`, Sinon, and `globals: true` — now documents the current ESM/vitest-native conventions, bans `vi.mock()`/`vi.doMock()`, and shows the `vi.spyOn()` stubbing patterns (direct spy on class exports vs. namespace-import spy on default-exported functions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)