### PR TITLE
Enforce external-before-internal import ordering within test file blocks

### DIFF
--- a/eslint-rules/order-within-import-groups.js
+++ b/eslint-rules/order-within-import-groups.js
@@ -1,0 +1,145 @@
+const SYNTAX_ORDER = ['all', 'single', 'multiple', 'none']
+
+function importCategory(node) {
+  if (node.specifiers.length === 0) {
+    return 'none'
+  }
+
+  if (
+    node.specifiers.some((specifier) => {
+      return specifier.type === 'ImportNamespaceSpecifier'
+    })
+  ) {
+    return 'all'
+  }
+
+  if (node.specifiers.length > 1) {
+    return 'multiple'
+  }
+
+  return 'single'
+}
+
+function firstLocalName(node) {
+  if (node.specifiers.length === 0) {
+    return ''
+  }
+
+  return node.specifiers[0].local.name
+}
+
+function isExternal(source) {
+  return !source.startsWith('.')
+}
+
+function sortKey(node) {
+  return {
+    node,
+    external: isExternal(node.source.value),
+    category: importCategory(node),
+    name: firstLocalName(node)
+  }
+}
+
+function compareEntries(first, second) {
+  if (first.external !== second.external) {
+    return first.external ? -1 : 1
+  }
+
+  const firstRank = SYNTAX_ORDER.indexOf(first.category)
+  const secondRank = SYNTAX_ORDER.indexOf(second.category)
+
+  if (firstRank !== secondRank) {
+    return firstRank - secondRank
+  }
+
+  if (first.name < second.name) {
+    return -1
+  }
+
+  if (first.name > second.name) {
+    return 1
+  }
+
+  return 0
+}
+
+export default {
+  meta: {
+    type: 'layout',
+    docs: {
+      description:
+        'Within each blank-line-separated group of imports, require external/builtin imports before internal (relative) ones'
+    },
+    fixable: 'code',
+    schema: [],
+    messages: {
+      unordered: 'Imports in this group should have external/builtin imports before internal ones'
+    }
+  },
+  create(context) {
+    const sourceCode = context.sourceCode ?? context.getSourceCode()
+
+    return {
+      'Program:exit'(program) {
+        const imports = program.body.filter((statement) => {
+          return statement.type === 'ImportDeclaration'
+        })
+
+        if (imports.length < 2) {
+          return
+        }
+
+        const runs = []
+        let currentRun = [imports[0]]
+
+        for (let i = 1; i < imports.length; i++) {
+          const previous = imports[i - 1]
+          const current = imports[i]
+
+          if (current.loc.start.line - previous.loc.end.line > 1) {
+            runs.push(currentRun)
+            currentRun = [current]
+          } else {
+            currentRun.push(current)
+          }
+        }
+
+        runs.push(currentRun)
+
+        for (const run of runs) {
+          if (run.length < 2) {
+            continue
+          }
+
+          const entries = run.map(sortKey)
+          const sortedEntries = [...entries].sort(compareEntries)
+
+          const alreadySorted = sortedEntries.every((entry, index) => {
+            return entry.node === run[index]
+          })
+
+          if (alreadySorted) {
+            continue
+          }
+
+          context.report({
+            node: run[0],
+            messageId: 'unordered',
+            fix(fixer) {
+              const newText = sortedEntries
+                .map((entry) => {
+                  return sourceCode.getText(entry.node)
+                })
+                .join('\n')
+              const start = run[0].range[0]
+              const end = run[run.length - 1].range[1]
+
+              return fixer.replaceTextRange([start, end], newText)
+            }
+          })
+        }
+      }
+    }
+  }
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,7 @@ import jsdocPlugin from 'eslint-plugin-jsdoc'
 import neostandard from 'neostandard'
 
 import noMixedExports from './eslint-rules/no-mixed-exports.js'
+import orderWithinImportGroups from './eslint-rules/order-within-import-groups.js'
 
 export default [
   // Ignore the folder created when JSDocs are generated
@@ -42,7 +43,12 @@ export default [
       // https://github.com/gajus/eslint-plugin-jsdoc
       jsdoc: jsdocPlugin,
       import: neostandard.plugins['import-x'],
-      local: { rules: { 'no-mixed-exports': noMixedExports } }
+      local: {
+        rules: {
+          'no-mixed-exports': noMixedExports,
+          'order-within-import-groups': orderWithinImportGroups
+        }
+      }
     },
     // NOTE: Special case for arrow-body-style below
     rules: {
@@ -108,11 +114,15 @@ export default [
     }
   },
   // Test files use blank lines to separate "Test helpers" / "Things we need to stub" / "Thing under test" blocks,
-  // a different convention to external-vs-internal grouping, so exempt them from import/order
+  // a different convention to external-vs-internal grouping, so exempt them from import/order. Instead,
+  // 'local/order-within-import-groups' enforces external-before-internal ordering *within* each of those
+  // blank-line-separated blocks, replacing sort-imports (which has no concept of external vs internal) for these files
   {
     files: ['templates/*.test.js', 'test/**/*'],
     rules: {
-      'import/order': 'off'
+      'import/order': 'off',
+      'sort-imports': 'off',
+      'local/order-within-import-groups': 'error'
     }
   },
   // This file deliberately separates its two imports with a large explanatory comment, which import/order treats as

--- a/test/controllers/bill-licences.controller.test.js
+++ b/test/controllers/bill-licences.controller.test.js
@@ -6,10 +6,10 @@ import http2 from 'node:http2'
 import { postRequestOptions } from '../support/general.js'
 
 // Things we need to stub
+import Boom from '@hapi/boom'
 import * as RemoveBillLicenceService from '../../app/services/bill-licences/remove-bill-licence.service.js'
 import * as SubmitRemoveBillLicenceService from '../../app/services/bill-licences/submit-remove-bill-licence.service.js'
 import * as ViewBillLicenceService from '../../app/services/bill-licences/view-bill-licence.service.js'
-import Boom from '@hapi/boom'
 
 // For running our service
 import { init } from '../../app/server.js'

--- a/test/controllers/bill-runs.controller.test.js
+++ b/test/controllers/bill-runs.controller.test.js
@@ -6,6 +6,7 @@ import http2 from 'node:http2'
 import { postRequestOptions } from '../support/general.js'
 
 // Things we need to stub
+import Boom from '@hapi/boom'
 import * as GenerateTwoPartTariffBillRunService from '../../app/services/bill-runs/generate-two-part-tariff-bill-run.service.js'
 import * as IndexBillRunsService from '../../app/services/bill-runs/index-bill-runs.service.js'
 import * as SubmitCancelBillRunService from '../../app/services/bill-runs/cancel/submit-cancel-bill-run.service.js'
@@ -14,7 +15,6 @@ import * as SubmitSendBillRunService from '../../app/services/bill-runs/send/sub
 import * as ViewBillRunService from '../../app/services/bill-runs/view-bill-run.service.js'
 import * as ViewCancelBillRunService from '../../app/services/bill-runs/cancel/view-cancel-bill-run.service.js'
 import * as ViewSendBillRunService from '../../app/services/bill-runs/send/view-send-bill-run.service.js'
-import Boom from '@hapi/boom'
 
 // For running our service
 import { init } from '../../app/server.js'

--- a/test/controllers/billing-accounts-setup.controller.test.js
+++ b/test/controllers/billing-accounts-setup.controller.test.js
@@ -2,8 +2,8 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import { generateUUID } from '../support/generators.js'
 import http2 from 'node:http2'
+import { generateUUID } from '../support/generators.js'
 import { postRequestOptions } from '../support/general.js'
 
 // Things we need to stub

--- a/test/controllers/billing-accounts.controller.test.js
+++ b/test/controllers/billing-accounts.controller.test.js
@@ -5,9 +5,9 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import http2 from 'node:http2'
 
 // Things we need to stub
+import Boom from '@hapi/boom'
 import * as ChangeAddressService from '../../app/services/billing-accounts/change-address.service.js'
 import * as ViewBillingAccountService from '../../app/services/billing-accounts/view-billing-account.service.js'
-import Boom from '@hapi/boom'
 
 // For running our service
 import { init } from '../../app/server.js'

--- a/test/controllers/bills.controller.test.js
+++ b/test/controllers/bills.controller.test.js
@@ -6,10 +6,10 @@ import http2 from 'node:http2'
 import { postRequestOptions } from '../support/general.js'
 
 // Things we need to stub
+import Boom from '@hapi/boom'
 import * as RemoveBillService from '../../app/services/bills/remove-bill.service.js'
 import * as SubmitRemoveBillService from '../../app/services/bills/submit-remove-bill.service.js'
 import * as ViewBillService from '../../app/services/bills/view-bill.service.js'
-import Boom from '@hapi/boom'
 
 // For running our service
 import { init } from '../../app/server.js'

--- a/test/controllers/notices.controller.test.js
+++ b/test/controllers/notices.controller.test.js
@@ -3,7 +3,6 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 
 // Test helpers
 import http2 from 'node:http2'
-
 import { generateNoticeReferenceCode } from '../support/generators.js'
 import { postRequestOptions } from '../support/general.js'
 

--- a/test/lib/base-notifier.lib.test.js
+++ b/test/lib/base-notifier.lib.test.js
@@ -5,9 +5,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { NOTIFY_TEMPLATES } from '../../app/lib/notify-templates.lib.js'
 
 // Things we need to stub
+import AirbrakeModule from '@airbrake/node'
 import * as CreateEmailRequest from '../../app/requests/notify/create-email.request.js'
 import AirbrakeConfig from '../../config/airbrake.config.js'
-import AirbrakeModule from '@airbrake/node'
 import NotifyConfig from '../../config/notify.config.js'
 
 // Thing under test

--- a/test/plugins/error-pages.plugin.test.js
+++ b/test/plugins/error-pages.plugin.test.js
@@ -3,8 +3,8 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 
 // Test helpers
 import Boom from '@hapi/boom'
-import SessionNotFoundError from '../../app/errors/session-not-found.error.js'
 import http2 from 'node:http2'
+import SessionNotFoundError from '../../app/errors/session-not-found.error.js'
 
 // Things we need to stub
 import GlobalNotifierStub from '../support/stubs/global-notifier.stub.js'

--- a/test/presenters/base.presenter.test.js
+++ b/test/presenters/base.presenter.test.js
@@ -2,9 +2,9 @@
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
+import { ValidationError } from 'joi'
 import LicenceVersionModel from '../../app/models/licence-version.model.js'
 import ReturnVersionModel from '../../app/models/return-version.model.js'
-import { ValidationError } from 'joi'
 import { generateUUID } from '../support/generators.js'
 import { today } from '../../app/lib/general.lib.js'
 import { tomorrow, yesterday } from '../support/general.js'

--- a/test/presenters/charging-module/create-transaction.presenter.test.js
+++ b/test/presenters/charging-module/create-transaction.presenter.test.js
@@ -2,11 +2,11 @@
 import { beforeEach, describe, expect, it } from 'vitest'
 
 // Test helpers
+import { ref } from 'objection'
 import LicenceHelper from '../../support/helpers/licence.helper.js'
 import LicenceModel from '../../../app/models/licence.model.js'
 import RegionHelper from '../../support/helpers/region.helper.js'
 import TransactionHelper from '../../support/helpers/transaction.helper.js'
-import { ref } from 'objection'
 
 // Thing under test
 import CreateTransactionPresenter from '../../../app/presenters/charging-module/create-transaction.presenter.js'

--- a/test/requests/notify/create-email.request.test.js
+++ b/test/requests/notify/create-email.request.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import { NOTIFY_TEMPLATES } from '../../../app/lib/notify-templates.lib.js'
 import http2 from 'node:http2'
+import { NOTIFY_TEMPLATES } from '../../../app/lib/notify-templates.lib.js'
 
 // Things we need to stub
 import * as NotifyRequest from '../../../app/requests/notify.request.js'

--- a/test/requests/notify/create-letter.request.test.js
+++ b/test/requests/notify/create-letter.request.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import { NOTIFY_TEMPLATES } from '../../../app/lib/notify-templates.lib.js'
 import http2 from 'node:http2'
+import { NOTIFY_TEMPLATES } from '../../../app/lib/notify-templates.lib.js'
 
 // Things we need to stub
 import * as NotifyRequest from '../../../app/requests/notify.request.js'

--- a/test/requests/notify/create-precompiled-file.request.test.js
+++ b/test/requests/notify/create-precompiled-file.request.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import { generateNoticeReferenceCode } from '../../support/generators.js'
 import http2 from 'node:http2'
+import { generateNoticeReferenceCode } from '../../support/generators.js'
 
 // Things we need to stub
 import * as NotifyRequest from '../../../app/requests/notify.request.js'

--- a/test/services/address/submit-select.service.test.js
+++ b/test/services/address/submit-select.service.test.js
@@ -2,9 +2,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
+import http2 from 'node:http2'
 import SessionModelStub from '../../support/stubs/session.stub.js'
 import { generateUUID } from '../../support/generators.js'
-import http2 from 'node:http2'
 
 // Things we need to stub
 import * as FetchSessionDal from '../../../app/dal/fetch-session.dal.js'

--- a/test/services/bill-runs/initiate-bill-run.service.test.js
+++ b/test/services/bill-runs/initiate-bill-run.service.test.js
@@ -2,9 +2,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
+import http2 from 'node:http2'
 import BillRunModel from '../../../app/models/bill-run.model.js'
 import RegionHelper from '../../support/helpers/region.helper.js'
-import http2 from 'node:http2'
 
 // Things we need to stub
 import * as ChargingModuleCreateBillRunRequest from '../../../app/requests/charging-module/create-bill-run.request.js'

--- a/test/services/bill-runs/reissue/reissue-bill.service.test.js
+++ b/test/services/bill-runs/reissue/reissue-bill.service.test.js
@@ -2,11 +2,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
+import http2 from 'node:http2'
 import BillHelper from '../../../support/helpers/bill.helper.js'
 import BillLicenceHelper from '../../../support/helpers/bill-licence.helper.js'
 import TransactionHelper from '../../../support/helpers/transaction.helper.js'
 import { generateUUID } from '../../../support/generators.js'
-import http2 from 'node:http2'
 
 // Things we need to stub
 import * as ChargingModuleReissueBillRequest from '../../../../app/requests/charging-module/reissue-bill.request.js'

--- a/test/services/bill-runs/review/preview.service.test.js
+++ b/test/services/bill-runs/review/preview.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 import http2 from 'node:http2'
+import BillRunsReviewFixture from '../../../support/fixtures/bill-runs-review.fixture.js'
 
 // Test helpers
 import YarStub from '../../../support/stubs/yar.stub.js'

--- a/test/services/health/info.service.test.js
+++ b/test/services/health/info.service.test.js
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import http2 from 'node:http2'
 
 // Things we need to stub
+import util from 'node:util'
 import * as AddressFacadeViewHealthRequest from '../../../app/requests/address-facade/view-health.request.js'
 import * as ChargingModuleViewHealthRequest from '../../../app/requests/charging-module/view-health.request.js'
 import * as CreateRedisClientService from '../../../app/services/health/create-redis-client.service.js'
@@ -11,7 +12,6 @@ import * as GotenbergViewHealthRequest from '../../../app/requests/gotenberg/vie
 import * as LegacyViewHealthRequest from '../../../app/requests/legacy/view-health.request.js'
 import * as NotifyViewHealthRequest from '../../../app/requests/notify/view-health.request.js'
 import * as RespViewHealthRequest from '../../../app/requests/resp/view-health.request.js'
-import util from 'node:util'
 
 // Thing under test
 import InfoService from '../../../app/services/health/info.service.js'

--- a/test/services/jobs/customer-files/process-customer-files.service.test.js
+++ b/test/services/jobs/customer-files/process-customer-files.service.test.js
@@ -2,9 +2,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
+import http2 from 'node:http2'
 import BillingAccountHelper from '../../../support/helpers/billing-account.helper.js'
 import BillingAccountModel from '../../../../app/models/billing-account.model.js'
-import http2 from 'node:http2'
 
 // Things we need to stub
 import * as ChargingModuleViewCustomerFilesRequest from '../../../../app/requests/charging-module/view-customer-files.request.js'

--- a/test/services/jobs/export/write-table-to-file.service.test.js
+++ b/test/services/jobs/export/write-table-to-file.service.test.js
@@ -2,10 +2,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import { data as chargeCategories } from '../../../../db/seeds/data/charge-categories.js'
-import { db } from '../../../../db/db.js'
 import fs from 'fs'
 import path from 'path'
+import { data as chargeCategories } from '../../../../db/seeds/data/charge-categories.js'
+import { db } from '../../../../db/db.js'
 
 // Thing under test
 import WriteTableToFileService from '../../../../app/services/jobs/export/write-table-to-file.service.js'

--- a/test/services/return-versions/setup/initiate-session.service.test.js
+++ b/test/services/return-versions/setup/initiate-session.service.test.js
@@ -2,8 +2,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Test helpers
-import LicenceModel from '../../../../app/models/licence.model.js'
 import http2 from 'node:http2'
+import LicenceModel from '../../../../app/models/licence.model.js'
 
 // Things we need to stub
 import * as FetchLicenceService from '../../../../app/services/return-versions/setup/fetch-licence.service.js'

--- a/test/support/fixtures/notify-response.fixture.js
+++ b/test/support/fixtures/notify-response.fixture.js
@@ -1,5 +1,5 @@
-import { NOTIFY_TEMPLATES } from '../../../app/lib/notify-templates.lib.js'
 import http2 from 'node:http2'
+import { NOTIFY_TEMPLATES } from '../../../app/lib/notify-templates.lib.js'
 
 const { HTTP_STATUS_OK } = http2.constants
 


### PR DESCRIPTION
## Summary
- Test files skip `import/order` in favour of blank-line-separated `// Test framework` / `// Test helpers` / `// Thing under test` comment blocks, but this left `node:` builtins and npm packages free to sort alphabetically alongside relative imports within a block instead of coming before them (e.g. `node:http2` sandwiched between two relative imports).
- `sort-imports` has no concept of external vs internal, so it can't enforce this without fighting the block convention whenever a builtin's name doesn't happen to sort alphabetically before the relative imports around it.
- Adds `eslint-rules/order-within-import-groups.js`, a custom rule that enforces external-before-internal ordering *within* each existing blank-line-separated block, and wires it in as `local/order-within-import-groups` for test files, replacing `sort-imports` there (which it fully subsumes: same syntax-type + alphabetical ordering, plus the external/internal split).
- Reformats the 22 test/fixture files this newly catches.