### PR TITLE
Use dedicated vitest matchers instead of generic assertions

### DIFF
--- a/app/presenters/bill-runs/review/base-review.presenter.js
+++ b/app/presenters/bill-runs/review/base-review.presenter.js
@@ -8,7 +8,7 @@ import { formatLongDate } from '../../base.presenter.js'
  *
  * @param {module:ReviewChargeElementModel[]} reviewChargeElements - array of `ReviewChargeElementModel` instances
  *
- * @returns {string} the sum of allocated volume against all review charge elements without loss of precision
+ * @returns {number} the sum of allocated volume against all review charge elements without loss of precision
  */
 export function calculateTotalBillableReturns(reviewChargeElements) {
   return reviewChargeElements.reduce((total, reviewChargeElement) => {

--- a/test/dal/notices/setup/fetch-renewal-licence.dal.test.js
+++ b/test/dal/notices/setup/fetch-renewal-licence.dal.test.js
@@ -36,7 +36,7 @@ describe('Notices - Setup - Fetch Renewal Licence DAL', () => {
     it('returns undefined', async () => {
       const result = await FetchRenewalLicenceDal('does-not-exist')
 
-      expect(result).toEqual(undefined)
+      expect(result).toBeUndefined()
     })
   })
 })

--- a/test/lib/dates.lib.test.js
+++ b/test/lib/dates.lib.test.js
@@ -142,7 +142,7 @@ describe('Dates lib', () => {
 
       it('returns null', () => {
         const result = DateLib.determineEarliestDate(dates)
-        expect(result).toEqual(null)
+        expect(result).toBeNull()
       })
     })
 
@@ -153,7 +153,7 @@ describe('Dates lib', () => {
 
       it('returns null', () => {
         const result = DateLib.determineEarliestDate(dates)
-        expect(result).toEqual(null)
+        expect(result).toBeNull()
       })
     })
   })

--- a/test/lib/general.lib.test.js
+++ b/test/lib/general.lib.test.js
@@ -326,7 +326,7 @@ describe('GeneralLib', () => {
       const result = GeneralLib.generateNoticeReferenceCode('TEST-')
 
       expect(result.startsWith('TEST-')).toBe(true)
-      expect(result.length).toEqual(11)
+      expect(result).toHaveLength(11)
     })
   })
 
@@ -523,7 +523,7 @@ describe('GeneralLib', () => {
       it('returns the provided array grouped by the given group size', () => {
         const result = GeneralLib.splitArrayIntoGroups(testArray, testGroupSize)
 
-        expect(result.length).toEqual(4)
+        expect(result).toHaveLength(4)
 
         expect(result).toEqual([
           [1, 2], // Group One
@@ -551,7 +551,7 @@ describe('GeneralLib', () => {
       it('returns the provided array grouped by the given group size', () => {
         const result = GeneralLib.splitArrayIntoGroups(testArray, testGroupSize)
 
-        expect(result.length).toEqual(3)
+        expect(result).toHaveLength(3)
 
         expect(result).toEqual([
           [{ number: 1 }, { number: 2 }, { number: 3 }], // Group One
@@ -570,7 +570,7 @@ describe('GeneralLib', () => {
       it('returns an empty array', () => {
         const result = GeneralLib.splitArrayIntoGroups(testArray, testGroupSize)
 
-        expect(result.length).toEqual(0)
+        expect(result).toHaveLength(0)
 
         expect(result).toEqual([])
       })
@@ -585,7 +585,7 @@ describe('GeneralLib', () => {
       it('returns the provided array (not grouped)', () => {
         const result = GeneralLib.splitArrayIntoGroups(testArray, testGroupSize)
 
-        expect(result.length).toEqual(7)
+        expect(result).toHaveLength(7)
 
         expect(result).toEqual([1, 2, 3, 4, 5, 6, 7])
       })
@@ -600,7 +600,7 @@ describe('GeneralLib', () => {
       it('returns the provided array grouped by the given group size', () => {
         const result = GeneralLib.splitArrayIntoGroups(testArray, testGroupSize)
 
-        expect(result.length).toEqual(1)
+        expect(result).toHaveLength(1)
 
         expect(result).toEqual([[1, 2]])
       })

--- a/test/lib/transform-to-csv.lib.test.js
+++ b/test/lib/transform-to-csv.lib.test.js
@@ -130,7 +130,7 @@ describe('Transform to csv', () => {
       it('returns undefined', () => {
         const result = transformArrayToCSVRow()
 
-        expect(result).toEqual(undefined)
+        expect(result).toBeUndefined()
       })
     })
   })

--- a/test/presenters/address/international.presenter.test.js
+++ b/test/presenters/address/international.presenter.test.js
@@ -50,7 +50,7 @@ describe('Address - International Presenter', () => {
       it('returns null', () => {
         const result = InternationalPresenter(session)
 
-        expect(result.addressLine1).toEqual(null)
+        expect(result.addressLine1).toBeNull()
       })
     })
 
@@ -72,7 +72,7 @@ describe('Address - International Presenter', () => {
       it('returns null', () => {
         const result = InternationalPresenter(session)
 
-        expect(result.addressLine2).toEqual(null)
+        expect(result.addressLine2).toBeNull()
       })
     })
 
@@ -94,7 +94,7 @@ describe('Address - International Presenter', () => {
       it('returns null', () => {
         const result = InternationalPresenter(session)
 
-        expect(result.addressLine3).toEqual(null)
+        expect(result.addressLine3).toBeNull()
       })
     })
 
@@ -116,7 +116,7 @@ describe('Address - International Presenter', () => {
       it('returns null', () => {
         const result = InternationalPresenter(session)
 
-        expect(result.addressLine4).toEqual(null)
+        expect(result.addressLine4).toBeNull()
       })
     })
 
@@ -160,7 +160,7 @@ describe('Address - International Presenter', () => {
       it('returns null', () => {
         const result = InternationalPresenter(session)
 
-        expect(result.pageTitleCaption).toEqual(null)
+        expect(result.pageTitleCaption).toBeNull()
       })
     })
 
@@ -182,7 +182,7 @@ describe('Address - International Presenter', () => {
       it('returns null', () => {
         const result = InternationalPresenter(session)
 
-        expect(result.postcode).toEqual(null)
+        expect(result.postcode).toBeNull()
       })
     })
 

--- a/test/presenters/address/manual.presenter.test.js
+++ b/test/presenters/address/manual.presenter.test.js
@@ -46,7 +46,7 @@ describe('Address - Manual Presenter', () => {
       it('returns null', () => {
         const result = ManualPresenter(session)
 
-        expect(result.addressLine1).toEqual(null)
+        expect(result.addressLine1).toBeNull()
       })
     })
 
@@ -68,7 +68,7 @@ describe('Address - Manual Presenter', () => {
       it('returns null', () => {
         const result = ManualPresenter(session)
 
-        expect(result.addressLine2).toEqual(null)
+        expect(result.addressLine2).toBeNull()
       })
     })
 
@@ -90,7 +90,7 @@ describe('Address - Manual Presenter', () => {
       it('returns null', () => {
         const result = ManualPresenter(session)
 
-        expect(result.addressLine3).toEqual(null)
+        expect(result.addressLine3).toBeNull()
       })
     })
 
@@ -112,7 +112,7 @@ describe('Address - Manual Presenter', () => {
       it('returns null', () => {
         const result = ManualPresenter(session)
 
-        expect(result.addressLine4).toEqual(null)
+        expect(result.addressLine4).toBeNull()
       })
     })
 
@@ -162,7 +162,7 @@ describe('Address - Manual Presenter', () => {
       it('returns null', () => {
         const result = ManualPresenter(session)
 
-        expect(result.pageTitleCaption).toEqual(null)
+        expect(result.pageTitleCaption).toBeNull()
       })
     })
 
@@ -188,7 +188,7 @@ describe('Address - Manual Presenter', () => {
       it('returns null', () => {
         const result = ManualPresenter(session)
 
-        expect(result.postcode).toEqual(null)
+        expect(result.postcode).toBeNull()
       })
     })
 

--- a/test/presenters/address/postcode.presenter.test.js
+++ b/test/presenters/address/postcode.presenter.test.js
@@ -43,7 +43,7 @@ describe('Address - Postcode Presenter', () => {
       it('returns null', () => {
         const result = PostcodePresenter(session)
 
-        expect(result.pageTitleCaption).toEqual(null)
+        expect(result.pageTitleCaption).toBeNull()
       })
     })
 
@@ -77,7 +77,7 @@ describe('Address - Postcode Presenter', () => {
       it('returns null', () => {
         const result = PostcodePresenter(session)
 
-        expect(result.postcode).toEqual(null)
+        expect(result.postcode).toBeNull()
       })
     })
   })
@@ -99,7 +99,7 @@ describe('Address - Postcode Presenter', () => {
       it('returns null', () => {
         const result = PostcodePresenter(session)
 
-        expect(result.activeNavBar).toEqual(null)
+        expect(result.activeNavBar).toBeNull()
       })
     })
   })

--- a/test/presenters/address/select.presenter.test.js
+++ b/test/presenters/address/select.presenter.test.js
@@ -114,7 +114,7 @@ describe('Address - Select Presenter', () => {
       it('returns null', () => {
         const result = SelectPresenter(session, addresses)
 
-        expect(result.pageTitleCaption).toEqual(null)
+        expect(result.pageTitleCaption).toBeNull()
       })
     })
 

--- a/test/presenters/base.presenter.test.js
+++ b/test/presenters/base.presenter.test.js
@@ -330,7 +330,7 @@ describe('Base presenter', () => {
       it('returns null', () => {
         const result = BasePresenter.formatNumber(null)
 
-        expect(result).toEqual(null)
+        expect(result).toBeNull()
       })
     })
 
@@ -338,7 +338,7 @@ describe('Base presenter', () => {
       it('returns null', () => {
         const result = BasePresenter.formatNumber(undefined)
 
-        expect(result).toEqual(null)
+        expect(result).toBeNull()
       })
     })
   })
@@ -444,7 +444,7 @@ describe('Base presenter', () => {
       it('returns null', () => {
         const result = BasePresenter.formatQuantityToUnit(null, 'someUnit')
 
-        expect(result).toEqual(null)
+        expect(result).toBeNull()
       })
     })
   })

--- a/test/presenters/billing-accounts/setup/check.presenter.test.js
+++ b/test/presenters/billing-accounts/setup/check.presenter.test.js
@@ -406,7 +406,7 @@ describe('Billing Accounts - Setup - Check Presenter', () => {
           companysHouseResult
         )
 
-        expect(result.contactSelected).toEqual(null)
+        expect(result.contactSelected).toBeNull()
       })
     })
 

--- a/test/presenters/billing-accounts/setup/company-search.presenter.test.js
+++ b/test/presenters/billing-accounts/setup/company-search.presenter.test.js
@@ -37,7 +37,7 @@ describe('Billing Accounts - Setup - Company Search Presenter', () => {
       it('returns null', () => {
         const result = CompanySearchPresenter(session)
 
-        expect(result.companySearch).toEqual(null)
+        expect(result.companySearch).toBeNull()
       })
     })
 

--- a/test/presenters/billing-accounts/setup/contact-name.presenter.test.js
+++ b/test/presenters/billing-accounts/setup/contact-name.presenter.test.js
@@ -39,7 +39,7 @@ describe('Billing Accounts - Setup - Contact Name Presenter', () => {
       it('returns null', () => {
         const result = ContactNamePresenter(session)
 
-        expect(result.contactName).toEqual(null)
+        expect(result.contactName).toBeNull()
       })
     })
 

--- a/test/presenters/billing-accounts/setup/contact.presenter.test.js
+++ b/test/presenters/billing-accounts/setup/contact.presenter.test.js
@@ -64,7 +64,7 @@ describe('Billing Accounts - Setup - Contact Presenter', () => {
       it('returns null', () => {
         const result = ContactPresenter(session, companyContacts)
 
-        expect(result.contactSelected).toEqual(null)
+        expect(result.contactSelected).toBeNull()
       })
     })
 

--- a/test/presenters/billing-accounts/setup/select-company.presenter.test.js
+++ b/test/presenters/billing-accounts/setup/select-company.presenter.test.js
@@ -106,7 +106,7 @@ describe('Billing Accounts - Setup - Select Company Presenter', () => {
       it('returns null', () => {
         const result = SelectCompanyPresenter(session, companies)
 
-        expect(result.companiesHouseNumber).toEqual(null)
+        expect(result.companiesHouseNumber).toBeNull()
       })
     })
   })

--- a/test/presenters/charging-module/create-transaction.presenter.test.js
+++ b/test/presenters/charging-module/create-transaction.presenter.test.js
@@ -86,7 +86,7 @@ describe('Charging Module Create Transaction presenter', () => {
       expect(result.section127Agreement).toEqual(false)
       expect(result.section130Agreement).toEqual(false)
       expect(result.supportedSource).toEqual(false)
-      expect(result.supportedSourceName).toEqual(null)
+      expect(result.supportedSourceName).toBeNull()
       expect(result.twoPartTariff).toEqual(false)
       expect(result.waterCompanyCharge).toEqual(false)
       expect(result.waterUndertaker).toEqual(false)

--- a/test/presenters/companies/licences.presenter.test.js
+++ b/test/presenters/companies/licences.presenter.test.js
@@ -92,7 +92,7 @@ describe('Companies - Licences presenter', () => {
         it('returns null', () => {
           const result = LicencesPresenter(company, licences)
 
-          expect(result.licences[0].status).toEqual(null)
+          expect(result.licences[0].status).toBeNull()
         })
       })
 
@@ -116,7 +116,7 @@ describe('Companies - Licences presenter', () => {
         it('returns null', () => {
           const result = LicencesPresenter(company, licences)
 
-          expect(result.licences[0].status).toEqual(null)
+          expect(result.licences[0].status).toBeNull()
         })
       })
     })

--- a/test/presenters/licences/summary.presenter.test.js
+++ b/test/presenters/licences/summary.presenter.test.js
@@ -730,7 +730,7 @@ describe('Licences - Summary Presenter', () => {
       it('returns null', () => {
         const result = SummaryPresenter(licence, summary)
 
-        expect(result.purposes).toEqual(null)
+        expect(result.purposes).toBeNull()
       })
     })
 
@@ -743,7 +743,7 @@ describe('Licences - Summary Presenter', () => {
         it('returns null', () => {
           const result = SummaryPresenter(licence, summary)
 
-          expect(result.purposes).toEqual(null)
+          expect(result.purposes).toBeNull()
         })
       })
 
@@ -802,7 +802,7 @@ describe('Licences - Summary Presenter', () => {
       it('returns null', () => {
         const result = SummaryPresenter(licence, summary)
 
-        expect(result.sourceOfSupply).toEqual(null)
+        expect(result.sourceOfSupply).toBeNull()
       })
     })
 
@@ -815,7 +815,7 @@ describe('Licences - Summary Presenter', () => {
         it('returns null', () => {
           const result = SummaryPresenter(licence, summary)
 
-          expect(result.sourceOfSupply).toEqual(null)
+          expect(result.sourceOfSupply).toBeNull()
         })
       })
 
@@ -828,7 +828,7 @@ describe('Licences - Summary Presenter', () => {
           it('returns null', () => {
             const result = SummaryPresenter(licence, summary)
 
-            expect(result.sourceOfSupply).toEqual(null)
+            expect(result.sourceOfSupply).toBeNull()
           })
         })
 

--- a/test/presenters/notices/base.presenter.test.js
+++ b/test/presenters/notices/base.presenter.test.js
@@ -26,7 +26,7 @@ describe('Notices - Base presenter', () => {
         it('returns a fixed array of 7 strings with all the address lines', () => {
           const result = BasePresenter.addressToCSV(address)
 
-          expect(result.length).toEqual(7)
+          expect(result).toHaveLength(7)
           expect(result).toEqual([
             'Returnsholder',
             '4',
@@ -49,7 +49,7 @@ describe('Notices - Base presenter', () => {
         it('returns a fixed array of 7 strings with some of the address lines, and missing strings at the end of the array', () => {
           const result = BasePresenter.addressToCSV(address)
 
-          expect(result.length).toEqual(7)
+          expect(result).toHaveLength(7)
           expect(result).toEqual(['Returnsholder', '4', 'Privet Drive', 'Little Whinging', 'WD25 7LR', '', ''])
         })
       })
@@ -70,7 +70,7 @@ describe('Notices - Base presenter', () => {
         it('returns a fixed array of 7 strings with the contact name as address line 1, and the "INVALID ADDRESS" message', () => {
           const result = BasePresenter.addressToCSV(address)
 
-          expect(result.length).toEqual(7)
+          expect(result).toHaveLength(7)
           expect(result).toEqual([
             'Returnsholder',
             'INVALID ADDRESS - Needs a valid postcode or country outside the UK',
@@ -92,7 +92,7 @@ describe('Notices - Base presenter', () => {
       it('returns a fixed array of 7 empty strings', () => {
         const result = BasePresenter.addressToCSV(address)
 
-        expect(result.length).toEqual(7)
+        expect(result).toHaveLength(7)
         expect(result).toEqual(['', '', '', '', '', '', ''])
       })
     })

--- a/test/presenters/notices/setup/abstraction-alert-notifications.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alert-notifications.presenter.test.js
@@ -721,7 +721,7 @@ describe('Notices - Setup - Abstraction Alert Notifications presenter', () => {
           it('correctly sets the default message ref', () => {
             const [result] = AbstractionAlertNotificationsPresenter(session, testRecipients, noticeId)
 
-            expect(result.templateId).toEqual(null)
+            expect(result.templateId).toBeNull()
           })
         })
       })

--- a/test/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.test.js
+++ b/test/presenters/notices/setup/abstraction-alerts/check-licence-matches.presenter.test.js
@@ -149,7 +149,7 @@ describe('Notices - Setup - Abstraction Alerts - Check Licence Matches presenter
           it('returns only the thresholds previously selected and not removed', () => {
             const result = CheckLicenceMatchesPresenter(session)
 
-            expect(result.restrictions.length).toEqual(2)
+            expect(result.restrictions).toHaveLength(2)
 
             expect(result.restrictions).toEqual([
               {

--- a/test/presenters/notices/setup/check.presenter.test.js
+++ b/test/presenters/notices/setup/check.presenter.test.js
@@ -422,7 +422,7 @@ describe('Notices - Setup - Check presenter', () => {
       it('returns all the recipients', () => {
         const result = CheckPresenter(recipients, page, session)
 
-        expect(result.recipients.length).toEqual(recipients.length)
+        expect(result.recipients).toHaveLength(recipients.length)
       })
     })
 
@@ -435,7 +435,7 @@ describe('Notices - Setup - Check presenter', () => {
         it('returns the first 25 recipients', () => {
           const result = CheckPresenter(recipients, page, session)
 
-          expect(result.recipients.length).toEqual(25)
+          expect(result.recipients).toHaveLength(25)
         })
       })
 
@@ -447,7 +447,7 @@ describe('Notices - Setup - Check presenter', () => {
         it('returns the remaining recipients', () => {
           const result = CheckPresenter(recipients, page, session)
 
-          expect(result.recipients.length).toEqual(1)
+          expect(result.recipients).toHaveLength(1)
         })
       })
     })

--- a/test/presenters/notices/setup/prepare-paper-return.presenter.test.js
+++ b/test/presenters/notices/setup/prepare-paper-return.presenter.test.js
@@ -291,7 +291,7 @@ describe('Notices - Setup - Prepare Paper Return presenter', () => {
           it('should return entries', () => {
             const result = PreparePaperReturnPresenter(notification)
 
-            expect(result.pageEntries.length).toEqual(1)
+            expect(result.pageEntries).toHaveLength(1)
             expect(result.pageEntries).toEqual([
               // Page
               [
@@ -337,8 +337,8 @@ describe('Notices - Setup - Prepare Paper Return presenter', () => {
           it('should return entries', () => {
             const result = PreparePaperReturnPresenter(notification)
 
-            expect(result.pageEntries.length).toEqual(2)
-            expect(result.pageEntries.length).toEqual(2)
+            expect(result.pageEntries).toHaveLength(2)
+            expect(result.pageEntries).toHaveLength(2)
             expect(result.pageEntries).toEqual([
               // Page 1
               [

--- a/test/presenters/return-logs/base-return-logs.presenter.test.js
+++ b/test/presenters/return-logs/base-return-logs.presenter.test.js
@@ -37,7 +37,7 @@ describe('Return Logs - Base Return Logs presenter', () => {
       it('returns null', () => {
         const result = BaseReturnLogsPresenter.formatMeterDetails(null)
 
-        expect(result).toEqual(null)
+        expect(result).toBeNull()
       })
     })
 
@@ -45,7 +45,7 @@ describe('Return Logs - Base Return Logs presenter', () => {
       it('returns null', () => {
         const result = BaseReturnLogsPresenter.formatMeterDetails({ ...testMeter, manufacturer: null })
 
-        expect(result).toEqual(null)
+        expect(result).toBeNull()
       })
     })
   })

--- a/test/presenters/return-submissions/view-return-submission.presenter.test.js
+++ b/test/presenters/return-submissions/view-return-submission.presenter.test.js
@@ -165,7 +165,7 @@ describe('View Return Submissions presenter', () => {
         it('includes the expected rows', () => {
           const result = ViewReturnSubmissionPresenter(testReturnSubmission, '2025-1')
 
-          expect(result.tableData.rows.length).toEqual(28)
+          expect(result.tableData.rows).toHaveLength(28)
           // We use include() as a row can also include a reading key which we don't care about for volumes
           expect(result.tableData.rows[0]).toMatchObject({
             cubicMetresQuantity: '1,000',
@@ -201,7 +201,7 @@ describe('View Return Submissions presenter', () => {
         it('includes the expected rows', () => {
           const result = ViewReturnSubmissionPresenter(testReturnSubmission, '2025-1')
 
-          expect(result.tableData.rows.length).toEqual(28)
+          expect(result.tableData.rows).toHaveLength(28)
           // We use include() as a row can also include a reading key which we don't care about for volumes
           expect(result.tableData.rows[0]).toMatchObject({
             cubicMetresQuantity: '1,000',
@@ -238,7 +238,7 @@ describe('View Return Submissions presenter', () => {
       it('includes the expected rows', () => {
         const result = ViewReturnSubmissionPresenter(testReturnSubmission, '2025-1')
 
-        expect(result.tableData.rows.length).toEqual(28)
+        expect(result.tableData.rows).toHaveLength(28)
         // We use include() as a row can also include a reading key which we don't care about for volumes
         expect(result.tableData.rows[0]).toMatchObject({
           reading: 1001,
@@ -290,7 +290,7 @@ describe('View Return Submissions presenter', () => {
       it('includes the expected rows', () => {
         const result = ViewReturnSubmissionPresenter(testReturnSubmission, '2025-1')
 
-        expect(result.tableData.rows.length).toEqual(28)
+        expect(result.tableData.rows).toHaveLength(28)
         expect(result.tableData.rows[0]).toMatchObject({ date: '1 February 2025' })
         expect(result.tableData.rows[27]).toMatchObject({ date: '28 February 2025' })
       })
@@ -316,7 +316,7 @@ describe('View Return Submissions presenter', () => {
       it('includes the expected rows that end within the month', () => {
         const result = ViewReturnSubmissionPresenter(testReturnSubmission, '2025-3')
 
-        expect(result.tableData.rows.length).toEqual(4)
+        expect(result.tableData.rows).toHaveLength(4)
         expect(result.tableData.rows[0]).toMatchObject({ date: '5 April 2025' })
         expect(result.tableData.rows).not.toContainEqual({ date: '3 May 2025' })
       })

--- a/test/services/bill-runs/annual/fetch-billing-accounts.service.test.js
+++ b/test/services/bill-runs/annual/fetch-billing-accounts.service.test.js
@@ -339,7 +339,7 @@ describe('Fetch Billing Accounts service', () => {
 
         const { chargeVersions } = billingAccountRecord
 
-        expect(chargeVersions.length).toEqual(1)
+        expect(chargeVersions).toHaveLength(1)
         expect(chargeVersions[0].id).toEqual(chargeVersion.id)
       })
     })

--- a/test/services/bill-runs/annual/process-billing-period.service.test.js
+++ b/test/services/bill-runs/annual/process-billing-period.service.test.js
@@ -103,7 +103,7 @@ describe('Annual Process billing period service', () => {
 
           const result = await BillModel.query().findOne('billRunId', billRun.id).withGraphFetched('billLicences')
 
-          expect(result.billLicences.length).toEqual(1)
+          expect(result.billLicences).toHaveLength(1)
           expect(result.billLicences[0].licenceId).toEqual(billingAccount.chargeVersions[0].licence.id)
         })
       })

--- a/test/services/bill-runs/fetch-bill-run.service.test.js
+++ b/test/services/bill-runs/fetch-bill-run.service.test.js
@@ -175,7 +175,7 @@ describe('Fetch Bill Run service', () => {
       const result = await FetchBillRunService('93112100-152b-4860-abea-2adee11dcd69')
 
       expect(result).toBeDefined()
-      expect(result.billRun).toEqual(undefined)
+      expect(result.billRun).toBeUndefined()
       expect(result.billSummaries).toEqual([])
     })
   })

--- a/test/services/bill-runs/fetch-bill-runs.service.test.js
+++ b/test/services/bill-runs/fetch-bill-runs.service.test.js
@@ -62,7 +62,7 @@ describe('Fetch Bill Runs service', () => {
         const { results, total } = await FetchBillRunsService(filters, page)
 
         expect(results).toHaveLength(3)
-        expect(total >= 5).toBe(true)
+        expect(total).toBeGreaterThanOrEqual(5)
       })
     })
 
@@ -74,8 +74,8 @@ describe('Fetch Bill Runs service', () => {
       it('returns a result with the matching "results" and the correct "total"', async () => {
         const { results, total } = await FetchBillRunsService(filters, page)
 
-        expect(results.length >= 2).toBe(true)
-        expect(total >= 5).toBe(true)
+        expect(results.length).toBeGreaterThanOrEqual(2)
+        expect(total).toBeGreaterThanOrEqual(5)
       })
     })
 
@@ -88,7 +88,7 @@ describe('Fetch Bill Runs service', () => {
         const { results, total } = await FetchBillRunsService(filters, page)
 
         expect(results).toHaveLength(0)
-        expect(total >= 5).toBe(true)
+        expect(total).toBeGreaterThanOrEqual(5)
       })
     })
 
@@ -133,7 +133,7 @@ describe('Fetch Bill Runs service', () => {
 
             // All returned results should match the filter
             expect(results[0].batchType).toEqual('supplementary')
-            expect(total >= 5).toBe(true)
+            expect(total).toBeGreaterThanOrEqual(5)
           })
         })
 
@@ -162,7 +162,7 @@ describe('Fetch Bill Runs service', () => {
 
             // All returned results should match the filter
             expect(results[0].region).toEqual(region.displayName)
-            expect(total >= 5).toBe(true)
+            expect(total).toBeGreaterThanOrEqual(5)
           })
         })
 
@@ -191,7 +191,7 @@ describe('Fetch Bill Runs service', () => {
 
             // All returned results should match the filter
             expect(results[0].status).toEqual('sent')
-            expect(total >= 5).toBe(true)
+            expect(total).toBeGreaterThanOrEqual(5)
           })
         })
 
@@ -220,7 +220,7 @@ describe('Fetch Bill Runs service', () => {
 
             // All returned results should match the filter
             expect(new Date(results[0].createdAt).getFullYear()).toEqual(filters.yearCreated)
-            expect(total >= 3).toBe(true)
+            expect(total).toBeGreaterThanOrEqual(3)
           })
         })
 

--- a/test/services/bill-runs/fetch-bill-runs.service.test.js
+++ b/test/services/bill-runs/fetch-bill-runs.service.test.js
@@ -61,7 +61,7 @@ describe('Fetch Bill Runs service', () => {
       it('returns a full page of 3 matching "results" and the correct "total"', async () => {
         const { results, total } = await FetchBillRunsService(filters, page)
 
-        expect(results.length).toEqual(3)
+        expect(results).toHaveLength(3)
         expect(total >= 5).toBe(true)
       })
     })

--- a/test/services/bill-runs/match/fetch-licences.service.test.js
+++ b/test/services/bill-runs/match/fetch-licences.service.test.js
@@ -62,7 +62,7 @@ describe('Bill Runs - Match - Fetch Licences service', () => {
         expect(result[0].chargeVersions).toHaveLength(1)
         expect(result[0].chargeVersions[0].id).toEqual('9407b74d-816c-44a2-9926-73a89a9da985')
         expect(result[0].chargeVersions[0].startDate).toEqual('2022-04-01T00:00:00.000Z')
-        expect(result[0].chargeVersions[0].endDate).toEqual(null)
+        expect(result[0].chargeVersions[0].endDate).toBeNull()
         expect(result[0].chargeVersions[0].status).toEqual('current')
         expect(result[0].chargeVersions[0].licence).toEqual(licenceOne)
       })

--- a/test/services/billing-accounts/change-address.service.test.js
+++ b/test/services/billing-accounts/change-address.service.test.js
@@ -99,7 +99,7 @@ describe('Change address service', () => {
 
             const result = await AddressModel.query().where('uprn', address.uprn)
 
-            expect(result.length).toEqual(1)
+            expect(result).toHaveLength(1)
             expect(result[0].address1).toEqual(address.addressLine1)
             expect(result[0].postcode).toEqual(address.postcode)
           })
@@ -124,7 +124,7 @@ describe('Change address service', () => {
 
           const result = await AddressModel.query().where('postcode', address.postcode)
 
-          expect(result.length).toEqual(1)
+          expect(result).toHaveLength(1)
           expect(result[0].address1).toEqual('2 Matrix Rd')
         })
 
@@ -208,7 +208,7 @@ describe('Change address service', () => {
 
           const result = await CompanyModel.query().where('companyNumber', agentCompany.companyNumber)
 
-          expect(result.length).toEqual(1)
+          expect(result).toHaveLength(1)
           expect(result[0].name).toEqual(agentCompany.name)
         })
 
@@ -267,7 +267,7 @@ describe('Change address service', () => {
 
           const result = await ContactModel.query().where('department', 'Humanoid Risk Assessment')
 
-          expect(result.length).toEqual(1)
+          expect(result).toHaveLength(1)
         })
 
         it('links the billing account address record to the new contact', async () => {
@@ -293,7 +293,7 @@ describe('Change address service', () => {
 
           const result = await ContactModel.query().where('lastName', 'Villa')
 
-          expect(result.length).toEqual(1)
+          expect(result).toHaveLength(1)
           expect(result[0].firstName).toEqual('Margarita')
           expect(result[0].lastName).toEqual('Villa')
         })

--- a/test/services/billing-accounts/setup/fetch-company.service.test.js
+++ b/test/services/billing-accounts/setup/fetch-company.service.test.js
@@ -59,7 +59,7 @@ describe('Billing Accounts - Setup - Fetch Company service', () => {
     it('returns an empty array', async () => {
       const result = await FetchCompanyService(companiesHouseNumber)
 
-      expect(result).toEqual(null)
+      expect(result).toBeNull()
     })
   })
 })

--- a/test/services/bills/fetch-bill.service.test.js
+++ b/test/services/bills/fetch-bill.service.test.js
@@ -102,7 +102,7 @@ describe('Fetch Bill service', () => {
       const result = await FetchBillService('93112100-152b-4860-abea-2adee11dcd69')
 
       expect(result).toBeDefined()
-      expect(result.bill).toEqual(undefined)
+      expect(result.bill).toBeUndefined()
       expect(result.licenceSummaries).toEqual([])
     })
   })

--- a/test/services/licence-monitoring-station/setup/submit-stop-or-reduce.service.test.js
+++ b/test/services/licence-monitoring-station/setup/submit-stop-or-reduce.service.test.js
@@ -40,7 +40,7 @@ describe('Licence Monitoring Station Setup - Stop Or Reduce service', () => {
         await SubmitStopOrReduceService(session.id, payload)
 
         expect(session.stopOrReduce).toEqual('stop')
-        expect(session.reduceAtThreshold).toEqual(null)
+        expect(session.reduceAtThreshold).toBeNull()
         expect(session.$update).toHaveBeenCalled()
       })
 

--- a/test/services/licences/end-dates/check-licence-end-dates.service.test.js
+++ b/test/services/licences/end-dates/check-licence-end-dates.service.test.js
@@ -49,7 +49,7 @@ describe('Licences - End Dates - Check Licence End Dates service', () => {
 
       const licenceEndDateChanges = await LicenceEndDateChangeModel.query().where('licenceId', licence.id)
 
-      expect(licenceEndDateChanges.length).toEqual(0)
+      expect(licenceEndDateChanges).toHaveLength(0)
     })
   })
 
@@ -64,7 +64,7 @@ describe('Licences - End Dates - Check Licence End Dates service', () => {
 
       const licenceEndDateChanges = await LicenceEndDateChangeModel.query().where('licenceId', licence.id)
 
-      expect(licenceEndDateChanges.length).toEqual(1)
+      expect(licenceEndDateChanges).toHaveLength(1)
     })
   })
 

--- a/test/services/licences/end-dates/determine-earliest-licence-changed-date.service.test.js
+++ b/test/services/licences/end-dates/determine-earliest-licence-changed-date.service.test.js
@@ -29,7 +29,7 @@ describe('Licences - End Dates - Determine Earliest Licence Changed Date service
     it('returns null', async () => {
       const result = await DetermineEarliestLicenceChangedDateService(licence)
 
-      expect(result).toEqual(null)
+      expect(result).toBeNull()
     })
   })
 

--- a/test/services/licences/supplementary/create-licence-supplementary-year.service.test.js
+++ b/test/services/licences/supplementary/create-licence-supplementary-year.service.test.js
@@ -72,7 +72,7 @@ describe('Create Licence Supplementary Years Service', () => {
 
           expect(result).toHaveLength(2)
           expect(result[0].billRunId).toEqual(billRunId)
-          expect(result[1].billRunId).toEqual(null)
+          expect(result[1].billRunId).toBeNull()
         })
       })
     })

--- a/test/services/licences/supplementary/determine-imported-licence-flags.service.test.js
+++ b/test/services/licences/supplementary/determine-imported-licence-flags.service.test.js
@@ -42,7 +42,7 @@ describe('Licences - Supplementary - Determine Imported Licence Flags service', 
 
               expect(result.licenceId).toEqual('aad74a3d-59ea-4c18-8091-02b0f8b0a147')
               expect(result.regionId).toEqual('ff92e0b1-3934-430b-8b16-5b89a3ea258f')
-              expect(result.startDate).toEqual(null)
+              expect(result.startDate).toBeNull()
               expect(result.endDate).toEqual(new Date('2025-03-31'))
             })
 
@@ -65,7 +65,7 @@ describe('Licences - Supplementary - Determine Imported Licence Flags service', 
 
               expect(result.licenceId).toEqual('aad74a3d-59ea-4c18-8091-02b0f8b0a147')
               expect(result.regionId).toEqual('ff92e0b1-3934-430b-8b16-5b89a3ea258f')
-              expect(result.startDate).toEqual(null)
+              expect(result.startDate).toBeNull()
               expect(result.endDate).toEqual(new Date('2025-03-31'))
             })
 

--- a/test/services/licences/supplementary/fetch-charge-version-billing-data.service.test.js
+++ b/test/services/licences/supplementary/fetch-charge-version-billing-data.service.test.js
@@ -161,7 +161,7 @@ describe('Licences - Supplementary - Fetch Charge Version Billing Data service',
         it('fetches only the sroc bill runs', async () => {
           const result = await FetchChargeVersionBillingDataService(srocChargeVersion.id)
 
-          expect(result.srocBillRuns.length).toEqual(2)
+          expect(result.srocBillRuns).toHaveLength(2)
           expect(result.srocBillRuns[0].scheme).toEqual('sroc')
           expect(result.srocBillRuns[1].scheme).toEqual('sroc')
         })
@@ -184,7 +184,7 @@ describe('Licences - Supplementary - Fetch Charge Version Billing Data service',
         it('fetches only the bill runs that have a financial year end >= to the charge version start date', async () => {
           const result = await FetchChargeVersionBillingDataService(srocChargeVersion.id)
 
-          expect(result.srocBillRuns.length).toEqual(2)
+          expect(result.srocBillRuns).toHaveLength(2)
           expect(result.srocBillRuns[0].toFinancialYearEnding).toEqual(2024)
           expect(result.srocBillRuns[1].toFinancialYearEnding).toEqual(2025)
         })
@@ -231,7 +231,7 @@ describe('Licences - Supplementary - Fetch Charge Version Billing Data service',
         it('only fetches bills run with a status of sent, ready or review', async () => {
           const result = await FetchChargeVersionBillingDataService(srocChargeVersion.id)
 
-          expect(result.srocBillRuns.length).toEqual(3)
+          expect(result.srocBillRuns).toHaveLength(3)
           expect(result.srocBillRuns[0].toFinancialYearEnding).toEqual(2024)
           expect(result.srocBillRuns[1].toFinancialYearEnding).toEqual(2025)
           expect(result.srocBillRuns[1].toFinancialYearEnding).toEqual(2025)

--- a/test/services/licences/supplementary/fetch-existing-licence-details.service.test.js
+++ b/test/services/licences/supplementary/fetch-existing-licence-details.service.test.js
@@ -69,9 +69,9 @@ describe('Fetch Existing Licence Details Service', () => {
 
         expect(result.id).toEqual(licence.id)
         expect(result.region_id).toEqual(licence.regionId)
-        expect(result.revoked_date).toEqual(null)
-        expect(result.lapsed_date).toEqual(null)
-        expect(result.expired_date).toEqual(null)
+        expect(result.revoked_date).toBeNull()
+        expect(result.lapsed_date).toBeNull()
+        expect(result.expired_date).toBeNull()
         expect(result.flagged_for_presroc).toEqual(false)
         expect(result.flagged_for_sroc).toEqual(false)
       })

--- a/test/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/determine-licence-monitoring-stations.service.test.js
@@ -224,7 +224,7 @@ describe('Notices Setup - Abstraction Alerts - Determine Licence Monitoring Stat
         it('returns null', async () => {
           const result = await DetermineLicenceMonitoringStationsService(monitoringStationId)
 
-          expect(result.licenceMonitoringStations[0].notes).toEqual(null)
+          expect(result.licenceMonitoringStations[0].notes).toBeNull()
         })
       })
 

--- a/test/services/notices/setup/abstraction-alerts/determine-relevant-licence-monitoring-stations.service.test.js
+++ b/test/services/notices/setup/abstraction-alerts/determine-relevant-licence-monitoring-stations.service.test.js
@@ -76,7 +76,7 @@ describe('Notices Setup - Abstraction Alerts - Determine relevant licence monito
         alertType
       )
 
-      expect(result.length).toEqual(2)
+      expect(result).toHaveLength(2)
 
       expect(result).toEqual([licenceMonitoringStationTwo, licenceMonitoringStationThree])
     })

--- a/test/services/notices/setup/returns-notice/generate-recipients-query.service.test.js
+++ b/test/services/notices/setup/returns-notice/generate-recipients-query.service.test.js
@@ -477,7 +477,7 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
           // NOTE: Because sorting is done in the code not the query, there is no 'order by' to improve performance.
           // That means we cannot assert the order that the records come out. But we can assert the number of records,
           // and that all we expect are present
-          expect(rows.length).toEqual(10)
+          expect(rows).toHaveLength(10)
         })
 
         it('(Scenario 1) returns the licence holder when only the licence holder is present', async () => {
@@ -611,7 +611,7 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
           // NOTE: Because sorting is done in the code not the query, there is no 'order by' to improve performance.
           // That means we cannot assert the order that the records come out. But we can assert the number of records,
           // and that all we expect are present
-          expect(rows.length).toEqual(13)
+          expect(rows).toHaveLength(13)
         })
 
         it('(Scenario 1) returns the licence holder when only the licence holder is present', async () => {
@@ -766,7 +766,7 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
           // NOTE: Because sorting is done in the code not the query, there is no 'order by' to improve performance.
           // That means we cannot assert the order that the records come out. But we can assert the number of records,
           // and that all we expect are present
-          expect(rows.length).toEqual(9)
+          expect(rows).toHaveLength(9)
         })
 
         it('(Scenario 1) returns the licence holder when only the licence holder is present', async () => {
@@ -899,7 +899,7 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
           // NOTE: Because sorting is done in the code not the query, there is no 'order by' to improve performance.
           // That means we cannot assert the order that the records come out. But we can assert the number of records,
           // and that all we expect are present
-          expect(rows.length).toEqual(12)
+          expect(rows).toHaveLength(12)
         })
 
         it('(Scenario 1) returns the licence holder when only the licence holder is present', async () => {
@@ -1049,7 +1049,7 @@ describe('Notices - Setup - Returns Notice - Generate Recipients Query service',
         // NOTE: Because sorting is done in the code not the query, there is no 'order by' to improve performance.
         // That means we cannot assert the order that the records come out. But we can assert the number of records,
         // and that all we expect are present
-        expect(rows.length).toEqual(8)
+        expect(rows).toHaveLength(8)
       })
 
       it('(Scenario 1) returns the licence holder when only the licence holder is present', async () => {

--- a/test/services/notices/setup/submit-contact-type.service.test.js
+++ b/test/services/notices/setup/submit-contact-type.service.test.js
@@ -55,7 +55,7 @@ describe('Notices - Setup - Submit Contact Type service', () => {
       it('saves the submitted value', async () => {
         await SubmitContactTypeService(session.id, payload, yarStub)
 
-        expect(session.contactType).toEqual(undefined)
+        expect(session.contactType).toBeUndefined()
         expect(session.additionalRecipients).toEqual([
           {
             contact: null,
@@ -105,7 +105,7 @@ describe('Notices - Setup - Submit Contact Type service', () => {
       it('saves the submitted value', async () => {
         await SubmitContactTypeService(session.id, payload, yarStub)
 
-        expect(session.contactType).toEqual(undefined)
+        expect(session.contactType).toBeUndefined()
         expect(session.additionalRecipients).toEqual([
           {
             contact: null,
@@ -148,7 +148,7 @@ describe('Notices - Setup - Submit Contact Type service', () => {
       it('saves the submitted value with the email address in lowercase', async () => {
         await SubmitContactTypeService(session.id, payload, yarStub)
 
-        expect(session.contactType).toEqual(undefined)
+        expect(session.contactType).toBeUndefined()
         expect(session.additionalRecipients).toEqual([
           {
             contact: null,
@@ -203,7 +203,7 @@ describe('Notices - Setup - Submit Contact Type service', () => {
       it('saves the submitted value', async () => {
         await SubmitContactTypeService(session.id, payload, yarStub)
 
-        expect(session.contactType).toEqual(undefined)
+        expect(session.contactType).toBeUndefined()
         expect(session.additionalRecipients).toEqual([
           {
             contact: null,

--- a/test/services/return-versions/setup/add.service.test.js
+++ b/test/services/return-versions/setup/add.service.test.js
@@ -44,7 +44,7 @@ describe('Return Versions Setup - Add service', () => {
     it('adds another empty object to the requirement array in the current setup session record', async () => {
       await AddService(session.id)
 
-      expect(session.requirements.length).toEqual(2)
+      expect(session.requirements).toHaveLength(2)
       expect(session.requirements).toEqual([{}, {}])
       expect(session.$update).toHaveBeenCalled()
     })

--- a/test/validators/abstraction-period.validator.test.js
+++ b/test/validators/abstraction-period.validator.test.js
@@ -64,7 +64,7 @@ describe('Abstraction Period validator', () => {
         expect(result.value.abstractionPeriodStart).toBeDefined()
         expect(result.value.abstractionPeriodEnd).toBeDefined()
         expect(result.error.details[0].message).toEqual('Enter a real start date')
-        expect(result.error.details.length).toEqual(1)
+        expect(result.error.details).toHaveLength(1)
       })
     })
 
@@ -84,7 +84,7 @@ describe('Abstraction Period validator', () => {
         expect(result.value.abstractionPeriodStart).toBeDefined()
         expect(result.value.abstractionPeriodEnd).toBeDefined()
         expect(result.error.details[0].message).toEqual('Enter a real end date')
-        expect(result.error.details.length).toEqual(1)
+        expect(result.error.details).toHaveLength(1)
       })
     })
 
@@ -105,7 +105,7 @@ describe('Abstraction Period validator', () => {
         expect(result.value.abstractionPeriodEnd).toBeNull()
         expect(result.error.details[0].message).toEqual('Enter a real start date')
         expect(result.error.details[1].message).toEqual('Select the end date of the abstraction period')
-        expect(result.error.details.length).toEqual(2)
+        expect(result.error.details).toHaveLength(2)
       })
     })
 
@@ -126,7 +126,7 @@ describe('Abstraction Period validator', () => {
         expect(result.value.abstractionPeriodEnd).toBeDefined()
         expect(result.error.details[0].message).toEqual('Select the start date of the abstraction period')
         expect(result.error.details[1].message).toEqual('Enter a real end date')
-        expect(result.error.details.length).toEqual(2)
+        expect(result.error.details).toHaveLength(2)
       })
     })
 
@@ -147,7 +147,7 @@ describe('Abstraction Period validator', () => {
         expect(result.value.abstractionPeriodEnd).toBeDefined()
         expect(result.error.details[0].message).toEqual('Enter a real start date')
         expect(result.error.details[1].message).toEqual('Enter a real end date')
-        expect(result.error.details.length).toEqual(2)
+        expect(result.error.details).toHaveLength(2)
       })
     })
   })
@@ -168,7 +168,7 @@ describe('Abstraction Period validator', () => {
       expect(result.value.abstractionPeriodStart).toBeDefined()
       expect(result.value.abstractionPeriodEnd).toBeNull()
       expect(result.error.details[0].message).toEqual('Select the end date of the abstraction period')
-      expect(result.error.details.length).toEqual(1)
+      expect(result.error.details).toHaveLength(1)
     })
   })
 
@@ -188,7 +188,7 @@ describe('Abstraction Period validator', () => {
       expect(result.value.abstractionPeriodStart).toBeNull()
       expect(result.value.abstractionPeriodEnd).toBeDefined()
       expect(result.error.details[0].message).toEqual('Select the start date of the abstraction period')
-      expect(result.error.details.length).toEqual(1)
+      expect(result.error.details).toHaveLength(1)
     })
   })
 
@@ -204,7 +204,7 @@ describe('Abstraction Period validator', () => {
       expect(result.value.abstractionPeriodEnd).toBeNull()
       expect(result.error.details[0].message).toEqual('Select the start date of the abstraction period')
       expect(result.error.details[1].message).toEqual('Select the end date of the abstraction period')
-      expect(result.error.details.length).toEqual(2)
+      expect(result.error.details).toHaveLength(2)
     })
   })
 })


### PR DESCRIPTION
## Summary

- Replace `toEqual(null)` / `toEqual(undefined)` with `toBeNull()` / `toBeUndefined()`
- Replace `expect(x.length).toEqual(n)` with `expect(x).toHaveLength(n)`
- Resolves related Sonar code smell findings