### PR TITLE
Un-skip the compress-schema-folder test

### DIFF
--- a/app/lib/tar-wrapper.lib.js
+++ b/app/lib/tar-wrapper.lib.js
@@ -1,18 +1,18 @@
 /**
- * Wraps the `tar` package so its `create()` function can be stubbed in tests
+ * Wraps `tar.create()` so it can be stubbed in tests
+ *
+ * `tar` is a genuine ES module, so its exports are non-configurable and cannot be stubbed directly with
+ * `vi.spyOn()`. This first-party wrapper gives tests something stubbable to spy on instead.
  * @module TarWrapperLib
  */
 
 import * as tar from 'tar'
 
 /**
- * Wraps `tar.create()`
+ * Creates a tarball, passing its arguments straight through to `tar.create()`
  *
- * `tar` is a genuine ES module, so its exports are non-configurable and cannot be stubbed directly with
- * `vi.spyOn()`. This first-party wrapper gives tests something stubbable to spy on instead.
- *
- * @param {object} options - Options passed straight through to `tar.create()`
- * @param {string[]} fileList - The list of files/folders passed straight through to `tar.create()`
+ * @param {object} options
+ * @param {string[]} fileList
  *
  * @returns {Promise<void>}
  */

--- a/app/lib/tar-wrapper.lib.js
+++ b/app/lib/tar-wrapper.lib.js
@@ -1,0 +1,21 @@
+/**
+ * Wraps the `tar` package so its `create()` function can be stubbed in tests
+ * @module TarWrapperLib
+ */
+
+import * as tar from 'tar'
+
+/**
+ * Wraps `tar.create()`
+ *
+ * `tar` is a genuine ES module, so its exports are non-configurable and cannot be stubbed directly with
+ * `vi.spyOn()`. This first-party wrapper gives tests something stubbable to spy on instead.
+ *
+ * @param {object} options - Options passed straight through to `tar.create()`
+ * @param {string[]} fileList - The list of files/folders passed straight through to `tar.create()`
+ *
+ * @returns {Promise<void>}
+ */
+export async function tarCreate(options, fileList) {
+  return tar.create(options, fileList)
+}

--- a/app/services/jobs/export/compress-schema-folder.service.js
+++ b/app/services/jobs/export/compress-schema-folder.service.js
@@ -3,7 +3,7 @@
  * @module CompressSchemaFolderService
  */
 
-import * as tar from 'tar'
+import { tarCreate } from '../../../lib/tar-wrapper.lib.js'
 
 /**
  * Create a compressed tarball (.tgz) from a given schema folder
@@ -15,7 +15,7 @@ import * as tar from 'tar'
 export default async function compressSchemaFolderService(schemaFolderPath) {
   const file = `${schemaFolderPath}.tgz`
 
-  await tar.create(
+  await tarCreate(
     {
       gzip: true,
       file

--- a/test/plugins/airbrake.plugin.test.js
+++ b/test/plugins/airbrake.plugin.test.js
@@ -2,7 +2,6 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Things we need to stub
-import AirbrakeModule from '@airbrake/node'
 import serverConfig from '../../config/server.config.js'
 
 // For running our service
@@ -55,52 +54,59 @@ describe('Airbrake plugin', () => {
     })
   })
 
-  // airbrake.plugin.js holds a module-level _notifier singleton, and the beforeAll above spins up a real Hapi server
-  // that sets it via the real plugin module. These tests need a completely fresh module instance (where _notifier is
-  // undefined) with Notifier and gotWrapper stubbed out, so we reset the module registry and dynamically re-import
-  // the plugin (plus its first-party dependencies, which resetModules() also disconnects from the copies imported
-  // above) per test. Notifier is stubbed via a default import of '@airbrake/node' (see
-  // test/lib/base-notifier.lib.test.js for the same pattern) rather than a namespace import, because named exports
-  // of a real ES module are non-configurable and can't be redefined by vi.spyOn().
-  describe('when registering the plugin', () => {
+  // TODO: airbrake.plugin.js holds a module-level _notifier singleton. The beforeAll above spins up a real Hapi
+  // server that sets it via the real plugin module, so these tests need a completely fresh module instance (where
+  // _notifier is undefined) with Notifier and gotWrapper stubbed out. Proxyquire provided that isolation in CJS
+  // mode, but it's a CJS-only tool and no longer works now the project is ESM.
+  //
+  // vi.resetModules() + dynamic import() looks like the obvious ESM replacement, and Notifier can be stubbed via a
+  // default import of '@airbrake/node' (see test/lib/base-notifier.lib.test.js) — but don't reach for
+  // vi.resetModules() here. This project's vitest.config.js runs the 'parallel' project with `isolate: false` (a
+  // single shared module registry across test files, for performance). Resetting the registry in one test file
+  // doesn't just create a locally-fresh copy — it invalidates the *shared* cache entry for
+  // 'app/plugins/airbrake.plugin.js', so the next test FILE anywhere in the run that imports this plugin for the
+  // first time gets re-pointed at whatever instance this test last created, singleton state and all. This was tried
+  // and confirmed to break unrelated controller tests elsewhere in the suite (their `server.app.airbrake.notify`
+  // came back undefined, because the shared _notifier had been left pointing at this test's stub).
+  //
+  // A safer route if this gets picked up again: export the plugin's private `_notifierArgs()` helper and test it
+  // directly — it contains all the gotWrapper/proxy logic these tests care about, without needing to go through
+  // register() or touch the _notifier singleton at all. We do not use vi.mock()/vi.doMock() here — see the testing
+  // skill's Mocking section for why.
+  describe.skip('when registering the plugin', () => {
     let AirbrakePluginWithStubs
     let fakeServer
-    let freshServerConfig
-    let freshGotWrapperLib
+    let gotWrapperStub
+    let NotifierStub
 
-    beforeEach(async () => {
-      vi.spyOn(AirbrakeModule, 'Notifier').mockImplementation(
-        class {
-          constructor(opts) {
-            this.request = opts.request
-          }
-        }
-      )
+    beforeEach(() => {
+      gotWrapperStub = vi.fn().mockResolvedValue('fake-request-fn')
+      NotifierStub = vi.fn()
+
+      // TODO: Replace with vi.spyOn() + dynamic import() once the project migrates to ESM
+      // AirbrakePluginWithStubs = Proxyquire('../../app/plugins/airbrake.plugin.js', {
+      //   '../lib/got-wrapper.lib.js': { gotWrapper: gotWrapperStub },
+      //   '@airbrake/node': { Notifier: NotifierStub },
+      //   '../../config/server.config.js': serverConfig
+      // })
 
       fakeServer = {
         app: {},
         events: { on: vi.fn() },
         logger: { error: vi.fn() }
       }
-
-      vi.resetModules()
-      ;({ default: AirbrakePluginWithStubs } = await import('../../app/plugins/airbrake.plugin.js'))
-      ;({ default: freshServerConfig } = await import('../../config/server.config.js'))
-      freshGotWrapperLib = await import('../../app/lib/got-wrapper.lib.js')
-
-      vi.spyOn(freshGotWrapperLib, 'gotWrapper').mockResolvedValue('fake-request-fn')
     })
 
     describe('and httpProxy is set', () => {
       beforeEach(() => {
-        freshServerConfig.httpProxy = 'http://proxy.local:8080'
+        serverConfig.httpProxy = 'http://proxy.local:8080'
       })
 
       it('calls gotWrapper to create a Request function', async () => {
         await AirbrakePluginWithStubs.register(fakeServer)
 
-        expect(freshGotWrapperLib.gotWrapper).toHaveBeenCalledOnce()
-        expect(freshGotWrapperLib.gotWrapper.mock.calls[0][0]).toEqual({
+        expect(gotWrapperStub).toHaveBeenCalledOnce()
+        expect(gotWrapperStub.mock.calls[0][0]).toEqual({
           proxy: 'http://proxy.local:8080'
         })
       })
@@ -108,28 +114,28 @@ describe('Airbrake plugin', () => {
       it('passes the Request function to Notifier', async () => {
         await AirbrakePluginWithStubs.register(fakeServer)
 
-        expect(AirbrakeModule.Notifier).toHaveBeenCalledOnce()
-        const args = AirbrakeModule.Notifier.mock.calls[0][0]
+        expect(NotifierStub).toHaveBeenCalledOnce()
+        const args = NotifierStub.mock.calls[0][0]
         expect(args.request).toEqual('fake-request-fn')
       })
     })
 
     describe('and httpProxy is not set', () => {
       beforeEach(() => {
-        freshServerConfig.httpProxy = null
+        serverConfig.httpProxy = null
       })
 
       it('does not call gotWrapper', async () => {
         await AirbrakePluginWithStubs.register(fakeServer)
 
-        expect(freshGotWrapperLib.gotWrapper).not.toHaveBeenCalled()
+        expect(gotWrapperStub).not.toHaveBeenCalled()
       })
 
       it('does not pass a request function to Notifier', async () => {
         await AirbrakePluginWithStubs.register(fakeServer)
 
-        expect(AirbrakeModule.Notifier).toHaveBeenCalledOnce()
-        const args = AirbrakeModule.Notifier.mock.calls[0][0]
+        expect(NotifierStub).toHaveBeenCalledOnce()
+        const args = NotifierStub.mock.calls[0][0]
         expect(args.request).toBeUndefined()
       })
     })

--- a/test/plugins/airbrake.plugin.test.js
+++ b/test/plugins/airbrake.plugin.test.js
@@ -2,6 +2,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Things we need to stub
+import AirbrakeModule from '@airbrake/node'
 import serverConfig from '../../config/server.config.js'
 
 // For running our service
@@ -54,47 +55,52 @@ describe('Airbrake plugin', () => {
     })
   })
 
-  // TODO: Remove describe.skip once the project migrates to ESM. In CJS mode, airbrake.plugin.js holds a module-level
-  // _notifier singleton. The beforeAll above spins up a real Hapi server that sets it via the real plugin module.
-  // These tests need a completely fresh module instance (where _notifier is undefined) with Notifier and gotWrapper
-  // stubbed out. Proxyquire provides that isolation today. We do not use vi.mock() here or once the project is ESM
-  // — see the testing skill's Mocking section for why. Instead, once ESM, use vi.resetModules() + dynamic import()
-  // to load a fresh plugin instance per test, then vi.spyOn() the namespace imports of '@airbrake/node' and
-  // '../lib/got-wrapper.lib.js' to stub their exports.
-  describe.skip('when registering the plugin', () => {
+  // airbrake.plugin.js holds a module-level _notifier singleton, and the beforeAll above spins up a real Hapi server
+  // that sets it via the real plugin module. These tests need a completely fresh module instance (where _notifier is
+  // undefined) with Notifier and gotWrapper stubbed out, so we reset the module registry and dynamically re-import
+  // the plugin (plus its first-party dependencies, which resetModules() also disconnects from the copies imported
+  // above) per test. Notifier is stubbed via a default import of '@airbrake/node' (see
+  // test/lib/base-notifier.lib.test.js for the same pattern) rather than a namespace import, because named exports
+  // of a real ES module are non-configurable and can't be redefined by vi.spyOn().
+  describe('when registering the plugin', () => {
     let AirbrakePluginWithStubs
     let fakeServer
-    let gotWrapperStub
-    let NotifierStub
+    let freshServerConfig
+    let freshGotWrapperLib
 
-    beforeEach(() => {
-      gotWrapperStub = vi.fn().mockResolvedValue('fake-request-fn')
-      NotifierStub = vi.fn()
-
-      // TODO: Replace with vi.spyOn() + dynamic import() once the project migrates to ESM
-      // AirbrakePluginWithStubs = Proxyquire('../../app/plugins/airbrake.plugin.js', {
-      //   '../lib/got-wrapper.lib.js': { gotWrapper: gotWrapperStub },
-      //   '@airbrake/node': { Notifier: NotifierStub },
-      //   '../../config/server.config.js': serverConfig
-      // })
+    beforeEach(async () => {
+      vi.spyOn(AirbrakeModule, 'Notifier').mockImplementation(
+        class {
+          constructor(opts) {
+            this.request = opts.request
+          }
+        }
+      )
 
       fakeServer = {
         app: {},
         events: { on: vi.fn() },
         logger: { error: vi.fn() }
       }
+
+      vi.resetModules()
+      ;({ default: AirbrakePluginWithStubs } = await import('../../app/plugins/airbrake.plugin.js'))
+      ;({ default: freshServerConfig } = await import('../../config/server.config.js'))
+      freshGotWrapperLib = await import('../../app/lib/got-wrapper.lib.js')
+
+      vi.spyOn(freshGotWrapperLib, 'gotWrapper').mockResolvedValue('fake-request-fn')
     })
 
     describe('and httpProxy is set', () => {
       beforeEach(() => {
-        serverConfig.httpProxy = 'http://proxy.local:8080'
+        freshServerConfig.httpProxy = 'http://proxy.local:8080'
       })
 
       it('calls gotWrapper to create a Request function', async () => {
         await AirbrakePluginWithStubs.register(fakeServer)
 
-        expect(gotWrapperStub).toHaveBeenCalledOnce()
-        expect(gotWrapperStub.mock.calls[0][0]).toEqual({
+        expect(freshGotWrapperLib.gotWrapper).toHaveBeenCalledOnce()
+        expect(freshGotWrapperLib.gotWrapper.mock.calls[0][0]).toEqual({
           proxy: 'http://proxy.local:8080'
         })
       })
@@ -102,28 +108,28 @@ describe('Airbrake plugin', () => {
       it('passes the Request function to Notifier', async () => {
         await AirbrakePluginWithStubs.register(fakeServer)
 
-        expect(NotifierStub).toHaveBeenCalledOnce()
-        const args = NotifierStub.mock.calls[0][0]
+        expect(AirbrakeModule.Notifier).toHaveBeenCalledOnce()
+        const args = AirbrakeModule.Notifier.mock.calls[0][0]
         expect(args.request).toEqual('fake-request-fn')
       })
     })
 
     describe('and httpProxy is not set', () => {
       beforeEach(() => {
-        serverConfig.httpProxy = null
+        freshServerConfig.httpProxy = null
       })
 
       it('does not call gotWrapper', async () => {
         await AirbrakePluginWithStubs.register(fakeServer)
 
-        expect(gotWrapperStub).not.toHaveBeenCalled()
+        expect(freshGotWrapperLib.gotWrapper).not.toHaveBeenCalled()
       })
 
       it('does not pass a request function to Notifier', async () => {
         await AirbrakePluginWithStubs.register(fakeServer)
 
-        expect(NotifierStub).toHaveBeenCalledOnce()
-        const args = NotifierStub.mock.calls[0][0]
+        expect(AirbrakeModule.Notifier).toHaveBeenCalledOnce()
+        const args = AirbrakeModule.Notifier.mock.calls[0][0]
         expect(args.request).toBeUndefined()
       })
     })

--- a/test/plugins/airbrake.plugin.test.js
+++ b/test/plugins/airbrake.plugin.test.js
@@ -54,25 +54,13 @@ describe('Airbrake plugin', () => {
     })
   })
 
-  // TODO: airbrake.plugin.js holds a module-level _notifier singleton. The beforeAll above spins up a real Hapi
-  // server that sets it via the real plugin module, so these tests need a completely fresh module instance (where
-  // _notifier is undefined) with Notifier and gotWrapper stubbed out. Proxyquire provided that isolation in CJS
-  // mode, but it's a CJS-only tool and no longer works now the project is ESM.
-  //
-  // vi.resetModules() + dynamic import() looks like the obvious ESM replacement, and Notifier can be stubbed via a
-  // default import of '@airbrake/node' (see test/lib/base-notifier.lib.test.js) — but don't reach for
-  // vi.resetModules() here. This project's vitest.config.js runs the 'parallel' project with `isolate: false` (a
-  // single shared module registry across test files, for performance). Resetting the registry in one test file
-  // doesn't just create a locally-fresh copy — it invalidates the *shared* cache entry for
-  // 'app/plugins/airbrake.plugin.js', so the next test FILE anywhere in the run that imports this plugin for the
-  // first time gets re-pointed at whatever instance this test last created, singleton state and all. This was tried
-  // and confirmed to break unrelated controller tests elsewhere in the suite (their `server.app.airbrake.notify`
-  // came back undefined, because the shared _notifier had been left pointing at this test's stub).
-  //
-  // A safer route if this gets picked up again: export the plugin's private `_notifierArgs()` helper and test it
-  // directly — it contains all the gotWrapper/proxy logic these tests care about, without needing to go through
-  // register() or touch the _notifier singleton at all. We do not use vi.mock()/vi.doMock() here — see the testing
-  // skill's Mocking section for why.
+  // TODO: Remove describe.skip once the project migrates to ESM. In CJS mode, airbrake.plugin.js holds a module-level
+  // _notifier singleton. The beforeAll above spins up a real Hapi server that sets it via the real plugin module.
+  // These tests need a completely fresh module instance (where _notifier is undefined) with Notifier and gotWrapper
+  // stubbed out. Proxyquire provides that isolation today. We do not use vi.mock() here or once the project is ESM
+  // — see the testing skill's Mocking section for why. Instead, once ESM, use vi.resetModules() + dynamic import()
+  // to load a fresh plugin instance per test, then vi.spyOn() the namespace imports of '@airbrake/node' and
+  // '../lib/got-wrapper.lib.js' to stub their exports.
   describe.skip('when registering the plugin', () => {
     let AirbrakePluginWithStubs
     let fakeServer

--- a/test/services/jobs/export/compress-schema-folder.service.test.js
+++ b/test/services/jobs/export/compress-schema-folder.service.test.js
@@ -1,31 +1,19 @@
 // Test framework
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-// Things we need to stub (dynamically required in beforeEach to support mocking)
-let tar
+// Things we need to stub
+import * as TarWrapperLib from '../../../../app/lib/tar-wrapper.lib.js'
 
-// Thing under test (dynamically required in beforeEach to support mocking)
-let CompressSchemaFolderService
+// Thing under test
+import CompressSchemaFolderService from '../../../../app/services/jobs/export/compress-schema-folder.service.js'
 
-// TODO: Remove describe.skip once the project migrates to ESM. In CJS mode, Node.js v22's require(esm)
-// compatibility layer runs before Vitest's module interceptor so vi.doMock('tar') cannot replace the ESM
-// package's live bindings. We do not use vi.mock() / vi.doMock() here or once the project is ESM — see the
-// testing skill's Mocking section for why. Once test files are ESM, replace this dynamic require with a static
-// `import * as Tar from 'tar'` and stub its export with `vi.spyOn(Tar, 'create')`.
-describe.skip('Jobs - Export - Compress Schema Folder service', () => {
+describe('Jobs - Export - Compress Schema Folder service', () => {
   beforeEach(() => {
-    vi.doMock('tar', () => {
-      return { create: vi.fn().mockResolvedValue(undefined) }
-    })
-    vi.resetModules()
-
-    tar = require('tar')
-    CompressSchemaFolderService = require('../../../../app/services/jobs/export/compress-schema-folder.service.js')
+    vi.spyOn(TarWrapperLib, 'tarCreate').mockResolvedValue(undefined)
   })
 
   afterEach(() => {
-    vi.resetAllMocks()
-    vi.resetModules()
+    vi.restoreAllMocks()
   })
 
   it('creates a compressed tarball from the given schema folder', async () => {
@@ -34,7 +22,7 @@ describe.skip('Jobs - Export - Compress Schema Folder service', () => {
 
     const result = await CompressSchemaFolderService(schemaFolderPath)
 
-    expect(tar.create).toHaveBeenCalledOnce()
+    expect(TarWrapperLib.tarCreate).toHaveBeenCalledOnce()
     expect(result).toEqual(expectedTarballPath)
   })
 })


### PR DESCRIPTION
## Summary

`test/services/jobs/export/compress-schema-folder.service.test.js` was left as `describe.skip` with a TODO assuming that once the project moved to ESM, `vi.spyOn()` would be able to stub `tar.create()` directly. That assumption turned out to be wrong: `tar` is a genuine ES module, so its exports are non-configurable — `vi.spyOn()` cannot redefine them under any import style (`Cannot redefine property: create`).

Added `app/lib/tar-wrapper.lib.js`, a thin first-party wrapper around `tar.create()`, matching the existing `got-wrapper.lib.js` pattern used for the same reason with `got`. The service now calls the wrapper instead of `tar` directly, and the test stubs the wrapper.

## Changes

- Add `app/lib/tar-wrapper.lib.js`
- Update `app/services/jobs/export/compress-schema-folder.service.js` to call the wrapper
- Un-skip and fix `test/services/jobs/export/compress-schema-folder.service.test.js`

🤖 Generated with [Claude Code](https://claude.com/claude-code)