### PR TITLE
Fix broken create user email validation 

### DIFF
--- a/app/dal/users/check-email-exists.dal.js
+++ b/app/dal/users/check-email-exists.dal.js
@@ -1,19 +1,29 @@
 /**
- * Checks if an email address already exists in the system.
+ * Checks if an email address already exists in the system
  * @module CheckEmailExistsDal
  */
 
 import UserModel from '../../models/user.model.js'
 
 /**
- * Checks if an email address already exists in the system.
+ * Checks if an email address already exists in the system
+ *
+ * Obviously we don't want to try and create duplicate user accounts. But in WRLS they are split by application type;
+ * 'water_admin' for internal users, 'water_vml' for external users.
+ *
+ * It is common for some EA staff to have both an internal and external user account. For some it allows them to deal
+ * with queries about the external service. For others, they user the external service to submit returns on behalf of
+ * licences held by the Environment Agency.
+ *
+ * So, we don't care if an external user account exists with the same email address. We only care if an internal user
+ * account exists.
  *
  * @param {string} email - The email address to check.
  *
- * @returns {Promise<boolean>} Returns `true` if the email exists, `false` otherwise.
+ * @returns {Promise<boolean>} Returns `true` if an existing internal user with the same email exists, otherwise `false`
  */
 export default async function checkEmailExistsDal(email) {
-  const emailExists = await UserModel.query().findOne({ username: email })
+  const emailExists = await UserModel.query().findOne({ application: 'water_admin', username: email })
 
   return !!emailExists
 }

--- a/app/services/data/tear-down/idm-schema.service.js
+++ b/app/services/data/tear-down/idm-schema.service.js
@@ -24,6 +24,7 @@ async function _deleteAllTestData() {
       "user_data",
       '$.source'
     ) #>> '{}' = 'acceptance-test-setup'
+    OR "user_name" LIKE 'both.sides@%'
     OR "user_name" LIKE '%@example.com'
     OR "user_name" LIKE '%@e'
     OR "user_name" LIKE 'regression.tests%';

--- a/app/services/data/tear-down/idm-schema.service.js
+++ b/app/services/data/tear-down/idm-schema.service.js
@@ -24,7 +24,6 @@ async function _deleteAllTestData() {
       "user_data",
       '$.source'
     ) #>> '{}' = 'acceptance-test-setup'
-    OR "user_name" LIKE 'both.sides@%'
     OR "user_name" LIKE '%@example.com'
     OR "user_name" LIKE '%@e'
     OR "user_name" LIKE 'regression.tests%';

--- a/package.json
+++ b/package.json
@@ -84,8 +84,9 @@
     "vitest": "4.1.9"
   },
   "allowScripts": {
-    "unrs-resolver@1.11.0": true,
     "@parcel/watcher@2.5.0": true,
-    "esbuild@0.27.7": true
+    "esbuild@0.27.7": true,
+    "unrs-resolver@1.12.2": true,
+    "fsevents@2.3.3": true
   }
 }

--- a/test/dal/users/check-email-exists.dal.test.js
+++ b/test/dal/users/check-email-exists.dal.test.js
@@ -11,20 +11,35 @@ describe('DAL - Check email exists dal', () => {
   let email
   let user
 
-  describe('when the user exists', () => {
-    beforeAll(async () => {
-      user = await UserHelper.add()
-      email = user.username
-    })
-
+  describe('when a user with the same email exists', () => {
     afterAll(async () => {
       await user.$query().delete()
     })
 
-    it('returns "true"', async () => {
-      const result = await CheckEmailExistsDal(email)
+    describe('and it is an internal account', () => {
+      beforeAll(async () => {
+        user = await UserHelper.add({ application: 'water_admin' })
+        email = user.username
+      })
 
-      expect(result).toBe(true)
+      it('returns "true"', async () => {
+        const result = await CheckEmailExistsDal(email)
+
+        expect(result).toBe(true)
+      })
+    })
+
+    describe('and it is an external account', () => {
+      beforeAll(async () => {
+        user = await UserHelper.add({ application: 'water_vml' })
+        email = user.username
+      })
+
+      it('returns "false"', async () => {
+        const result = await CheckEmailExistsDal(email)
+
+        expect(result).toBe(false)
+      })
     })
   })
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5739

We recently [migrated the internal create user functionality from the legacy service](https://github.com/DEFRA/water-abstraction-system/pull/3276).

Part of the 'create user' journey is checking whether the email address is already used by another user.

But there is a complication. WRLS has both internal and external users, and they all live in the same table. They are differentiated by the `application` field. And there are Environment Agency users who have to submit returns on behalf of the EA because the EA holds abstraction licences!

So, the legacy service allowed you to create an internal user, even if the email address matched an external account. We've overlooked that in our validation, so we're blocking the creation of internal users if the email address is already used by an external user.

This fixes the validation.