### PR TITLE
Only default necessary fields in charge helpers 2! 

### DIFF
--- a/test/services/bill-runs/annual/fetch-billing-accounts.service.test.js
+++ b/test/services/bill-runs/annual/fetch-billing-accounts.service.test.js
@@ -207,8 +207,15 @@ describe('Fetch Billing Accounts service', () => {
 
       chargeCategory = ChargeCategoryHelper.select()
       chargeReference = await ChargeReferenceHelper.add({
+        abstractionPeriodStartDay: 1,
+        abstractionPeriodStartMonth: 4,
+        abstractionPeriodEndDay: 31,
+        abstractionPeriodEndMonth: 3,
+        adjustments: { s126: null, s127: false, s130: false, charge: null, winter: false, aggregate: null },
         chargeVersionId: chargeVersion.id,
-        chargeCategoryId: chargeCategory.id
+        chargeCategoryId: chargeCategory.id,
+        description: 'Charge reference 1 - Mineral washing',
+        scheme: 'sroc'
       })
       chargeElement = await ChargeElementHelper.add({ chargeReferenceId: chargeReference.id })
     })

--- a/test/services/bill-runs/generate-transactions.service.test.js
+++ b/test/services/bill-runs/generate-transactions.service.test.js
@@ -29,9 +29,19 @@ describe('Generate Transactions service', () => {
 
   beforeEach(async () => {
     chargeCategory = ChargeCategoryHelper.select()
+
     const { id: chargeCategoryId } = chargeCategory
 
-    const baseChargeReference = await ChargeReferenceHelper.add({ chargeCategoryId })
+    const baseChargeReference = await ChargeReferenceHelper.add({
+      abstractionPeriodStartDay: 1,
+      abstractionPeriodStartMonth: 4,
+      abstractionPeriodEndDay: 31,
+      abstractionPeriodEndMonth: 3,
+      adjustments: { s126: null, s127: false, s130: false, charge: null, winter: false, aggregate: null },
+      chargeCategoryId,
+      description: 'Charge reference 1 - Mineral washing',
+      scheme: 'sroc'
+    })
 
     chargeElement = await ChargeElementHelper.add({ chargeReferenceId: baseChargeReference.id })
     chargeReference = await baseChargeReference

--- a/test/services/bill-runs/match/fetch-charge-versions.service.test.js
+++ b/test/services/bill-runs/match/fetch-charge-versions.service.test.js
@@ -349,9 +349,15 @@ describe('Bill Runs - Match - Fetch Charge Versions service', () => {
       })
 
       chargeReference = await ChargeReferenceHelper.add({
+        abstractionPeriodStartDay: 1,
+        abstractionPeriodStartMonth: 4,
+        abstractionPeriodEndDay: 31,
+        abstractionPeriodEndMonth: 3,
+        adjustments: { s126: null, s127: true, s130: false, charge: null, winter: false, aggregate: 0.562114443 },
         chargeVersionId: chargeVersion.id,
         chargeCategoryId: chargeCategory.id,
-        adjustments: { s127: true, aggregate: 0.562114443 }
+        description: 'Charge reference 1 - Mineral washing',
+        scheme: 'sroc'
       })
 
       chargeElement1 = await ChargeElementHelper.add({
@@ -432,8 +438,8 @@ describe('Bill Runs - Match - Fetch Charge Versions service', () => {
               aggregate: 0.562114443,
               s126: null,
               s127: 'true',
-              s130: null,
-              winter: null,
+              s130: 'false',
+              winter: 'false',
               charge: null,
               chargeCategory: {
                 reference: chargeCategory.reference,

--- a/test/services/bill-runs/supplementary/process-billing-period.service.test.js
+++ b/test/services/bill-runs/supplementary/process-billing-period.service.test.js
@@ -37,6 +37,9 @@ describe('Bill Runs - Supplementary - Process Billing Period service', () => {
   let billingAccount
   let chargeCategory
   let changeReason
+  let chargeElement
+  let chargeReference
+  let chargeVersion
   let chargeVersions
   let licence
   let region
@@ -54,7 +57,23 @@ describe('Bill Runs - Supplementary - Process Billing Period service', () => {
     vi.spyOn(FetchPreviousTransactionsService, 'default').mockResolvedValue([])
   })
 
-  afterEach(() => {
+  afterEach(async () => {
+    await licence.$query().delete()
+    await billingAccount.$query().delete()
+    await billRun.$query().delete()
+
+    if (chargeElement) {
+      await chargeElement.$query().delete()
+    }
+
+    if (chargeReference) {
+      await chargeReference.$query().delete()
+    }
+
+    if (chargeVersion) {
+      await chargeVersion.$query().delete()
+    }
+
     vi.restoreAllMocks()
   })
 
@@ -75,19 +94,27 @@ describe('Bill Runs - Supplementary - Process Billing Period service', () => {
       describe('but none of them are billable', () => {
         describe('because the billable days calculated as 0', () => {
           beforeEach(async () => {
-            const { id: chargeVersionId } = await ChargeVersionHelper.add({
+            chargeVersion = await ChargeVersionHelper.add({
               changeReasonId: changeReason.id,
               billingAccountId: billingAccount.id,
               startDate: new Date(2022, 7, 1, 9),
               licenceId: licence.id
             })
-            const { id: chargeReferenceId } = await ChargeReferenceHelper.add({
+
+            chargeReference = await ChargeReferenceHelper.add({
+              abstractionPeriodStartDay: 1,
+              abstractionPeriodStartMonth: 4,
+              abstractionPeriodEndDay: 31,
+              abstractionPeriodEndMonth: 3,
+              adjustments: { s126: null, s127: false, s130: false, charge: null, winter: false, aggregate: null },
               chargeCategoryId: chargeCategory.id,
-              chargeVersionId
+              chargeVersionId: chargeVersion.id,
+              description: 'Charge reference 1 - Mineral washing',
+              scheme: 'sroc'
             })
 
-            await ChargeElementHelper.add({
-              chargeReferenceId,
+            chargeElement = await ChargeElementHelper.add({
+              chargeReferenceId: chargeReference.id,
               abstractionPeriodStartDay: 1,
               abstractionPeriodStartMonth: 4,
               abstractionPeriodEndDay: 31,
@@ -111,20 +138,28 @@ describe('Bill Runs - Supplementary - Process Billing Period service', () => {
         describe('because the charge version status is "superseded"', () => {
           describe('and there are no previously billed transactions', () => {
             beforeEach(async () => {
-              const { id: chargeVersionId } = await ChargeVersionHelper.add({
+              chargeVersion = await ChargeVersionHelper.add({
                 changeReasonId: changeReason.id,
                 billingAccountId: billingAccount.id,
                 startDate: new Date(2022, 7, 1, 9),
                 licenceId: licence.id,
                 status: 'superseded'
               })
-              const { chargeElementId } = await ChargeReferenceHelper.add({
+
+              chargeReference = await ChargeReferenceHelper.add({
+                abstractionPeriodStartDay: 1,
+                abstractionPeriodStartMonth: 4,
+                abstractionPeriodEndDay: 31,
+                abstractionPeriodEndMonth: 3,
+                adjustments: { s126: null, s127: false, s130: false, charge: null, winter: false, aggregate: null },
                 chargeCategoryId: chargeCategory.id,
-                chargeVersionId
+                chargeVersionId: chargeVersion.id,
+                description: 'Charge reference 1 - Mineral washing',
+                scheme: 'sroc'
               })
 
-              await ChargeElementHelper.add({
-                chargeElementId,
+              chargeElement = await ChargeElementHelper.add({
+                chargeReferenceId: chargeReference.id,
                 abstractionPeriodStartDay: 1,
                 abstractionPeriodStartMonth: 4,
                 abstractionPeriodEndDay: 31,
@@ -147,19 +182,27 @@ describe('Bill Runs - Supplementary - Process Billing Period service', () => {
 
       describe('and they are billable', () => {
         beforeEach(async () => {
-          const { id: chargeVersionId } = await ChargeVersionHelper.add({
+          chargeVersion = await ChargeVersionHelper.add({
             changeReasonId: changeReason.id,
             billingAccountId: billingAccount.id,
             startDate: new Date(2022, 7, 1, 9),
             licenceId: licence.id
           })
-          const { id: chargeReferenceId } = await ChargeReferenceHelper.add({
+
+          chargeReference = await ChargeReferenceHelper.add({
+            abstractionPeriodStartDay: 1,
+            abstractionPeriodStartMonth: 4,
+            abstractionPeriodEndDay: 31,
+            abstractionPeriodEndMonth: 3,
+            adjustments: { s126: null, s127: false, s130: false, charge: null, winter: false, aggregate: null },
             chargeCategoryId: chargeCategory.id,
-            chargeVersionId
+            chargeVersionId: chargeVersion.id,
+            description: 'Charge reference 1 - Mineral washing',
+            scheme: 'sroc'
           })
 
-          await ChargeElementHelper.add({
-            chargeReferenceId,
+          chargeElement = await ChargeElementHelper.add({
+            chargeReferenceId: chargeReference.id,
             abstractionPeriodStartDay: 1,
             abstractionPeriodStartMonth: 4,
             abstractionPeriodEndDay: 31,
@@ -228,17 +271,25 @@ describe('Bill Runs - Supplementary - Process Billing Period service', () => {
 
   describe('when the service errors', () => {
     beforeEach(async () => {
-      const { id: chargeVersionId } = await ChargeVersionHelper.add({
+      chargeVersion = await ChargeVersionHelper.add({
         changeReasonId: changeReason.id,
         billingAccountId: billingAccount.id,
         licenceId: licence.id
       })
-      const { id: chargeReferenceId } = await ChargeReferenceHelper.add({
+
+      chargeReference = await ChargeReferenceHelper.add({
+        abstractionPeriodStartDay: 1,
+        abstractionPeriodStartMonth: 4,
+        abstractionPeriodEndDay: 31,
+        abstractionPeriodEndMonth: 3,
+        adjustments: { s126: null, s127: true, s130: false, charge: null, winter: false, aggregate: null },
         chargeCategoryId: chargeCategory.id,
-        chargeVersionId
+        chargeVersionId: chargeVersion.id,
+        description: 'Charge reference 1 - Mineral washing',
+        scheme: 'sroc'
       })
 
-      await ChargeElementHelper.add({ chargeReferenceId })
+      chargeElement = await ChargeElementHelper.add({ chargeReferenceId: chargeReference.id })
 
       const chargeVersionData = await FetchChargeVersionsService(licence.regionId, billingPeriod)
 

--- a/test/services/bill-runs/two-part-tariff/fetch-billing-accounts.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-billing-accounts.service.test.js
@@ -70,7 +70,7 @@ describe('Bill Runs - Two Part Tariff - Fetch Billing Accounts service', () => {
       chargeVersionId,
       chargeCategoryId,
       description: 'Charge reference 1 - Mineral washing',
-      scheme: 'sroc',
+      scheme: 'sroc'
     })
     const { id: chargeReferenceId } = chargeReference
 

--- a/test/services/bill-runs/two-part-tariff/fetch-billing-accounts.service.test.js
+++ b/test/services/bill-runs/two-part-tariff/fetch-billing-accounts.service.test.js
@@ -61,7 +61,17 @@ describe('Bill Runs - Two Part Tariff - Fetch Billing Accounts service', () => {
     chargeCategory = ChargeCategoryHelper.select()
     const { id: chargeCategoryId } = chargeCategory
 
-    chargeReference = await ChargeReferenceHelper.add({ chargeVersionId, chargeCategoryId })
+    chargeReference = await ChargeReferenceHelper.add({
+      abstractionPeriodStartDay: 1,
+      abstractionPeriodStartMonth: 4,
+      abstractionPeriodEndDay: 31,
+      abstractionPeriodEndMonth: 3,
+      adjustments: {},
+      chargeVersionId,
+      chargeCategoryId,
+      description: 'Charge reference 1 - Mineral washing',
+      scheme: 'sroc',
+    })
     const { id: chargeReferenceId } = chargeReference
 
     reviewChargeReference = await ReviewChargeReferenceHelper.add({ chargeReferenceId, reviewChargeVersionId })
@@ -129,14 +139,7 @@ describe('Bill Runs - Two Part Tariff - Fetch Billing Accounts service', () => {
             expect(chargeReferences[0].source).toEqual('non-tidal')
             expect(chargeReferences[0].loss).toEqual('low')
             expect(chargeReferences[0].volume).toEqual(200)
-            expect(chargeReferences[0].adjustments).toEqual({
-              s126: null,
-              s127: false,
-              s130: false,
-              charge: null,
-              winter: false,
-              aggregate: null
-            })
+            expect(chargeReferences[0].adjustments).toEqual({})
             expect(chargeReferences[0].additionalCharges).toBeNull()
             expect(chargeReferences[0].description).toEqual('Charge reference 1 - Mineral washing')
           })

--- a/test/services/licences/supplementary/fetch-charge-version-billing-data.service.test.js
+++ b/test/services/licences/supplementary/fetch-charge-version-billing-data.service.test.js
@@ -51,7 +51,7 @@ describe('Licences - Supplementary - Fetch Charge Version Billing Data service',
         season: 'all year',
         seasonDerived: 'all year',
         section127Agreement: true,
-        source: 'unsupported',
+        source: 'unsupported'
       })
     })
 

--- a/test/services/licences/supplementary/fetch-charge-version-billing-data.service.test.js
+++ b/test/services/licences/supplementary/fetch-charge-version-billing-data.service.test.js
@@ -26,16 +26,32 @@ describe('Licences - Supplementary - Fetch Charge Version Billing Data service',
       // Add sroc charge version and charge reference
       srocChargeVersion = await ChargeVersionHelper.add({ licenceId: licence.id, startDate: new Date('2023-04-01') })
       srocChargeReference = await ChargeReferenceHelper.add({
+        abstractionPeriodStartDay: 1,
+        abstractionPeriodStartMonth: 4,
+        abstractionPeriodEndDay: 31,
+        abstractionPeriodEndMonth: 3,
+        adjustments: { s126: null, s127: true, s130: false, charge: null, winter: false, aggregate: null },
         chargeVersionId: srocChargeVersion.id,
-        adjustments: { s127: true }
+        description: 'Charge reference 1 - SROC',
+        scheme: 'sroc'
       })
 
       // Add pre sroc charge version
       preSrocChargeVersion = await ChargeVersionHelper.add({ scheme: 'alcs', licenceId: licence.id })
       preSrocChargeReference = await ChargeReferenceHelper.add({
+        abstractionPeriodStartDay: 1,
+        abstractionPeriodStartMonth: 4,
+        abstractionPeriodEndDay: 31,
+        abstractionPeriodEndMonth: 3,
+        authorisedAnnualQuantity: 200,
         chargeVersionId: preSrocChargeVersion.id,
+        description: 'Charge element 1 - PRESROC',
+        restrictedSource: false,
         scheme: 'alcs',
-        adjustments: { s127: true }
+        season: 'all year',
+        seasonDerived: 'all year',
+        section127Agreement: true,
+        source: 'unsupported',
       })
     })
 
@@ -52,7 +68,7 @@ describe('Licences - Supplementary - Fetch Charge Version Billing Data service',
             {
               id: preSrocChargeReference.id,
               scheme: 'alcs',
-              twoPartTariff: true
+              twoPartTariff: null
             }
           ],
           licence: {

--- a/test/support/helpers/charge-reference.helper.js
+++ b/test/support/helpers/charge-reference.helper.js
@@ -14,19 +14,7 @@ import { generateUUID } from '../generators.js'
  * - `chargeVersionId` - [random UUID]
  * - `source` - non-tidal
  * - `loss` - low
- * - `description` - Charge reference 1 - Mineral washing
- * - `section127Agreement` - false
- * - `scheme` - sroc
- * - `restrictedSource` - false
- * - `waterModel` - no model
- * - `volume` - 200
- * - `chargeCategoryId` - [randomly selected UUID from charge categories]
- * - `adjustments` - { s126: null, s127: false, s130: false, charge: null, winter: false, aggregate: null }
- * - `eiucRegion` - Anglian
- * - `abstractionPeriodStartDay` - 1
- * - `abstractionPeriodStartMonth` - 4
- * - `abstractionPeriodEndDay` - 31
- * - `abstractionPeriodEndMonth` - 3
+ * - `volume` - 200 [if scheme is not 'alcs', otherwise null]
  *
  * @param {object} [data] - Any data you want to use instead of the defaults used here or in the database
  *
@@ -53,23 +41,16 @@ function add(data = {}) {
 function defaults(data = {}) {
   const { id: chargeCategoryId } = ChargeCategoryHelper.select()
 
+  // The table has a constraint that either authorisedAnnualQuantity or volume must be populated. But if the scheme is
+  // 'alcs' (PRESROC) volume should be null. As most of our tests are for SROC, we default to 200 for volume unless the
+  // scheme is 'alcs'.
+  const volume = data.scheme === 'alcs' ? null : 200
+
   const defaults = {
     chargeVersionId: generateUUID(),
     source: 'non-tidal',
     loss: 'low',
-    description: 'Charge reference 1 - Mineral washing',
-    section127Agreement: false,
-    scheme: 'sroc',
-    restrictedSource: false,
-    waterModel: 'no model',
-    volume: 200,
-    chargeCategoryId,
-    adjustments: { s126: null, s127: false, s130: false, charge: null, winter: false, aggregate: null },
-    eiucRegion: 'Anglian',
-    abstractionPeriodStartDay: 1,
-    abstractionPeriodStartMonth: 4,
-    abstractionPeriodEndDay: 31,
-    abstractionPeriodEndMonth: 3
+    volume
   }
 
   return {

--- a/test/support/helpers/charge-reference.helper.js
+++ b/test/support/helpers/charge-reference.helper.js
@@ -2,7 +2,6 @@
  * @module ChargeReferenceHelper
  */
 
-import ChargeCategoryHelper from './charge-category.helper.js'
 import ChargeReferenceModel from '../../../app/models/charge-reference.model.js'
 import { generateUUID } from '../generators.js'
 
@@ -39,8 +38,6 @@ function add(data = {}) {
  * @returns {object} - Returns the set defaults with the override data spread
  */
 function defaults(data = {}) {
-  const { id: chargeCategoryId } = ChargeCategoryHelper.select()
-
   // The table has a constraint that either authorisedAnnualQuantity or volume must be populated. But if the scheme is
   // 'alcs' (PRESROC) volume should be null. As most of our tests are for SROC, we default to 200 for volume unless the
   // scheme is 'alcs'.


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5579

In [Only default necessary fields in charge helpers](https://github.com/DEFRA/water-abstraction-system/pull/3554), we aimed to stop populating fields that were not required in the `charge-element` and `charge-reference` helpers.

As part of migrating our [acceptance tests](https://github.com/DEFRA/water-abstraction-acceptance-tests) to [Playwright](https://playwright.dev/), we're trying to make the data we seed 'real'.

One of the issues we've found when it comes to charge information is that the system test helpers we rely on are populating fields we don't want populated.

We obviously rushed stopping doing this the first time around, because we really only stopped doing it for the charge element helper.

This change ensures the charge reference helper also stops seeding fields that the DB does not require to be populated.